### PR TITLE
Update pip to 9.0.3 for TLS brownouts

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-pip==9.0.1
+pip==9.0.3
 setuptools==38.2.4
 wheel==0.30.0a0
 


### PR DESCRIPTION
In short, the python infrastructure is using a brownout period which causes pip install to fail:

> During that window, clients accessing pypi.python.org with clients that do not support TLSv1.2 will receive an HTTP 403 with the error message "This is a brown out of TLSv1 support. TLSv1 support is going away soon, upgrade to a TLSv1.2+ capable client.".

See: 
http://pyfound.blogspot.fi/2017/01/time-to-upgrade-your-python-tls-v12.html


The errors provided by bazel aren't very clear either (even though it's mostly due to pip):
```
$> bazel --batch run apps/yap/etl:etl --define CONFIG=prod --  bank_operations_importer_job -c ~/Downloads/1712\ Looker\ DrillDown.csv
ERROR: error loading package '': Encountered error while reading extension file 'requirements.bzl': no such package '@all_requirements//': pip_import failed: Collecting awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1))
 (  Could not find a version that satisfies the requirement awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1)) (from versions: )
No matching distribution found for awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1))
)
ERROR: error loading package '': Encountered error while reading extension file 'requirements.bzl': no such package '@all_requirements//': pip_import failed: Collecting awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1))
 (  Could not find a version that satisfies the requirement awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1)) (from versions: )
No matching distribution found for awscli==1.11.133 (from -r /Users/J-B/Work/backend/requirements.txt (line 1))
)
INFO: Elapsed time: 8.291s
FAILED: Build did NOT complete successfully (0 packages loaded)
ERROR: Build failed. Not running target
```

From the official mailing list: https://mail.python.org/pipermail/python-announce-list/2018-April/011885.html
> Pip 9.0.3 supports TLSv1.2 when running under system Python on macOS <
10.13. Official release notes: https://pip.pypa.io/en/stable/news/

