### PR TITLE
Py23 proposal: Update plan for py provider fields

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -7,4 +7,4 @@ Proposals that impact native code are also indexed by [bazelbuild/proposals](htt
 Last updated | Status        | Title | Author(s)
 ------------ | ------------- | ------| ---------
 2018-11-09   | Draft         | [Customizing the Python Stub Template](https://github.com/bazelbuild/rules_python/blob/master/proposals/2018-11-08-customizing-the-python-stub-template.md) | [brandjon@](https://github.com/brandjon)
-2019-01-10   | Accepted      | [Selecting Between Python 2 and 3](https://github.com/bazelbuild/rules_python/blob/master/proposals/2018-10-25-selecting-between-python-2-and-3.md) | [brandjon@](https://github.com/brandjon)
+2019-01-11   | Accepted      | [Selecting Between Python 2 and 3](https://github.com/bazelbuild/rules_python/blob/master/proposals/2018-10-25-selecting-between-python-2-and-3.md) | [brandjon@](https://github.com/brandjon)


### PR DESCRIPTION
I don't like the way I was going to add extra provider fields to report better error messages. This updates the doc to say we're not committed to any particular approach. But I think in practice I'll probably do warning messages when a py2-only or py3-only library is depended on by any other py library that's not also py2-only or py3-only respectively. Then when py_binary fails due to version conflicts, it'll direct users to check the log, e.g. by repeating the build with --output_filter.