### PR TITLE
Cleanup temporary folder created for cert file extracted from wheel (#150)

### DIFF
--- a/rules_python/piptool.py
+++ b/rules_python/piptool.py
@@ -73,11 +73,14 @@ import wheel
 def pip_main(argv):
     # Extract the certificates from the PAR following the example of get-pip.py
     # https://github.com/pypa/get-pip/blob/430ba37776ae2ad89/template.py#L164-L168
-    cert_path = os.path.join(tempfile.mkdtemp(), "cacert.pem")
+    cert_tmpdir = tempfile.mkdtemp()
+    cert_path = os.path.join(cert_tmpdir, "cacert.pem")
     with open(cert_path, "wb") as cert:
       cert.write(pkgutil.get_data("pip._vendor.requests", "cacert.pem"))
     argv = ["--disable-pip-version-check", "--cert", cert_path] + argv
-    return pip.main(argv)
+    result = pip.main(argv)
+    shutil.rmtree(cert_tmpdir, ignore_errors=True)
+    return result
 
 from rules_python.whl import Wheel
 


### PR DESCRIPTION
The piptool run is not properly sandboxed and the temporary folder
created during extraction of cacert.pem does not get cleaned on
exit. This leads to accumulation in /tmp and may result in out of
space errors over long a period of time.