### PR TITLE
Switch to new http repo rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,22 +11,47 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 workspace(name = "io_bazel_rules_python")
 
-# Skydoc stuff
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+################################
+# Skydoc and its dependencies. #
+################################
+
+# Skydoc's sass dependency is not covered by skydoc_repositories(), so we have
+# to redeclare it here. Watch that the version matches when updating Skydoc's
+# version.
+
 git_repository(
     name = "io_bazel_rules_sass",
+    commit = "8b61ad6953fde55031658e1731c335220f881369",  # Taken from skydoc's WORKSPACE
     remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.3",
 )
 
-load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
+load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+
+rules_sass_dependencies()
+
+# Node is used by sass. This weird (anti-?)pattern of initializing a repo we
+# didn't directly import is taken from Skydoc's WORKSPACE.
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
+node_repositories()
+
+load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
+# We implicitly depend on Skydoc importing Skylib under `@bazel_skylib`.
+# We don't redeclare it here in order to avoid repeating a definition that
+# could get out of sync with Skydoc.
+
 git_repository(
     name = "io_bazel_skydoc",
-    commit = "e9be81cf5be41e4200749f5d8aa2db7955f8aacc",
+    commit = "77e5399258f6d91417d23634fce97d73b40cf337",  # 2018-10-29
     remote = "https://github.com/bazelbuild/skydoc.git",
 )
 
@@ -34,7 +59,10 @@ load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 
 skydoc_repositories()
 
-# Requirements for building our piptool.
+##########################################
+# Requirements for building our piptool. #
+##########################################
+
 load("//python:pip.bzl", "pip_import")
 
 pip_import(
@@ -51,58 +79,69 @@ _piptool_install()
 
 git_repository(
     name = "subpar",
-    remote = "https://github.com/google/subpar",
     # HEAD as of 2018/02/15
     commit = "1f695ee5d42585a66d9dd9b71219eb8551e59c89",
+    remote = "https://github.com/google/subpar",
 )
 
-# Test data for WHL tool testing.
+###################################
+# Test data for WHL tool testing. #
+###################################
+
 http_file(
     name = "grpc_whl",
+    downloaded_file_path = "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
     sha256 = "c232d6d168cb582e5eba8e1c0da8d64b54b041dd5ea194895a2fe76050916561",
     # From https://pypi.python.org/pypi/grpcio/1.6.0
-    url = ("https://pypi.python.org/packages/c6/28/" +
-           "67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/" +
-           "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl"),
+    urls = [("https://pypi.python.org/packages/c6/28/" +
+             "67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/" +
+             "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl")],
 )
 
 http_file(
     name = "futures_3_1_1_whl",
+    downloaded_file_path = "futures-3.1.1-py2-none-any.whl",
     sha256 = "c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
     # From https://pypi.python.org/pypi/futures
-    url = ("https://pypi.python.org/packages/a6/1c/" +
-           "72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/" +
-           "futures-3.1.1-py2-none-any.whl"),
+    urls = [("https://pypi.python.org/packages/a6/1c/" +
+             "72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/" +
+             "futures-3.1.1-py2-none-any.whl")],
 )
 
 http_file(
     name = "futures_2_2_0_whl",
+    downloaded_file_path = "futures-2.2.0-py2.py3-none-any.whl",
     sha256 = "9fd22b354a4c4755ad8c7d161d93f5026aca4cfe999bd2e53168f14765c02cd6",
     # From https://pypi.python.org/pypi/futures/2.2.0
-    url = ("https://pypi.python.org/packages/d7/1d/" +
-           "68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/" +
-           "futures-2.2.0-py2.py3-none-any.whl"),
+    urls = [("https://pypi.python.org/packages/d7/1d/" +
+             "68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/" +
+             "futures-2.2.0-py2.py3-none-any.whl")],
 )
 
 http_file(
     name = "mock_whl",
+    downloaded_file_path = "mock-2.0.0-py2.py3-none-any.whl",
     sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
     # From https://pypi.python.org/pypi/mock
-    url = ("https://pypi.python.org/packages/e6/35/" +
-           "f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/" +
-           "mock-2.0.0-py2.py3-none-any.whl"),
+    urls = [("https://pypi.python.org/packages/e6/35/" +
+             "f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/" +
+             "mock-2.0.0-py2.py3-none-any.whl")],
 )
 
 http_file(
     name = "google_cloud_language_whl",
+    downloaded_file_path = "google_cloud_language-0.29.0-py2.py3-none-any.whl",
     sha256 = "a2dd34f0a0ebf5705dcbe34bd41199b1d0a55c4597d38ed045bd183361a561e9",
     # From https://pypi.python.org/pypi/google-cloud-language
-    url = ("https://pypi.python.org/packages/6e/86/" +
-           "cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/" +
-           "google_cloud_language-0.29.0-py2.py3-none-any.whl"),
+    urls = [("https://pypi.python.org/packages/6e/86/" +
+             "cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/" +
+             "google_cloud_language-0.29.0-py2.py3-none-any.whl")],
 )
 
-# Imports for examples
+#########################
+# Imports for examples. #
+#########################
+
 pip_import(
     name = "examples_helloworld",
     requirements = "//examples/helloworld:requirements.txt",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -18,7 +18,8 @@ licenses(["notice"])  # Apache 2.0
 # To regenerate html docs, run:
 #   ./update_docs.sh
 
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc", "skylark_library")
+load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 
 skylark_library(
     name = "whl",


### PR DESCRIPTION
This upgrades our dependencies to newer versions that are compatible with the new repo rules, and handles the fallout. Also add some comments to WORKSPACE.

rules_python now builds under Bazel 0.19.1 with `--incompatible_remove_native_git_repository` and `incompatible_remove_native_http_archive`.

Fixes #105.