### PR TITLE
Add experimental support for building wheels.

### DIFF
--- a/experimental/BUILD
+++ b/experimental/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -31,9 +31,9 @@ py_wheel(
     # Only include these Python packages.
     packages=["experimental.examples.wheel"],
     # Package data. We're building "example_minimal-0.0.1-py3-none-any.whl"
-    wheel_name="example_minimal",
+    distribution="example_minimal",
     version="0.0.1",
-    python="py3",
+    python_tag="py3",
 )
 
 # An example that uses all features provided by py_wheel.
@@ -44,9 +44,9 @@ py_wheel(
     # Only include these Python packages.
     packages=["experimental.examples.wheel"],
     # Package data. We're building "example_customized-0.0.1-py3-none-any.whl"
-    wheel_name="example_customized",
+    distribution="example_customized",
     version="0.0.1",
-    python="py3",
+    python_tag="py3",
     author="Example Author with non-ascii characters: żółw",
     author_email="example@example.com",
     homepage="www.example.com",

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -16,20 +16,28 @@ package(default_visibility=["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 load("//python:python.bzl", "py_library", "py_test")
-load("//experimental/python:wheel.bzl", "py_wheel")
+load("//experimental/python:wheel.bzl", "py_package", "py_wheel")
 
 py_library(name="main",
            srcs=["main.py"],
            deps=["//experimental/examples/wheel/lib:simple_module",
-                 "//experimental/examples/wheel/lib:module_with_data"])
+                 "//experimental/examples/wheel/lib:module_with_data",
+                 # Example dependency which is not packaged in the wheel
+                 # due to "packages" filter on py_package rule.
+                 "//examples/helloworld"])
+
+# Collect files to be packaged.
+py_package(
+    name="example_pkg",
+    deps = [":main"],
+    # Only include these Python packages.
+    packages=["experimental.examples.wheel"],
+)
 
 # A barebones example of a wheel
 py_wheel(
     name="minimal",
-    # Pulls in main and all recursive dependencies,
-    deps=[":main"],
-    # Only include these Python packages.
-    packages=["experimental.examples.wheel"],
+    deps=[":example_pkg"],
     # Package data. We're building "example_minimal-0.0.1-py3-none-any.whl"
     distribution="example_minimal",
     version="0.0.1",
@@ -39,10 +47,7 @@ py_wheel(
 # An example that uses all features provided by py_wheel.
 py_wheel(
     name="customized",
-    # Pulls in main and all recursive dependencies,
-    deps=[":main"],
-    # Only include these Python packages.
-    packages=["experimental.examples.wheel"],
+    deps=[":example_pkg"],
     # Package data. We're building "example_customized-0.0.1-py3-none-any.whl"
     distribution="example_customized",
     version="0.0.1",

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -91,5 +91,6 @@ py_test(
     data = [
         ":customized",
         ":minimal_with_py_library",
+        ":minimal_with_py_package",
     ],
 )

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -11,61 +11,85 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package(default_visibility=["//visibility:public"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
 load("//python:python.bzl", "py_library", "py_test")
 load("//experimental/python:wheel.bzl", "py_package", "py_wheel")
 
-py_library(name="main",
-           srcs=["main.py"],
-           deps=["//experimental/examples/wheel/lib:simple_module",
-                 "//experimental/examples/wheel/lib:module_with_data",
-                 # Example dependency which is not packaged in the wheel
-                 # due to "packages" filter on py_package rule.
-                 "//examples/helloworld"])
-
-# Collect files to be packaged.
-py_package(
-    name="example_pkg",
-    deps = [":main"],
-    # Only include these Python packages.
-    packages=["experimental.examples.wheel"],
+py_library(
+    name = "main",
+    srcs = ["main.py"],
+    deps = [
+        "//experimental/examples/wheel/lib:simple_module",
+        "//experimental/examples/wheel/lib:module_with_data",
+        # Example dependency which is not packaged in the wheel
+        # due to "packages" filter on py_package rule.
+        "//examples/helloworld",
+    ],
 )
 
-# A barebones example of a wheel
+# Package just a specific py_libraries, without their dependencies
 py_wheel(
-    name="minimal",
-    deps=[":example_pkg"],
-    # Package data. We're building "example_minimal-0.0.1-py3-none-any.whl"
-    distribution="example_minimal",
-    version="0.0.1",
-    python_tag="py3",
+    name = "minimal_with_py_library",
+    # Package data. We're building "example_minimal_library-0.0.1-py3-none-any.whl"
+    distribution = "example_minimal_library",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        "//experimental/examples/wheel/lib:module_with_data",
+        "//experimental/examples/wheel/lib:simple_module",
+    ],
+)
+
+# Use py_package to collect all transitive dependencies of a target,
+# selecting just the files within a specific python package.
+py_package(
+    name = "example_pkg",
+    # Only include these Python packages.
+    packages = ["experimental.examples.wheel"],
+    deps = [":main"],
+)
+
+py_wheel(
+    name = "minimal_with_py_package",
+    # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl"
+    distribution = "example_minimal_package",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [":example_pkg"],
 )
 
 # An example that uses all features provided by py_wheel.
 py_wheel(
-    name="customized",
-    deps=[":example_pkg"],
+    name = "customized",
+    author = "Example Author with non-ascii characters: żółw",
+    author_email = "example@example.com",
+    classifiers = [
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+    ],
+    console_scripts = {
+        "customized_wheel": "experimental.examples.wheel.main:main",
+    },
+    description_file = "README.md",
     # Package data. We're building "example_customized-0.0.1-py3-none-any.whl"
-    distribution="example_customized",
-    version="0.0.1",
-    python_tag="py3",
-    author="Example Author with non-ascii characters: żółw",
-    author_email="example@example.com",
-    homepage="www.example.com",
-    license="Apache 2.0",
-    classifiers=["License :: OSI Approved :: Apache Software License",
-                 "Intended Audience :: Developers"],
-    description_file="README.md",
+    distribution = "example_customized",
+    homepage = "www.example.com",
+    license = "Apache 2.0",
+    python_tag = "py3",
     # Requirements embedded into the wheel metadata.
-    requires=["pytest"],
-    console_scripts={
-        'customized_wheel': 'experimental.examples.wheel.main:main'}
+    requires = ["pytest"],
+    version = "0.0.1",
+    deps = [":example_pkg"],
 )
 
 py_test(
-    name="wheel_test",
-    srcs=["wheel_test.py"],
-    data=[":customized"])
+    name = "wheel_test",
+    srcs = ["wheel_test.py"],
+    data = [
+        ":customized",
+        ":minimal_with_py_library",
+    ],
+)

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -1,0 +1,66 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility=["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("//python:python.bzl", "py_library", "py_test")
+load("//experimental/python:wheel.bzl", "py_wheel")
+
+py_library(name="main",
+           srcs=["main.py"],
+           deps=["//experimental/examples/wheel/lib:simple_module",
+                 "//experimental/examples/wheel/lib:module_with_data"])
+
+# A barebones example of a wheel
+py_wheel(
+    name="minimal",
+    # Pulls in main and all recursive dependencies,
+    deps=[":main"],
+    # Only include these Python packages.
+    packages=["experimental.examples.wheel"],
+    # Package data. We're building "example_minimal-0.0.1-py3-none-any.whl"
+    wheel_name="example_minimal",
+    version="0.0.1",
+    python="py3",
+)
+
+# An example that uses all features provided by py_wheel.
+py_wheel(
+    name="customized",
+    # Pulls in main and all recursive dependencies,
+    deps=[":main"],
+    # Only include these Python packages.
+    packages=["experimental.examples.wheel"],
+    # Package data. We're building "example_customized-0.0.1-py3-none-any.whl"
+    wheel_name="example_customized",
+    version="0.0.1",
+    python="py3",
+    author="Example Author with non-ascii characters: żółw",
+    author_email="example@example.com",
+    homepage="www.example.com",
+    license="Apache 2.0",
+    classifiers=["License :: OSI Approved :: Apache Software License",
+                 "Intended Audience :: Developers"],
+    description_file="README.md",
+    # Requirements embedded into the wheel metadata.
+    requires=["pytest"],
+    console_scripts={
+        'customized_wheel': 'experimental.examples.wheel.main:main'}
+)
+
+py_test(
+    name="wheel_test",
+    srcs=["wheel_test.py"],
+    data=[":customized"])

--- a/experimental/examples/wheel/README.md
+++ b/experimental/examples/wheel/README.md
@@ -1,0 +1,1 @@
+This is a sample description of a wheel.

--- a/experimental/examples/wheel/lib/BUILD
+++ b/experimental/examples/wheel/lib/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/experimental/examples/wheel/lib/BUILD
+++ b/experimental/examples/wheel/lib/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("//python:python.bzl", "py_library")
+
+py_library(
+    name = "simple_module",
+    srcs = ["simple_module.py"],
+)
+
+py_library(
+    name = "module_with_data",
+    srcs = ["module_with_data.py"],
+    data = [":data.txt"],
+)
+
+genrule(
+    name="make_data",
+    outs=["data.txt"],
+    cmd="echo foo bar baz > $@",
+)

--- a/experimental/examples/wheel/lib/BUILD
+++ b/experimental/examples/wheel/lib/BUILD
@@ -29,7 +29,7 @@ py_library(
 )
 
 genrule(
-    name="make_data",
-    outs=["data.txt"],
-    cmd="echo foo bar baz > $@",
+    name = "make_data",
+    outs = ["data.txt"],
+    cmd = "echo foo bar baz > $@",
 )

--- a/experimental/examples/wheel/lib/module_with_data.py
+++ b/experimental/examples/wheel/lib/module_with_data.py
@@ -1,0 +1,16 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def function():
+    return "foo"

--- a/experimental/examples/wheel/lib/simple_module.py
+++ b/experimental/examples/wheel/lib/simple_module.py
@@ -1,0 +1,16 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def function():
+    return "bar"

--- a/experimental/examples/wheel/main.py
+++ b/experimental/examples/wheel/main.py
@@ -1,0 +1,30 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import experimental.examples.wheel.lib.module_with_data as module_with_data
+import experimental.examples.wheel.lib.simple_module as simple_module
+
+
+def function():
+    return "baz"
+
+
+def main():
+    print(function())
+    print(module_with_data.function())
+    print(simple_module.function())
+
+
+if __name__ == '__main__':
+    main()

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -1,0 +1,77 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+import zipfile
+
+
+class WheelTest(unittest.TestCase):
+    def test_customized_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_customized-0.0.1-py3-none-any.whl')
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['experimental/examples/wheel/lib/data.txt',
+                 'experimental/examples/wheel/lib/module_with_data.py',
+                 'experimental/examples/wheel/lib/simple_module.py',
+                 'experimental/examples/wheel/main.py',
+                 'example_customized-0.0.1.dist-info/WHEEL',
+                 'example_customized-0.0.1.dist-info/METADATA',
+                 'example_customized-0.0.1.dist-info/entry_points.txt',
+                 'example_customized-0.0.1.dist-info/RECORD'])
+            record_contents = zf.read(
+                'example_customized-0.0.1.dist-info/RECORD')
+            wheel_contents = zf.read(
+                'example_customized-0.0.1.dist-info/WHEEL')
+            metadata_contents = zf.read(
+                'example_customized-0.0.1.dist-info/METADATA')
+            # The entries are guaranteed to be sorted.
+            self.assertEquals(record_contents, b"""\
+example_customized-0.0.1.dist-info/METADATA,sha256=TeeEmokHE2NWjkaMcVJuSAq4_AXUoIad2-SLuquRmbg,372
+example_customized-0.0.1.dist-info/RECORD,,
+example_customized-0.0.1.dist-info/WHEEL,sha256=F01lGfVCzcXUzzQHzUkBmXAcu_TXd5zqMLrvrspncJo,85
+example_customized-0.0.1.dist-info/entry_points.txt,sha256=olLJ8FK88aft2pcdj4BD05F8Xyz83Mo51I93tRGT2Yk,74
+experimental/examples/wheel/lib/data.txt,sha256=9vJKEdfLu8bZRArKLroPZJh1XKkK3qFMXiM79MBL2Sg,12
+experimental/examples/wheel/lib/module_with_data.py,sha256=K_IGAq_CHcZX0HUyINpD1hqSKIEdCn58d9E9nhWF2EA,636
+experimental/examples/wheel/lib/simple_module.py,sha256=72-91Dm6NB_jw-7wYQt7shzdwvk5RB0LujIah8g7kr8,636
+experimental/examples/wheel/main.py,sha256=E0xCyiPg6fCo4IrFmqo_tqpNGtk1iCewobqD0_KlFd0,935
+""")
+            self.assertEquals(wheel_contents, b"""\
+Wheel-Version: 1.0
+Generator: wheelmaker 1.0
+Root-Is-Purelib: true
+Tag: py3-none-any
+""")
+            self.assertEquals(metadata_contents, b"""\
+Metadata-Version: 2.1
+Name: example_customized
+Version: 0.0.1
+Author: Example Author with non-ascii characters: \xc5\xbc\xc3\xb3\xc5\x82w
+Author-email: example@example.com
+Home-page: www.example.com
+License: Apache 2.0
+Classifier: License :: OSI Approved :: Apache Software License
+Classifier: Intended Audience :: Developers
+Requires-Dist: pytest
+
+This is a sample description of a wheel.
+""")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -18,6 +18,20 @@ import zipfile
 
 
 class WheelTest(unittest.TestCase):
+    def test_py_library_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_minimal_library-0.0.1-py3-none-any.whl')
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['experimental/examples/wheel/lib/module_with_data.py',
+                 'experimental/examples/wheel/lib/simple_module.py',
+                 'example_minimal_library-0.0.1.dist-info/WHEEL',
+                 'example_minimal_library-0.0.1.dist-info/METADATA',
+                 'example_minimal_library-0.0.1.dist-info/RECORD'])
+
     def test_customized_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
                                 'io_bazel_rules_python', 'experimental',

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -32,6 +32,22 @@ class WheelTest(unittest.TestCase):
                  'example_minimal_library-0.0.1.dist-info/METADATA',
                  'example_minimal_library-0.0.1.dist-info/RECORD'])
 
+    def test_py_package_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_minimal_package-0.0.1-py3-none-any.whl')
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['experimental/examples/wheel/lib/data.txt',
+                 'experimental/examples/wheel/lib/module_with_data.py',
+                 'experimental/examples/wheel/lib/simple_module.py',
+                 'experimental/examples/wheel/main.py',
+                 'example_minimal_package-0.0.1.dist-info/WHEEL',
+                 'example_minimal_package-0.0.1.dist-info/METADATA',
+                 'example_minimal_package-0.0.1.dist-info/RECORD'])
+
     def test_customized_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
                                 'io_bazel_rules_python', 'experimental',

--- a/experimental/python/BUILD
+++ b/experimental/python/BUILD
@@ -1,0 +1,18 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(['wheel.bzl'])

--- a/experimental/python/BUILD
+++ b/experimental/python/BUILD
@@ -15,4 +15,4 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-exports_files(['wheel.bzl'])
+exports_files(["wheel.bzl"])

--- a/experimental/python/BUILD
+++ b/experimental/python/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -1,0 +1,142 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for building wheels."""
+
+
+def _py_wheel_impl(ctx):
+    outfile = ctx.actions.declare_file('-'.join([
+        ctx.attr.wheel_name,
+        ctx.attr.version,
+        ctx.attr.python,
+        ctx.attr.abi,
+        ctx.attr.platform
+    ]) + '.whl')
+
+    inputs = depset(
+        transitive=[dep[DefaultInfo].data_runfiles.files for dep in
+                    ctx.attr.deps] +
+                   [dep[DefaultInfo].default_runfiles.files for dep in
+                    ctx.attr.deps]
+    )
+    arguments = ['--name', ctx.attr.wheel_name,
+                 '--version', ctx.attr.version,
+                 '--python', ctx.attr.python,
+                 '--abi', ctx.attr.abi,
+                 '--platform', ctx.attr.platform,
+                 '--out', outfile.path]
+    arguments.extend(['--restrict_package=%s' % p for p in ctx.attr.packages])
+    for input_file in inputs.to_list():
+        arguments.append('--input_file')
+        arguments.append('%s;%s' % (input_file.short_path, input_file.path))
+
+    extra_headers = []
+    if ctx.attr.author:
+        extra_headers.append("Author: %s" % ctx.attr.author)
+    if ctx.attr.author_email:
+        extra_headers.append("Author-email: %s" % ctx.attr.author_email)
+    if ctx.attr.homepage:
+        extra_headers.append("Home-page: %s" % ctx.attr.homepage)
+    if ctx.attr.license:
+        extra_headers.append("License: %s" % ctx.attr.license)
+
+    for h in extra_headers:
+        arguments.append('--header')
+        arguments.append(h)
+
+    for c in ctx.attr.classifiers:
+        arguments.append('--classifier')
+        arguments.append(c)
+
+    for r in ctx.attr.requires:
+        arguments.append('--requires')
+        arguments.append(r)
+
+    for option, requirements in ctx.attr.extra_requires.items():
+        for r in requirements:
+            arguments.append('--extra_requires')
+            arguments.append(r + ';' + option)
+
+    for name, ref in ctx.attr.console_scripts.items():
+        arguments.append('--console_script')
+        arguments.append(name + ' = ' + ref)
+
+    if ctx.attr.description_file:
+        description_files = ctx.attr.description_file.files.to_list()
+        arguments.append('--description_file')
+        arguments.append(description_files[0].path)
+        inputs = inputs.union(ctx.attr.description_file.files)
+
+    ctx.actions.run(
+        inputs=inputs,
+        outputs=[outfile],
+        arguments=arguments,
+        executable=ctx.executable._wheelmaker,
+        progress_message="Building wheel")
+    return [DefaultInfo(files=depset([outfile]),
+                        data_runfiles=ctx.runfiles(files=[outfile]))]
+
+
+py_wheel = rule(
+    implementation=_py_wheel_impl,
+    attrs={
+        "deps": attr.label_list(
+            doc="Dependencies of this package, e.g. py_library rules"),
+        "packages": attr.string_list(
+            mandatory=True,
+            allow_empty=False,
+            doc="""\
+List of Python packages to include in the distribution.
+Sub-packages are automatically included.
+"""),
+        # Attributes defining the distribution
+        "wheel_name": attr.string(
+            mandatory=True,
+            doc="Name of the wheel"),
+        "version": attr.string(
+            mandatory=True,
+            doc="Version number of the package"),
+        "python": attr.string(
+            default='py3',
+            doc="Supported Python major version. 'py2' or 'py3'"),
+        "abi": attr.string(
+            default='none',
+            doc="Python ABI tag. 'none' for pure-Python wheels."),
+        # TODO(pstradomski): Support non-pure wheels
+        "platform": attr.string(
+            default='any',
+            doc="Supported platforms. 'any' for pure-Python wheel."),
+        # Other attributes
+        "author": attr.string(default=''),
+        "author_email": attr.string(default=''),
+        "homepage": attr.string(default=''),
+        "license": attr.string(default=''),
+        "classifiers": attr.string_list(),
+        "description_file": attr.label(allow_files=True),
+        # Requirements
+        "requires": attr.string_list(
+            doc="List of requirements for this package"),
+        "extra_requires": attr.string_list_dict(
+            doc="List of optional requirements for this package"),
+        # Entry points
+        "console_scripts": attr.string_dict(
+            doc="console_script entry points",
+        ),
+        # Implementation details.
+        "_wheelmaker": attr.label(
+            executable=True,
+            cfg="host",
+            default="//experimental/rules_python:wheelmaker")
+    },
+)

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -232,6 +232,7 @@ to refer to the package in other packages' dependencies.
         "python_tag": attr.string(
             default = "py3",
             doc = "Supported Python major version. 'py2' or 'py3'",
+            values = ["py2", "py3"],
         ),
         "abi": attr.string(
             default = "none",

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -90,10 +90,10 @@ def _py_wheel_impl(ctx):
         arguments.append(name + " = " + ref)
 
     if ctx.attr.description_file:
-        description_files = ctx.attr.description_file.files.to_list()
+        description_file = ctx.file.description_file
         arguments.append("--description_file")
-        arguments.append(description_files[0].path)
-        inputs = inputs.union(ctx.attr.description_file.files)
+        arguments.append(description_file.path)
+        inputs = inputs.union([description_file])
 
     ctx.actions.run(
         inputs = inputs,
@@ -193,7 +193,7 @@ to refer to the package in other packages' dependencies.
         "homepage": attr.string(default = ""),
         "license": attr.string(default = ""),
         "classifiers": attr.string_list(),
-        "description_file": attr.label(allow_files = True),
+        "description_file": attr.label(allow_single_file = True),
         # Requirements
         "requires": attr.string_list(
             doc = "List of requirements for this package",

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -14,32 +14,37 @@
 
 """Rules for building wheels."""
 
-
 def _py_wheel_impl(ctx):
-    outfile = ctx.actions.declare_file('-'.join([
+    outfile = ctx.actions.declare_file("-".join([
         ctx.attr.wheel_name,
         ctx.attr.version,
         ctx.attr.python,
         ctx.attr.abi,
-        ctx.attr.platform
-    ]) + '.whl')
+        ctx.attr.platform,
+    ]) + ".whl")
 
     inputs = depset(
-        transitive=[dep[DefaultInfo].data_runfiles.files for dep in
-                    ctx.attr.deps] +
-                   [dep[DefaultInfo].default_runfiles.files for dep in
-                    ctx.attr.deps]
+        transitive = [dep[DefaultInfo].data_runfiles.files for dep in ctx.attr.deps] +
+                     [dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps],
     )
-    arguments = ['--name', ctx.attr.wheel_name,
-                 '--version', ctx.attr.version,
-                 '--python', ctx.attr.python,
-                 '--abi', ctx.attr.abi,
-                 '--platform', ctx.attr.platform,
-                 '--out', outfile.path]
-    arguments.extend(['--restrict_package=%s' % p for p in ctx.attr.packages])
+    arguments = [
+        "--name",
+        ctx.attr.wheel_name,
+        "--version",
+        ctx.attr.version,
+        "--python",
+        ctx.attr.python,
+        "--abi",
+        ctx.attr.abi,
+        "--platform",
+        ctx.attr.platform,
+        "--out",
+        outfile.path,
+    ]
+    arguments.extend(["--restrict_package=%s" % p for p in ctx.attr.packages])
     for input_file in inputs.to_list():
-        arguments.append('--input_file')
-        arguments.append('%s;%s' % (input_file.short_path, input_file.path))
+        arguments.append("--input_file")
+        arguments.append("%s;%s" % (input_file.short_path, input_file.path))
 
     extra_headers = []
     if ctx.attr.author:
@@ -52,91 +57,103 @@ def _py_wheel_impl(ctx):
         extra_headers.append("License: %s" % ctx.attr.license)
 
     for h in extra_headers:
-        arguments.append('--header')
+        arguments.append("--header")
         arguments.append(h)
 
     for c in ctx.attr.classifiers:
-        arguments.append('--classifier')
+        arguments.append("--classifier")
         arguments.append(c)
 
     for r in ctx.attr.requires:
-        arguments.append('--requires')
+        arguments.append("--requires")
         arguments.append(r)
 
     for option, requirements in ctx.attr.extra_requires.items():
         for r in requirements:
-            arguments.append('--extra_requires')
-            arguments.append(r + ';' + option)
+            arguments.append("--extra_requires")
+            arguments.append(r + ";" + option)
 
     for name, ref in ctx.attr.console_scripts.items():
-        arguments.append('--console_script')
-        arguments.append(name + ' = ' + ref)
+        arguments.append("--console_script")
+        arguments.append(name + " = " + ref)
 
     if ctx.attr.description_file:
         description_files = ctx.attr.description_file.files.to_list()
-        arguments.append('--description_file')
+        arguments.append("--description_file")
         arguments.append(description_files[0].path)
         inputs = inputs.union(ctx.attr.description_file.files)
 
     ctx.actions.run(
-        inputs=inputs,
-        outputs=[outfile],
-        arguments=arguments,
-        executable=ctx.executable._wheelmaker,
-        progress_message="Building wheel")
-    return [DefaultInfo(files=depset([outfile]),
-                        data_runfiles=ctx.runfiles(files=[outfile]))]
-
+        inputs = inputs,
+        outputs = [outfile],
+        arguments = arguments,
+        executable = ctx.executable._wheelmaker,
+        progress_message = "Building wheel",
+    )
+    return [DefaultInfo(
+        files = depset([outfile]),
+        data_runfiles = ctx.runfiles(files = [outfile]),
+    )]
 
 py_wheel = rule(
-    implementation=_py_wheel_impl,
-    attrs={
+    implementation = _py_wheel_impl,
+    attrs = {
         "deps": attr.label_list(
-            doc="Dependencies of this package, e.g. py_library rules"),
+            doc = "Dependencies of this package, e.g. py_library rules",
+        ),
         "packages": attr.string_list(
-            mandatory=True,
-            allow_empty=False,
-            doc="""\
+            mandatory = True,
+            allow_empty = False,
+            doc = """\
 List of Python packages to include in the distribution.
 Sub-packages are automatically included.
-"""),
+""",
+        ),
         # Attributes defining the distribution
         "wheel_name": attr.string(
-            mandatory=True,
-            doc="Name of the wheel"),
+            mandatory = True,
+            doc = "Name of the wheel",
+        ),
         "version": attr.string(
-            mandatory=True,
-            doc="Version number of the package"),
+            mandatory = True,
+            doc = "Version number of the package",
+        ),
         "python": attr.string(
-            default='py3',
-            doc="Supported Python major version. 'py2' or 'py3'"),
+            default = "py3",
+            doc = "Supported Python major version. 'py2' or 'py3'",
+        ),
         "abi": attr.string(
-            default='none',
-            doc="Python ABI tag. 'none' for pure-Python wheels."),
+            default = "none",
+            doc = "Python ABI tag. 'none' for pure-Python wheels.",
+        ),
         # TODO(pstradomski): Support non-pure wheels
         "platform": attr.string(
-            default='any',
-            doc="Supported platforms. 'any' for pure-Python wheel."),
+            default = "any",
+            doc = "Supported platforms. 'any' for pure-Python wheel.",
+        ),
         # Other attributes
-        "author": attr.string(default=''),
-        "author_email": attr.string(default=''),
-        "homepage": attr.string(default=''),
-        "license": attr.string(default=''),
+        "author": attr.string(default = ""),
+        "author_email": attr.string(default = ""),
+        "homepage": attr.string(default = ""),
+        "license": attr.string(default = ""),
         "classifiers": attr.string_list(),
-        "description_file": attr.label(allow_files=True),
+        "description_file": attr.label(allow_files = True),
         # Requirements
         "requires": attr.string_list(
-            doc="List of requirements for this package"),
+            doc = "List of requirements for this package",
+        ),
         "extra_requires": attr.string_list_dict(
-            doc="List of optional requirements for this package"),
+            doc = "List of optional requirements for this package",
+        ),
         # Entry points
         "console_scripts": attr.string_dict(
-            doc="console_script entry points",
+            doc = "console_script entry points",
         ),
         # Implementation details.
         "_wheelmaker": attr.label(
-            executable=True,
-            cfg="host",
-            default="//experimental/rules_python:wheelmaker")
+            executable = True,
+            cfg = "host",
+            default = "//experimental/rules_python:wheelmaker",
+        ),
     },
 )

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -153,8 +153,8 @@ tries to locate `.runfiles` directory which is not packaged in the wheel.
 """,
         ),
         "packages": attr.string_list(
-            mandatory = True,
-            allow_empty = False,
+            mandatory = False,
+            allow_empty = True,
             doc = """\
 List of Python packages to include in the distribution.
 Sub-packages are automatically included.
@@ -163,7 +163,12 @@ Sub-packages are automatically included.
         # Attributes defining the distribution
         "distribution": attr.string(
             mandatory = True,
-            doc = "Name of the wheel",
+            doc = """
+Name of the distribution.
+
+This should match the project name onm PyPI. It's also the name that is used
+to refer to the package in other packages' dependencies.
+""",
         ),
         "version": attr.string(
             mandatory = True,

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -16,9 +16,9 @@
 
 def _py_wheel_impl(ctx):
     outfile = ctx.actions.declare_file("-".join([
-        ctx.attr.wheel_name,
+        ctx.attr.distribution,
         ctx.attr.version,
-        ctx.attr.python,
+        ctx.attr.python_tag,
         ctx.attr.abi,
         ctx.attr.platform,
     ]) + ".whl")
@@ -29,11 +29,11 @@ def _py_wheel_impl(ctx):
     )
     arguments = [
         "--name",
-        ctx.attr.wheel_name,
+        ctx.attr.distribution,
         "--version",
         ctx.attr.version,
-        "--python",
-        ctx.attr.python,
+        "--python_tag",
+        ctx.attr.python_tag,
         "--abi",
         ctx.attr.abi,
         "--platform",
@@ -110,7 +110,7 @@ Sub-packages are automatically included.
 """,
         ),
         # Attributes defining the distribution
