### PR TITLE
Split the extras param by comma

### DIFF
--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -24,7 +24,10 @@ def _whl_impl(repository_ctx):
   ]
 
   if repository_ctx.attr.extras:
-    args += ["--extras", ",".join(repository_ctx.attr.extras)]
+    args += [
+      "--extras=%s" % extra
+      for extra in repository_ctx.attr.extras
+    ]
 
   result = repository_ctx.execute(args)
   if result.return_code:

--- a/rules_python/whl.py
+++ b/rules_python/whl.py
@@ -110,6 +110,10 @@ class Wheel(object):
     name_pattern = re.compile('Name: (.*)')
     return { 'name': name_pattern.search(content).group(1) }
 
+class SplitByCommaAndAppend(argparse._AppendAction):
+  def __call__(self, parser, namespace, values, option_string=None):
+    for val in values.split(','):
+      super(SplitByCommaAndAppend, self).__call__(parser, namespace, val, option_string)
 
 parser = argparse.ArgumentParser(
     description='Unpack a WHL file as a py_library.')
@@ -123,7 +127,7 @@ parser.add_argument('--requirements', action='store',
 parser.add_argument('--directory', action='store', default='.',
                     help='The directory into which to expand things.')
 
-parser.add_argument('--extras', action='append',
+parser.add_argument('--extras', action=SplitByCommaAndAppend,
                     help='The set of extras for which to generate library targets.')
 
 def main():

--- a/rules_python/whl.py
+++ b/rules_python/whl.py
@@ -110,10 +110,6 @@ class Wheel(object):
     name_pattern = re.compile('Name: (.*)')
     return { 'name': name_pattern.search(content).group(1) }
 
-class SplitByCommaAndAppend(argparse._AppendAction):
-  def __call__(self, parser, namespace, values, option_string=None):
-    for val in values.split(','):
-      super(SplitByCommaAndAppend, self).__call__(parser, namespace, val, option_string)
 
 parser = argparse.ArgumentParser(
     description='Unpack a WHL file as a py_library.')
@@ -127,7 +123,7 @@ parser.add_argument('--requirements', action='store',
 parser.add_argument('--directory', action='store', default='.',
                     help='The directory into which to expand things.')
 
-parser.add_argument('--extras', action=SplitByCommaAndAppend,
+parser.add_argument('--extras', action='append',
                     help='The set of extras for which to generate library targets.')
 
 def main():


### PR DESCRIPTION
When the bazel implementation calls into the wheel python script, it joins the extras arg by commas (https://github.com/bazelbuild/rules_python/blob/3e167dcfb17356c68588715ed324c5e9b76f391d/python/whl.bzl#L27).

When that arg is parsed, it should be split by commas. In the case of multiple args being passed with the same argument name, we should continue to use an Append parser, but with modifications to split by comma.