### PR TITLE
Run `buildifier --lint=fix`

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -14,32 +14,36 @@
 """Import pip requirements into Bazel."""
 
 def _pip_import_impl(repository_ctx):
-  """Core implementation of pip_import."""
+    """Core implementation of pip_import."""
 
-  # Add an empty top-level BUILD file.
-  # This is because Bazel requires BUILD files along all paths accessed
-  # via //this/sort/of:path and we wouldn't be able to load our generated
-  # requirements.bzl without it.
-  repository_ctx.file("BUILD", "")
+    # Add an empty top-level BUILD file.
+    # This is because Bazel requires BUILD files along all paths accessed
+    # via //this/sort/of:path and we wouldn't be able to load our generated
+    # requirements.bzl without it.
+    repository_ctx.file("BUILD", "")
 
-  # To see the output, pass: quiet=False
-  result = repository_ctx.execute([
-    "python", repository_ctx.path(repository_ctx.attr._script),
-    "--name", repository_ctx.attr.name,
-    "--input", repository_ctx.path(repository_ctx.attr.requirements),
-    "--output", repository_ctx.path("requirements.bzl"),
-    "--directory", repository_ctx.path(""),
-  ])
+    # To see the output, pass: quiet=False
+    result = repository_ctx.execute([
+        "python",
+        repository_ctx.path(repository_ctx.attr._script),
+        "--name",
+        repository_ctx.attr.name,
+        "--input",
+        repository_ctx.path(repository_ctx.attr.requirements),
+        "--output",
+        repository_ctx.path("requirements.bzl"),
+        "--directory",
+        repository_ctx.path(""),
+    ])
 
-  if result.return_code:
-    fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
+    if result.return_code:
+        fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
 
 pip_import = repository_rule(
     attrs = {
         "requirements": attr.label(
-            allow_files = True,
             mandatory = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "_script": attr.label(
             executable = True,
@@ -93,9 +97,9 @@ Args:
 """
 
 def pip_repositories():
-  """Pull in dependencies needed for pulling in pip dependencies.
+    """Pull in dependencies needed for pulling in pip dependencies.
 
-  A placeholder method that will eventually pull in any dependencies
-  needed to install pip dependencies.
-  """
-  pass
+    A placeholder method that will eventually pull in any dependencies
+    needed to install pip dependencies.
+    """
+    pass

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -13,25 +13,25 @@
 # limitations under the License.
 
 def py_library(*args, **kwargs):
-  """See the Bazel core py_library documentation.
+    """See the Bazel core py_library documentation.
 
-  [available here](
-  https://docs.bazel.build/versions/master/be/python.html#py_library).
-  """
-  native.py_library(*args, **kwargs)
+    [available here](
+    https://docs.bazel.build/versions/master/be/python.html#py_library).
+    """
+    native.py_library(*args, **kwargs)
 
 def py_binary(*args, **kwargs):
-  """See the Bazel core py_binary documentation.
+    """See the Bazel core py_binary documentation.
 
-  [available here](
-  https://docs.bazel.build/versions/master/be/python.html#py_binary).
-  """
-  native.py_binary(*args, **kwargs)
+    [available here](
+    https://docs.bazel.build/versions/master/be/python.html#py_binary).
+    """
+    native.py_binary(*args, **kwargs)
 
 def py_test(*args, **kwargs):
-  """See the Bazel core py_test documentation.
+    """See the Bazel core py_test documentation.
 
-  [available here](
-  https://docs.bazel.build/versions/master/be/python.html#py_test).
-  """
-  native.py_test(*args, **kwargs)
+    [available here](
+    https://docs.bazel.build/versions/master/be/python.html#py_test).
+    """
+    native.py_test(*args, **kwargs)

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -14,31 +14,32 @@
 """Import .whl files into Bazel."""
 
 def _whl_impl(repository_ctx):
-  """Core implementation of whl_library."""
+    """Core implementation of whl_library."""
 
-  args = [
-    "python",
-    repository_ctx.path(repository_ctx.attr._script),
-    "--whl", repository_ctx.path(repository_ctx.attr.whl),
-    "--requirements", repository_ctx.attr.requirements,
-  ]
-
-  if repository_ctx.attr.extras:
-    args += [
-      "--extras=%s" % extra
-      for extra in repository_ctx.attr.extras
+    args = [
+        "python",
+        repository_ctx.path(repository_ctx.attr._script),
+        "--whl",
+        repository_ctx.path(repository_ctx.attr.whl),
+        "--requirements",
+        repository_ctx.attr.requirements,
     ]
 
-  result = repository_ctx.execute(args)
-  if result.return_code:
-    fail("whl_library failed: %s (%s)" % (result.stdout, result.stderr))
+    if repository_ctx.attr.extras:
+        args += [
+            "--extras=%s" % extra
+            for extra in repository_ctx.attr.extras
+        ]
+
+    result = repository_ctx.execute(args)
+    if result.return_code:
+        fail("whl_library failed: %s (%s)" % (result.stdout, result.stderr))
 
 whl_library = repository_rule(
     attrs = {
         "whl": attr.label(
-            allow_files = True,
             mandatory = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "requirements": attr.string(),
         "extras": attr.string_list(),


### PR DESCRIPTION
This reformats the files and applies some automated fixes. This should
help get the repository forward-compatible with Bazel incompatible
changes.

Progress towards #134