-        "wheel_name": attr.string(
+        "distribution": attr.string(
             mandatory = True,
             doc = "Name of the wheel",
         ),
@@ -118,7 +118,7 @@ Sub-packages are automatically included.
             mandatory = True,
             doc = "Version number of the package",
         ),
-        "python": attr.string(
+        "python_tag": attr.string(
             default = "py3",
             doc = "Supported Python major version. 'py2' or 'py3'",
         ),

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -99,7 +99,14 @@ py_wheel = rule(
     implementation = _py_wheel_impl,
     attrs = {
         "deps": attr.label_list(
-            doc = "Dependencies of this package, e.g. py_library rules",
+            doc = """\
+Dependencies of this package, e.g. `py_library` rules.
+
+Note it's usually better to package `py_library` targets and use
+`console_scripts` attribute to specify entry points than to package
+`py_binary` rules. `py_binary` targets would wrap a executable script that
+tries to locate `.runfiles` directory which is not packaged in the wheel.
+""",
         ),
         "packages": attr.string_list(
             mandatory = True,
@@ -147,7 +154,9 @@ Sub-packages are automatically included.
         ),
         # Entry points
         "console_scripts": attr.string_dict(
-            doc = "console_script entry points",
+            doc = """\
+console_script entry points, e.g. 'experimental.examples.wheel.main:main'.
+""",
         ),
         # Implementation details.
         "_wheelmaker": attr.label(

--- a/experimental/rules_python/BUILD
+++ b/experimental/rules_python/BUILD
@@ -1,0 +1,21 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:python.bzl", "py_binary")
+
+py_binary(
+    name='wheelmaker',
+    srcs= ['wheelmaker.py'],
+    visibility=['//visibility:public'],
+)

--- a/experimental/rules_python/BUILD
+++ b/experimental/rules_python/BUILD
@@ -15,7 +15,7 @@
 load("//python:python.bzl", "py_binary")
 
 py_binary(
-    name='wheelmaker',
-    srcs= ['wheelmaker.py'],
-    visibility=['//visibility:public'],
+    name = "wheelmaker",
+    srcs = ["wheelmaker.py"],
+    visibility = ["//visibility:public"],
 )

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -1,0 +1,313 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import base64
+import collections
+import csv
+import hashlib
+import io
+import os
+import os.path
+import sys
+import zipfile
+
+
+def commonpath(path1, path2):
+    ret = []
+    for a, b in zip(path1.split(os.path.sep), path2.split(os.path.sep)):
+        if a != b:
+            break
+        ret.append(a)
+    return os.path.sep.join(ret)
+
+
+class WheelMaker(object):
+    def __init__(self, name, version, build_tag, python, abi, platform,
+                 outfile=None):
+        self._name = name
+        self._version = version
+        self._build_tag = build_tag
+        self._python = python
+        self._abi = abi
+        self._platform = platform
+        self._outfile = outfile
+
+        self._zipfile = None
+        self._record = []
+
+    def __enter__(self):
+        self._zipfile = zipfile.ZipFile(self.filename(), mode="w",
+                                        compression=zipfile.ZIP_DEFLATED)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._zipfile.close()
+        self._zipfile = None
+
+    def filename(self):
+        if self._outfile:
+            return self._outfile
+        components = [self._name, self._version]
+        if self._build_tag:
+            components.append(self._build_tag)
+        components += [self._python, self._abi, self._platform]
+        return '-'.join(components) + '.whl'
+
+    def distname(self):
+        return self._name + '-' + self._version
+
+    def disttags(self):
+        return ['-'.join([self._python, self._abi, self._platform])]
+
+    def distinfo_path(self, basename):
+        return self.distname() + '.dist-info/' + basename
+
+    def _serialize_digest(self, hash):
+        # https://www.python.org/dev/peps/pep-0376/#record
+        # "base64.urlsafe_b64encode(digest) with trailing = removed"
+        digest = base64.urlsafe_b64encode(hash.digest())
+        digest = b'sha256=' + digest.rstrip(b'=')
+        return digest
+
+    def add_string(self, filename, contents):
+        """Add given 'contents' as filename to the distribution."""
+        if sys.version_info[0] > 2 and isinstance(contents, str):
+            contents = contents.encode('utf-8', 'surrogateescape')
+        self._zipfile.writestr(filename, contents)
+        hash = hashlib.sha256()
+        hash.update(contents)
+        self._add_to_record(filename, self._serialize_digest(hash),
+                            len(contents))
+
+    def add_file(self, package_filename, real_filename):
+        """Add given file to the distribution."""
+        # Always use unix path separators.
+        arcname = package_filename.replace(os.path.sep, '/')
+        self._zipfile.write(real_filename, arcname=arcname)
+        # Find the hash and length
+        hash = hashlib.sha256()
+        size = 0
+        with open(real_filename, 'rb') as f:
+            while True:
+                block = f.read(2 ** 20)
+                if not block:
+                    break
+                hash.update(block)
+                size += len(block)
+        self._add_to_record(arcname, self._serialize_digest(hash), size)
+
+    def add_wheelfile(self):
+        """Write WHEEL file to the distribution"""
+        # TODO(pstradomski): Support non-purelib wheels.
+        wheel_contents = """\
+Wheel-Version: 1.0
+Generator: wheelmaker 1.0
+Root-Is-Purelib: true
+"""
+        for tag in self.disttags():
+            wheel_contents += "Tag: %s\n" % tag
+        self.add_string(self.distinfo_path('WHEEL'), wheel_contents)
+
+    def add_metadata(self, extra_headers, description, classifiers, requires,
+                     extra_requires):
+        """Write METADATA file to the distribution."""
+        # https://www.python.org/dev/peps/pep-0566/
+        # https://packaging.python.org/specifications/core-metadata/
+        metadata = []
+        metadata.append("Metadata-Version: 2.1")
+        metadata.append("Name: %s" % self._name)
+        metadata.append("Version: %s" % self._version)
+        metadata.extend(extra_headers)
+        for classifier in classifiers:
+            metadata.append("Classifier: %s" % classifier)
+        for requirement in requires:
+            metadata.append("Requires-Dist: %s" % requirement)
+
+        extra_requires = sorted(extra_requires.items())
+        for option, option_requires in extra_requires:
+            metadata.append("Provides-Extra: %s" % option)
+            for requirement in option_requires:
+                metadata.append(
+                    "Requires-Dist: %s; extra == '%s'" % (requirement, option))
+
+        metadata = '\n'.join(metadata) + '\n\n'
+        # setuptools seems to insert UNKNOWN as description when none is
+        # provided.
+        metadata += description if description else "UNKNOWN"
+        metadata += "\n"
+        self.add_string(self.distinfo_path('METADATA'), metadata)
+
+    def add_entry_points(self, console_scripts):
+        """Write entry_points.txt file to the distribution."""
+        # https://packaging.python.org/specifications/entry-points/
+        if not console_scripts:
+            return
+        lines = ["[console_scripts]"] + console_scripts
+        contents = '\n'.join(lines)
+        self.add_string(self.distinfo_path('entry_points.txt'), contents)
+
+    def add_recordfile(self):
+        """Write RECORD file to the distribution."""
+        record_path = self.distinfo_path('RECORD')
+        entries = self._record + [(record_path, b'', b'')]
+        entries.sort()
+        contents = b''
+        for filename, digest, size in entries:
+            if sys.version_info[0] > 2 and isinstance(filename, str):
+                filename = filename.encode('utf-8', 'surrogateescape')
+            contents += b'%s,%s,%s\n' % (filename, digest, size)
+        self.add_string(record_path, contents)
+
+    def _add_to_record(self, filename, hash, size):
+        size = str(size).encode('ascii')
+        self._record.append((filename, hash, size))
+
+
+def file_matches_packages(filename, packages):
+    """Check if the file belongs to any of the listed packages."""
+    if not packages:
+        return True
+    for package in packages:
+        if commonpath(filename, package) == package:
+            return True
+    return False
+
+
+def get_files_to_package(input_files, restrict_packages):
+    """Find files to be added to the distribution.
+
+    input_files: list of pairs (package_path, real_path)
+    restrict_packages: list of packages to be included in the distribution.
+    """
+    files = {}
+    for package_path, real_path in input_files:
+        if not file_matches_packages(package_path, restrict_packages):
+            continue
+        files[package_path] = real_path
+    return files
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Builds a python wheel')
+    metadata_group = parser.add_argument_group(
+        "Wheel name, version and platform")
+    metadata_group.add_argument('--name', required=True,
+                                type=str,
+                                help="Name of the distribution")
+    metadata_group.add_argument('--version', required=True,
+                                type=str,
+                                help="Version of the distribution")
+    metadata_group.add_argument('--build_tag', type=str, default='',
+                                help="Optional build tag for the distribution")
+    metadata_group.add_argument('--python', type=str, default='py3',
+                                help="Python version, e.g. 'py2' or 'py3'")
+    metadata_group.add_argument('--abi', type=str, default='none')
+    metadata_group.add_argument('--platform', type=str, default='any',
+                                help="Target platform. ")
+
+    output_group = parser.add_argument_group("Output file location")
+    output_group.add_argument('--out', type=str, default=None,
+                              help="Override name of ouptut file")
+
+    wheel_group = parser.add_argument_group("Wheel metadata")
+    wheel_group.add_argument(
+        '--header', action='append',
+        help="Additional headers to be embedded in the package metadata. "
+             "Can be supplied multiple times.")
+    wheel_group.add_argument('--classifier', action='append',
+                             help="Classifiers to embed in package metadata. "
+                                  "Can be supplied multiple times")
+    wheel_group.add_argument('--description_file',
+                             help="Path to the file with package description")
+
+    contents_group = parser.add_argument_group("Wheel contents")
+    contents_group.add_argument(
+        '--input_file', action='append',
+        help="'package_path;real_path' pairs listing "
+             "files to be included in the wheel. "
+             "Can be supplied multiple times.")
+    contents_group.add_argument(
+        '--restrict_package', action='append',
+        help="Restrict files included in the wheel to only those belonging "
+             "to the listed packages. "
+             "Can be supplied multiple times.")
+    contents_group.add_argument(
+        '--console_script', action='append',
+        help="Defines a 'console_script' entry point. "
+             "Can be supplied multiple times.")
+
+    requirements_group = parser.add_argument_group("Package requirements")
+    requirements_group.add_argument(
+        '--requires', type=str, action='append',
+        help="List of package requirements. Can be supplied multiple times.")
+    requirements_group.add_argument(
+        '--extra_requires', type=str, action='append',
+        help="List of optional requirements in a 'requirement;option name'. "
+             "Can be supplied multiple times.")
+    arguments = parser.parse_args(sys.argv[1:])
+
+    # add_wheelfile and add_metadata currently assume pure-Python.
+    assert arguments.platform == 'any', "Only pure-Python wheels are supported"
+
+    input_files = [i.split(';') for i in arguments.input_file]
+    restrict_packages = [package.replace('.', os.path.sep) for package in
+                         arguments.restrict_package]
+    all_files = get_files_to_package(input_files, restrict_packages)
+    # Sort the files for reproducible order in the archive.
+    all_files = sorted(all_files.items())
+
+    with WheelMaker(name=arguments.name,
+                    version=arguments.version,
+                    build_tag=arguments.build_tag,
+                    python=arguments.python,
+                    abi=arguments.abi,
+                    platform=arguments.platform,
+                    outfile=arguments.out) as maker:
+        for package_filename, real_filename in all_files:
+            maker.add_file(package_filename, real_filename)
+        maker.add_wheelfile()
+
+        description = None
+        if arguments.description_file:
+            if sys.version_info[0] == 2:
+                with open(arguments.description_file,
+                          'rt') as description_file:
+                    description = description_file.read()
+            else:
+                with open(arguments.description_file, 'rt',
+                          encoding='utf-8') as description_file:
+                    description = description_file.read()
+
+        extra_requires = collections.defaultdict(list)
+        if arguments.extra_requires:
+            for extra in arguments.extra_requires:
+                req, option = extra.rsplit(';', 1)
+                extra_requires[option].append(req)
+        classifiers = arguments.classifier or []
+        requires = arguments.requires or []
+        extra_headers = arguments.header or []
+        console_scripts = arguments.console_script or []
+
+        maker.add_metadata(extra_headers=extra_headers,
+                           description=description,
+                           classifiers=classifiers,
+                           requires=requires,
+                           extra_requires=extra_requires)
+        maker.add_entry_points(console_scripts=console_scripts)
+        maker.add_recordfile()
+
+
+if __name__ == '__main__':
+    main()

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -34,12 +34,12 @@ def commonpath(path1, path2):
 
 
 class WheelMaker(object):
-    def __init__(self, name, version, build_tag, python, abi, platform,
+    def __init__(self, name, version, build_tag, python_tag, abi, platform,
                  outfile=None):
         self._name = name
         self._version = version
         self._build_tag = build_tag
-        self._python = python
+        self._python_tag = python_tag
         self._abi = abi
         self._platform = platform
         self._outfile = outfile
@@ -62,14 +62,14 @@ class WheelMaker(object):
         components = [self._name, self._version]
         if self._build_tag:
             components.append(self._build_tag)
-        components += [self._python, self._abi, self._platform]
+        components += [self._python_tag, self._abi, self._platform]
         return '-'.join(components) + '.whl'
 
     def distname(self):
         return self._name + '-' + self._version
 
     def disttags(self):
-        return ['-'.join([self._python, self._abi, self._platform])]
+        return ['-'.join([self._python_tag, self._abi, self._platform])]
 
     def distinfo_path(self, basename):
         return self.distname() + '.dist-info/' + basename
@@ -211,7 +211,7 @@ def main():
                                 help="Version of the distribution")
     metadata_group.add_argument('--build_tag', type=str, default='',
                                 help="Optional build tag for the distribution")
-    metadata_group.add_argument('--python', type=str, default='py3',
+    metadata_group.add_argument('--python_tag', type=str, default='py3',
                                 help="Python version, e.g. 'py2' or 'py3'")
     metadata_group.add_argument('--abi', type=str, default='none')
     metadata_group.add_argument('--platform', type=str, default='any',
@@ -271,7 +271,7 @@ def main():
     with WheelMaker(name=arguments.name,
                     version=arguments.version,
                     build_tag=arguments.build_tag,
-                    python=arguments.python,
+                    python_tag=arguments.python_tag,
                     abi=arguments.abi,
                     platform=arguments.platform,
                     outfile=arguments.out) as maker:

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -175,26 +175,13 @@ Root-Is-Purelib: true
         self._record.append((filename, hash, size))
 
 
-def file_matches_packages(filename, packages):
-    """Check if the file belongs to any of the listed packages."""
-    if not packages:
-        return True
-    for package in packages:
-        if commonpath(filename, package) == package:
-            return True
-    return False
-
-
-def get_files_to_package(input_files, restrict_packages):
+def get_files_to_package(input_files):
     """Find files to be added to the distribution.
 
     input_files: list of pairs (package_path, real_path)
-    restrict_packages: list of packages to be included in the distribution.
     """
     files = {}
     for package_path, real_path in input_files:
-        if not file_matches_packages(package_path, restrict_packages):
-            continue
         files[package_path] = real_path
     return files
 
@@ -239,11 +226,6 @@ def main():
              "files to be included in the wheel. "
              "Can be supplied multiple times.")
     contents_group.add_argument(
-        '--restrict_package', action='append',
-        help="Restrict files included in the wheel to only those belonging "
-             "to the listed packages. "
-             "Can be supplied multiple times.")
-    contents_group.add_argument(
         '--console_script', action='append',
         help="Defines a 'console_script' entry point. "
              "Can be supplied multiple times.")
@@ -262,9 +244,7 @@ def main():
     assert arguments.platform == 'any', "Only pure-Python wheels are supported"
 
     input_files = [i.split(';') for i in arguments.input_file]
-    restrict_packages = [package.replace('.', os.path.sep) for package in
-                         arguments.restrict_package]
-    all_files = get_files_to_package(input_files, restrict_packages)
+    all_files = get_files_to_package(input_files)
     # Sort the files for reproducible order in the archive.
     all_files = sorted(all_files.items())
 


### PR DESCRIPTION
Currently only pure python wheels are supported.

This extension builds wheels directly, invoking a simple python script
that creates the zip archive in the desired format instead of using
distutils/setuptools.

This will make building platform-dependent wheels easier in the future,
as bazel will have full control on how extension code is built.

This replaces previous pull request (#128) that had bad merge history.