### PR TITLE
whl: Parse requirements from METADATA files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,15 @@ http_file(
 )
 
 http_file(
+    name = "wheel_0_31_1_whl",
+    sha256 = "80044e51ec5bbf6c894ba0bc48d26a8c20a9ba629f4ca19ea26ecfcf87685f5f",
+    # From https://pypi.org/project/wheel/
+    url = ("https://files.pythonhosted.org/packages/81/30/" +
+           "e935244ca6165187ae8be876b6316ae201b71485538ffac1d718843025a9/" +
+           "wheel-0.31.1-py2.py3-none-any.whl"),
+)
+
+http_file(
     name = "mock_whl",
     sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
     # From https://pypi.python.org/pypi/mock

--- a/rules_python/BUILD
+++ b/rules_python/BUILD
@@ -35,6 +35,7 @@ py_test(
         "@google_cloud_language_whl//file",
         "@grpc_whl//file",
         "@mock_whl//file",
+        "@wheel_0_31_1_whl//file",
     ],
     deps = [
         ":whl",


### PR DESCRIPTION
Some wheels only include METADATA files (examples: wheel 0.31.0,
tenacity 4.10.0). Previously whl did not parse the requirement
sections. Add code to parse these sections.

The most complicated part is parsing out the extra == 'something'
clauses from the boolean expression. Use the same expression parser
used by pkg_resources.evaluate_marker which is already used by this
code to find those clauses and produce a version with them removed.