### PR TITLE
Travis CI: Add a parallel built to test the testers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ addons:
         key_url: 'https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg'
     packages:
       - bazel
+matrix:
+  include:
+    - python: 3.7
+      language: python
+      dist: xenial  # travis-ci/travis-ci#9069
+      install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
 install:
   - go get -u github.com/bazelbuild/buildifier/buildifier


### PR DESCRIPTION
A quick sanity check run in parallel to ensure that the rule contains no syntax errors or undefined names.

E901,E999,F821,F822,F823 are the "showstopper" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

    F821: undefined name name
    F822: undefined name name in __all__
    F823: local variable name referenced before assignment
    E901: SyntaxError or IndentationError
    E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree