### PR TITLE
pip_import: Let users override system Python via PYTHON env var

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -24,7 +24,7 @@ def _pip_import_impl(repository_ctx):
 
     # To see the output, pass: quiet=False
     result = repository_ctx.execute([
-        "python",
+        repository_ctx.os.environ.get("PYTHON", "python"),
         repository_ctx.path(repository_ctx.attr._script),
         "--name",
         repository_ctx.attr.name,
@@ -52,6 +52,7 @@ pip_import = repository_rule(
         ),
     },
     implementation = _pip_import_impl,
+    environ = ["PYTHON"],
 )
 
 """A rule for importing <code>requirements.txt</code> dependencies into Bazel.

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -17,7 +17,7 @@ def _whl_impl(repository_ctx):
     """Core implementation of whl_library."""
 
     args = [
-        "python",
+        repository_ctx.os.environ.get("PYTHON", "python"),
         repository_ctx.path(repository_ctx.attr._script),
         "--whl",
         repository_ctx.path(repository_ctx.attr.whl),
@@ -50,6 +50,7 @@ whl_library = repository_rule(
         ),
     },
     implementation = _whl_impl,
+    environ = ["PYTHON"],
 )
 
 """A rule for importing <code>.whl</code> dependencies into Bazel.


### PR DESCRIPTION
CentOS 6 provides Python 2.6.6, which is too old to satisfy `pip_import`'s
dict comprehension requirement.  I need some way to point `pip_import` to
an alternate Python distribution.

This change adds system Python override to `pip_import` and `whl_library`
via the `PYTHON` environment variable.

Resolves https://github.com/bazelbuild/rules_python/issues/178.