### PR TITLE
Add pip3_import to run pip with python 3.

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -14,24 +14,24 @@
 """Import pip requirements into Bazel."""
 
 def _shared_pip_import_impl(python_interpreter, repository_ctx):
-    """Core implementation of pip_import."""
-    # Add an empty top-level BUILD file.
-    # This is because Bazel requires BUILD files along all paths accessed
-    # via //this/sort/of:path and we wouldn't be able to load our generated
-    # requirements.bzl without it.
-    repository_ctx.file("BUILD", "")
+  """Core implementation of pip_import."""
+  # Add an empty top-level BUILD file.
+  # This is because Bazel requires BUILD files along all paths accessed
+  # via //this/sort/of:path and we wouldn't be able to load our generated
+  # requirements.bzl without it.
+  repository_ctx.file("BUILD", "")
 
-    # To see the output, pass: quiet=False
-    result = repository_ctx.execute([
-      python_interpreter, repository_ctx.path(repository_ctx.attr._script),
-      "--name", repository_ctx.attr.name,
-      "--input", repository_ctx.path(repository_ctx.attr.requirements),
-      "--output", repository_ctx.path("requirements.bzl"),
-      "--directory", repository_ctx.path(""),
-    ])
+  # To see the output, pass: quiet=False
+  result = repository_ctx.execute([
+    python_interpreter, repository_ctx.path(repository_ctx.attr._script),
+    "--name", repository_ctx.attr.name,
+    "--input", repository_ctx.path(repository_ctx.attr.requirements),
+    "--output", repository_ctx.path("requirements.bzl"),
+    "--directory", repository_ctx.path(""),
+  ])
 
-    if result.return_code:
-      fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
+  if result.return_code:
+    fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
 
 _shared_attrs = {
     "requirements": attr.label(

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -13,41 +13,48 @@
 # limitations under the License.
 """Import pip requirements into Bazel."""
 
-def _pip_import_impl(repository_ctx):
+def _make_pip_import_impl(python_interpreter):
   """Core implementation of pip_import."""
+  return lambda repository_ctx:
+      # Add an empty top-level BUILD file.
+      # This is because Bazel requires BUILD files along all paths accessed
+      # via //this/sort/of:path and we wouldn't be able to load our generated
+      # requirements.bzl without it.
+      repository_ctx.file("BUILD", "")
 
-  # Add an empty top-level BUILD file.
-  # This is because Bazel requires BUILD files along all paths accessed
-  # via //this/sort/of:path and we wouldn't be able to load our generated
-  # requirements.bzl without it.
-  repository_ctx.file("BUILD", "")
+      # To see the output, pass: quiet=False
+      result = repository_ctx.execute([
+        python_interpreter, repository_ctx.path(repository_ctx.attr._script),
+        "--name", repository_ctx.attr.name,
+        "--input", repository_ctx.path(repository_ctx.attr.requirements),
+        "--output", repository_ctx.path("requirements.bzl"),
+        "--directory", repository_ctx.path(""),
+      ])
 
-  # To see the output, pass: quiet=False
-  result = repository_ctx.execute([
-    "python", repository_ctx.path(repository_ctx.attr._script),
-    "--name", repository_ctx.attr.name,
-    "--input", repository_ctx.path(repository_ctx.attr.requirements),
-    "--output", repository_ctx.path("requirements.bzl"),
-    "--directory", repository_ctx.path(""),
-  ])
+      if result.return_code:
+        fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
 
-  if result.return_code:
-    fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
+_shared_attrs = {
+    "requirements": attr.label(
+        allow_files = True,
+        mandatory = True,
+        single_file = True,
+    ),
+    "_script": attr.label(
+        executable = True,
+        default = Label("//tools:piptool.par"),
+        cfg = "host",
+    ),
+}
 
 pip_import = repository_rule(
-    attrs = {
-        "requirements": attr.label(
-            allow_files = True,
-            mandatory = True,
-            single_file = True,
-        ),
-        "_script": attr.label(
-            executable = True,
-            default = Label("//tools:piptool.par"),
-            cfg = "host",
-        ),
-    },
-    implementation = _pip_import_impl,
+    attrs = _shared_attrs,
+    implementation = _make_pip_import_impl("python2"),
+)
+
+pip3_import = repository_rule(
+  attrs = _shared_attrs,
+  implementation = _make_pip_import_impl("python3"),
 )
 
 """A rule for importing <code>requirements.txt</code> dependencies into Bazel.

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -15,6 +15,7 @@
 
 def _shared_pip_import_impl(python_interpreter, repository_ctx):
   """Core implementation of pip_import."""
+
   # Add an empty top-level BUILD file.
   # This is because Bazel requires BUILD files along all paths accessed
   # via //this/sort/of:path and we wouldn't be able to load our generated


### PR DESCRIPTION
While it's possible to select which interpreter to run python rules with, pip will always be run with `python` from the system path.

This uses the interpreter names as described in [PEP 394](https://www.python.org/dev/peps/pep-0394/) to be able to run pip in both python 2 and python 3 as an interim solution until `py_toolchain` is finalised, since the values for the current mechanism in Bazel to configure the python interpreter at the invocation level (`python_path`, `python_top`) are not forwarded to the skylark context.

See discussion in #62.