### PR TITLE
Example of trying to use pip rules with beam.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,6 +155,18 @@ load(
 _helloworld_install()
 
 pip_import(
+    name = "examples_dataflaw",
+    requirements = "//examples/dataflaw:requirements.txt",
+)
+
+load(
+    "@examples_dataflaw//:requirements.bzl",
+    _dataflaw_install = "pip_install",
+)
+
+_dataflaw_install()
+
+pip_import(
     name = "examples_version",
     requirements = "//examples/version:requirements.txt",
 )

--- a/examples/dataflaw/BUILD
+++ b/examples/dataflaw/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("@examples_dataflaw//:requirements.bzl", "requirement")
+load("//python:python.bzl", "py_library", "py_test")
+
+py_library(
+    name = "dataflow",
+    srcs = ["dataflow.py"],
+    deps = [requirement("apache-beam")],
+)
+
+py_test(
+    name = "dataflow_test",
+    srcs = ["dataflow_test.py"],
+    python_version = "PY2",
+    deps = [":dataflow"],
+)

--- a/examples/dataflaw/dataflow.py
+++ b/examples/dataflaw/dataflow.py
@@ -1,0 +1,23 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import apache_beam as beam
+
+
+class WordToOne(beam.DoFn):
+
+  def process(self, word):
+    yield (word, 1)

--- a/examples/dataflaw/dataflow_test.py
+++ b/examples/dataflaw/dataflow_test.py
@@ -1,0 +1,68 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note the following pacakages are installed by pip install apache-beam
+# apache-beam==2.13.0
+# avro==1.9.0
+# certifi==2019.3.9
+# chardet==3.0.4
+# crcmod==1.7
+# dill==0.2.9
+# docopt==0.6.2
+# enum34==1.1.6
+# fastavro==0.21.24
+# funcsigs==1.0.2
+# future==0.17.1
+# futures==3.2.0
+# grpcio==1.21.1
+# hdfs==2.5.3
+# httplib2==0.12.0
+# idna==2.8
+# mock==2.0.0
+# numpy==1.16.4
+# oauth2client==3.0.0
+# pbr==5.2.1
+# protobuf==3.8.0
+# pyarrow==0.13.0
+# pyasn1==0.4.5
+# pyasn1-modules==0.2.5
+# pydot==1.2.4
+# pyparsing==2.4.0
+# pytz==2019.1
+# PyVCF==0.6.8
+# PyYAML==3.13
+# requests==2.22.0
+# rsa==4.0
+# six==1.12.0
+# typing==3.6.6
+# urllib3==1.25.3
+
+import unittest
+import apache_beam as beam
+from apache_beam.testing import test_pipeline
+from apache_beam.testing import util
+from examples.dataflaw import dataflow
+
+
+class HelloWorldTest(unittest.TestCase):
+
+  def test_helloworld(self):
+    p = test_pipeline.TestPipeline()
+    output = p | beam.Create(["wow", "wow", "whatever"]) | beam.ParDo(
+        dataflow.WordToOne()) | beam.GroupByKey() | beam.CombinePerKey(sum)
+    util.assert_that(output, util.equal_to([("wow", 2), ("whatever", 1)]))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/examples/dataflaw/requirements.txt
+++ b/examples/dataflaw/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam>=2.13.0


### PR DESCRIPTION
Fails like this as beam transitive dependencies are not in scope.

  File "/usr/local/google/home/sorenj/.cache/bazel/_bazel_sorenj/4ac712636e67a1f87a02bdf9338c2f63/sandbox/linux-sandbox/7/execroot/io_bazel_rules_python/bazel-out/k8-py2-fastbuild/bin/examples/dataflaw/dataflow_test.runfiles/io_bazel_rules_python/examples/dataflaw/dataflow_test.py", line 52, in <module>
    import apache_beam as beam
  File "/usr/local/google/home/sorenj/.cache/bazel/_bazel_sorenj/4ac712636e67a1f87a02bdf9338c2f63/sandbox/linux-sandbox/7/execroot/io_bazel_rules_python/bazel-out/k8-py2-fastbuild/bin/examples/dataflaw/dataflow_test.runfiles/pypi__apache_beam_2_13_0/apache_beam/__init__.py", line 95, in <module>
    import apache_beam.internal.pickler
  File "/usr/local/google/home/sorenj/.cache/bazel/_bazel_sorenj/4ac712636e67a1f87a02bdf9338c2f63/sandbox/linux-sandbox/7/execroot/io_bazel_rules_python/bazel-out/k8-py2-fastbuild/bin/examples/dataflaw/dataflow_test.runfiles/pypi__apache_beam_2_13_0/apache_beam/internal/pickler.py", line 40, in <module>
    import dill
ImportError: No module named dill