### PR TITLE
Handle METADATA files in python wheels

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,12 +66,21 @@ http_file(
 )
 
 http_file(
-    name = "futures_whl",
+    name = "futures_3_1_1_whl",
     sha256 = "c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
     # From https://pypi.python.org/pypi/futures
     url = ("https://pypi.python.org/packages/a6/1c/" +
            "72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/" +
            "futures-3.1.1-py2-none-any.whl"),
+)
+
+http_file(
+    name = "futures_2_2_0_whl",
+    sha256 = "9fd22b354a4c4755ad8c7d161d93f5026aca4cfe999bd2e53168f14765c02cd6",
+    # From https://pypi.python.org/pypi/futures/2.2.0
+    url = ("https://pypi.python.org/packages/d7/1d/" +
+           "68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/" +
+           "futures-2.2.0-py2.py3-none-any.whl"),
 )
 
 http_file(

--- a/rules_python/BUILD
+++ b/rules_python/BUILD
@@ -26,7 +26,8 @@ py_test(
     name = "whl_test",
     srcs = ["whl_test.py"],
     data = [
-        "@futures_whl//file",
+        "@futures_3_1_1_whl//file",
+        "@futures_2_2_0_whl//file",
         "@grpc_whl//file",
         "@mock_whl//file",
     ],

--- a/rules_python/whl_test.py
+++ b/rules_python/whl_test.py
@@ -35,13 +35,22 @@ class WheelTest(unittest.TestCase):
     self.assertEqual('pypi__grpcio_1_6_0', wheel.repository_name())
 
   def test_futures_whl(self):
-    td = TestData('futures_whl/file/futures-3.1.1-py2-none-any.whl')
+    td = TestData('futures_3_1_1_whl/file/futures-3.1.1-py2-none-any.whl')
     wheel = whl.Wheel(td)
     self.assertEqual(wheel.name(), 'futures')
     self.assertEqual(wheel.distribution(), 'futures')
     self.assertEqual(wheel.version(), '3.1.1')
     self.assertEqual(set(wheel.dependencies()), set())
     self.assertEqual('pypi__futures_3_1_1', wheel.repository_name())
+
+  def test_whl_with_METADATA_file(self):
+    td = TestData('futures_2_2_0_whl/file/futures-2.2.0-py2.py3-none-any.whl')
+    wheel = whl.Wheel(td)
+    self.assertEqual(wheel.name(), 'futures')
+    self.assertEqual(wheel.distribution(), 'futures')
+    self.assertEqual(wheel.version(), '2.2.0')
+    self.assertEqual(set(wheel.dependencies()), set())
+    self.assertEqual('pypi__futures_2_2_0', wheel.repository_name())
 
   def test_mock_whl(self):
     td = TestData('mock_whl/file/mock-2.0.0-py2.py3-none-any.whl')


### PR DESCRIPTION
According to https://www.python.org/dev/peps/pep-0427/:
```
{distribution}-{version}.dist-info/METADATA is Metadata version 1.1 or greater format metadata.
```

Currently, rules_python fails when metadata.json is not present. Let's also check for a METADATA file. Tested with `futures==2.2.0` wheel and rules_python can now include that as a requirement, where it couldnt before.