### PR TITLE
Correctly decode metadata.json into a utf8 str

### DIFF
--- a/rules_python/whl.py
+++ b/rules_python/whl.py
@@ -58,7 +58,7 @@ class Wheel(object):
     # directory.
     with zipfile.ZipFile(self.path(), 'r') as whl:
       with whl.open(os.path.join(self._dist_info(), 'metadata.json')) as f:
-        return json.loads(f.read())
+        return json.loads(f.read().decode("utf-8"))
 
   def name(self):
     return self.metadata().get('name')


### PR DESCRIPTION
Without this, the metadata.json file is read as bytes instead of a str, and the call
to json.loads() fails with the following error:
```bash
TypeError: the JSON object must be str, not 'bytes'
```