### PR TITLE
Allow environment variables and extra args to be passed to pip.

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -23,13 +23,16 @@ def _pip_import_impl(repository_ctx):
   repository_ctx.file("BUILD", "")
 
   # To see the output, pass: quiet=False
-  result = repository_ctx.execute([
+  result = repository_ctx.execute(
+    [
     "python", repository_ctx.path(repository_ctx.attr._script),
     "--name", repository_ctx.attr.name,
     "--input", repository_ctx.path(repository_ctx.attr.requirements),
     "--output", repository_ctx.path("requirements.bzl"),
     "--directory", repository_ctx.path(""),
-  ])
+    ] + repository_ctx.attr.extra_args,
+    environment = repository_ctx.attr.environment,
+  )
 
   if result.return_code:
     fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
@@ -41,6 +44,8 @@ pip_import = repository_rule(
             mandatory = True,
             single_file = True,
         ),
+        "environment": attr.string_dict(),
+        "extra_args": attr.string_list(),
         "_script": attr.label(
             executable = True,
             default = Label("//tools:piptool.par"),

--- a/rules_python/piptool.py
+++ b/rules_python/piptool.py
@@ -151,10 +151,10 @@ def determine_possible_extras(whls):
   }
 
 def main():
-  args = parser.parse_args()
+  args, unkwown = parser.parse_known_args()
 
   # https://github.com/pypa/pip/blob/9.0.1/pip/__init__.py#L209
-  if pip_main(["wheel", "-w", args.directory, "-r", args.input]):
+  if pip_main(["wheel", "-w", args.directory,] + unkwown + ["-r", args.input]):
     sys.exit(1)
 
   # Enumerate the .whl files we downloaded.


### PR DESCRIPTION
This should fix #74 but was really motivated by the fact that I wanted to install https://github.com/uploadcare/pillow-simd with the `cc -mavx2` option reliably. So I needed the option to pass in environment variables that get propagated to pip and I further ran into this issue: https://github.com/uploadcare/pillow-simd/pull/26 so also needed to be able to pass in custom arguments.

So an example would be:

```
pip_import(
   name = "py_deps",
   requirements = "//:requirements.txt",
   environment = {
       "CC": "cc -maxv2",
   },
   extra_args = ["--no-binary", "pillow-simd"],
)
```