### PR TITLE
Note that "{HEAD}" is invalid, not special.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Add the following to your `WORKSPACE` file to add the external repositories:
 git_repository(
     name = "io_bazel_rules_python",
     remote = "https://github.com/bazelbuild/rules_python.git",
+    # NOT VALID!  Replace this with a Git commit SHA.
     commit = "{HEAD}",
 )
 


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_python/issues/24