### PR TITLE
Add loading of git_repository rule to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ dependencies typically managed via `pip`.
 Add the following to your `WORKSPACE` file to add the external repositories:
 
 ```python
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "io_bazel_rules_python",
     remote = "https://github.com/bazelbuild/rules_python.git",


### PR DESCRIPTION
Newer versions of Bazel do not contain a native `git_repository` rule so users of `rules_python` are required to load the `git_repository` rule before they can use it to fetch `rules_python`. This PR updates the documentation accordingly.