### PR TITLE
Update to work with --incompatible_use_python_toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,7 +81,7 @@ _piptool_install()
 git_repository(
     name = "subpar",
     remote = "https://github.com/google/subpar",
-    commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",  # 2019-03-07
+    tag = "2.0.0",
 )
 
 ###################################

--- a/examples/extras/BUILD
+++ b/examples/extras/BUILD
@@ -26,4 +26,5 @@ py_test(
         # Make sure that we can resolve the "extra" dependency
         requirement("googleapis-common-protos[grpc]"),
     ],
+    python_version = "PY2",
 )

--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -28,4 +28,5 @@ py_test(
     name = "helloworld_test",
     srcs = ["helloworld_test.py"],
     deps = [":helloworld"],
+    python_version = "PY2",
 )


### PR DESCRIPTION
Added `python_version = "PY2"` to some examples, and updated subpar dependency.