### PR TITLE
added the ability to specify a custom wheel package root

### DIFF
--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -85,7 +85,7 @@ py_wheel(
     deps = [":example_pkg"],
 )
 
-# An example of how to change the wheel package root directory.
+# An example of how to change the wheel package root directory using 'strip_path_prefix'.
 py_wheel(
     name = "custom_package_root",
     # Package data. We're building "custom_package_root-0.0.1-py3-none-any.whl"
@@ -95,7 +95,7 @@ py_wheel(
     deps = [
         ":example_pkg"
     ],
-    package_root_path = "experimental"
+    strip_path_prefix = "experimental"
 )
 
 py_test(

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -85,7 +85,7 @@ py_wheel(
     deps = [":example_pkg"],
 )
 
-# An example of how to change the wheel package root directory using 'strip_path_prefix'.
+# An example of how to change the wheel package root directory using 'strip_path_prefixes'.
 py_wheel(
     name = "custom_package_root",
     # Package data. We're building "custom_package_root-0.0.1-py3-none-any.whl"
@@ -95,7 +95,39 @@ py_wheel(
     deps = [
         ":example_pkg"
     ],
-    strip_path_prefix = "experimental"
+    strip_path_prefixes = [
+        "experimental"
+    ]
+)
+
+py_wheel(
+    name = "custom_package_root_multi_prefix",
+    # Package data. We're building "custom_custom_package_root_multi_prefix-0.0.1-py3-none-any.whl"
+    distribution = "example_custom_package_root_multi_prefix",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        ":example_pkg"
+    ],
+    strip_path_prefixes = [
+        "experimental/examples/wheel/lib",
+        "experimental/examples/wheel" ,
+    ]
+)
+
+py_wheel(
+    name = "custom_package_root_multi_prefix_reverse_order",
+    # Package data. We're building "custom_custom_package_root_multi_prefix_reverse_order-0.0.1-py3-none-any.whl"
+    distribution = "example_custom_package_root_multi_prefix_reverse_order",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        ":example_pkg"
+    ],
+    strip_path_prefixes = [
+        "experimental/examples/wheel" ,
+        "experimental/examples/wheel/lib", # this is not effective, because the first prefix takes priority
+    ]
 )
 
 py_test(
@@ -106,5 +138,7 @@ py_test(
         ":minimal_with_py_library",
         ":minimal_with_py_package",
         ":custom_package_root",
+        ":custom_package_root_multi_prefix",
+        ":custom_package_root_multi_prefix_reverse_order",
     ],
 )

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -85,6 +85,19 @@ py_wheel(
     deps = [":example_pkg"],
 )
 
+# An example of how to change the wheel package root directory.
+py_wheel(
+    name = "custom_package_root",
+    # Package data. We're building "custom_package_root-0.0.1-py3-none-any.whl"
+    distribution = "example_custom_package_root",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        ":example_pkg"
+    ],
+    package_root_path = "experimental"
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],
@@ -92,5 +105,6 @@ py_test(
         ":customized",
         ":minimal_with_py_library",
         ":minimal_with_py_package",
+        ":custom_package_root",
     ],
 )

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -111,7 +111,7 @@ py_wheel(
     ],
     strip_path_prefixes = [
         "experimental/examples/wheel/lib",
-        "experimental/examples/wheel" ,
+        "experimental/examples/wheel"
     ]
 )
 
@@ -126,7 +126,7 @@ py_wheel(
     ],
     strip_path_prefixes = [
         "experimental/examples/wheel" ,
-        "experimental/examples/wheel/lib", # this is not effective, because the first prefix takes priority
+        "experimental/examples/wheel/lib" # this is not effective, because the first prefix takes priority
     ]
 )
 
@@ -139,6 +139,6 @@ py_test(
         ":minimal_with_py_package",
         ":custom_package_root",
         ":custom_package_root_multi_prefix",
-        ":custom_package_root_multi_prefix_reverse_order",
-    ],
+        ":custom_package_root_multi_prefix_reverse_order"
+    ]
 )

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -102,6 +102,23 @@ Requires-Dist: pytest
 This is a sample description of a wheel.
 """)
 
+    def test_custom_package_root_path_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_custom_package_root-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['examples/wheel/lib/data.txt',
+                 'examples/wheel/lib/module_with_data.py',
+                 'examples/wheel/lib/simple_module.py',
+                 'examples/wheel/main.py',
+                 'example_custom_package_root-0.0.1.dist-info/WHEEL',
+                 'example_custom_package_root-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root-0.0.1.dist-info/RECORD'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -102,7 +102,7 @@ Requires-Dist: pytest
 This is a sample description of a wheel.
 """)
 
-    def test_custom_package_root_path_wheel(self):
+    def test_custom_package_root_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
                                 'io_bazel_rules_python', 'experimental',
                                 'examples', 'wheel',

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -119,6 +119,40 @@ This is a sample description of a wheel.
                  'example_custom_package_root-0.0.1.dist-info/METADATA',
                  'example_custom_package_root-0.0.1.dist-info/RECORD'])
 
+    def test_custom_package_root_multi_prefix_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_custom_package_root_multi_prefix-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['data.txt',
+                 'module_with_data.py',
+                 'simple_module.py',
+                 'main.py',
+                 'example_custom_package_root_multi_prefix-0.0.1.dist-info/WHEEL',
+                 'example_custom_package_root_multi_prefix-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root_multi_prefix-0.0.1.dist-info/RECORD'])
+
+    def test_custom_package_root_multi_prefix_reverse_order_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'io_bazel_rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_custom_package_root_multi_prefix_reverse_order-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['lib/data.txt',
+                 'lib/module_with_data.py',
+                 'lib/simple_module.py',
+                 'main.py',
+                 'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/WHEEL',
+                 'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/RECORD'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -102,7 +102,7 @@ def _py_wheel_impl(ctx):
     args.add("--abi", ctx.attr.abi)
     args.add("--platform", ctx.attr.platform)
     args.add("--out", outfile.path)
-    args.add("--strip_path_prefix", ctx.attr.strip_path_prefix)
+    args.add_all(ctx.attr.strip_path_prefixes, format_each = "--strip_path_prefix=%s")
 
     args.add_all(inputs_to_package, format_each = "--input_file=%s", map_each = _input_file_to_arg)
 
@@ -243,9 +243,9 @@ to refer to the package in other packages' dependencies.
         "license": attr.string(default = ""),
         "classifiers": attr.string_list(),
         "description_file": attr.label(allow_single_file = True),
-        "strip_path_prefix": attr.string(
-            default = "none",
-            doc = "path to the root of the generated package (default is workspace path)",
+        "strip_path_prefixes": attr.string_list(
+            default = [],
+            doc = "path prefixes to strip from files added to the generated package",
         ),
         # Requirements
         "requires": attr.string_list(

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -102,7 +102,7 @@ def _py_wheel_impl(ctx):
     args.add("--abi", ctx.attr.abi)
     args.add("--platform", ctx.attr.platform)
     args.add("--out", outfile.path)
-    args.add("--package_root_path", ctx.attr.package_root_path)
+    args.add("--strip_path_prefix", ctx.attr.strip_path_prefix)
 
     args.add_all(inputs_to_package, format_each = "--input_file=%s", map_each = _input_file_to_arg)
 
@@ -243,7 +243,7 @@ to refer to the package in other packages' dependencies.
         "license": attr.string(default = ""),
         "classifiers": attr.string_list(),
         "description_file": attr.label(allow_single_file = True),
-        "package_root_path": attr.string(
+        "strip_path_prefix": attr.string(
             default = "none",
             doc = "path to the root of the generated package (default is workspace path)",
         ),

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -102,6 +102,7 @@ def _py_wheel_impl(ctx):
     args.add("--abi", ctx.attr.abi)
     args.add("--platform", ctx.attr.platform)
     args.add("--out", outfile.path)
+    args.add("--package_root_path", ctx.attr.package_root_path)
 
     args.add_all(inputs_to_package, format_each = "--input_file=%s", map_each = _input_file_to_arg)
 
@@ -242,6 +243,10 @@ to refer to the package in other packages' dependencies.
         "license": attr.string(default = ""),
         "classifiers": attr.string_list(),
         "description_file": attr.label(allow_single_file = True),
+        "package_root_path": attr.string(
+            default = "none",
+            doc = "path to the root of the generated package (default is workspace path)",
+        ),
         # Requirements
         "requires": attr.string_list(
             doc = "List of requirements for this package",

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -92,17 +92,17 @@ class WheelMaker(object):
 
     def add_file(self, package_filename, real_filename):
         """Add given file to the distribution."""
-        def strip_prefix(path, prefixes):
-            for prefix in prefixes:
-                if path.startswith(prefix):
-                    return path[len(prefix):]
+        def arcname_from(name):
+            # Always use unix path separators.
+            normalized_arcname = name.replace(os.path.sep, '/')
+            for prefix in self._strip_path_prefixes:
+                if normalized_arcname.startswith(prefix):
+                    return normalized_arcname[len(prefix):]
 
-            return path
+            return normalized_arcname
 
-        resolved_package_filename = strip_prefix(package_filename, self._strip_path_prefixes)
+        arcname = arcname_from(package_filename)
 
-        # Always use unix path separators.
-        arcname = resolved_package_filename.replace(os.path.sep, '/')
         self._zipfile.write(real_filename, arcname=arcname)
         # Find the hash and length
         hash = hashlib.sha256()

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -15,9 +15,7 @@
 import argparse
 import base64
 import collections
-import csv
 import hashlib
-import io
 import os
 import os.path
 import sys
@@ -276,7 +274,7 @@ def main():
                     abi=arguments.abi,
                     platform=arguments.platform,
                     outfile=arguments.out,
-                    strip_path_prefixes=strip_prefixes,
+                    strip_path_prefixes=strip_prefixes
                     ) as maker:
         for package_filename, real_filename in all_files:
             maker.add_file(package_filename, real_filename)


### PR DESCRIPTION
This PR suggests a possible way to address the issues described in https://github.com/bazelbuild/rules_python/issues/199. I added an optional attribute `package_root_path` to the `py_wheel` rule, that specifies the root of the package, relative to the workspace path. 

This patch only fixes the problem for cases in which the entire package is under the same path. If the package bundles dependencies from other paths, those will not be fixed. It would be nice if we could define the prefix on the sources and strip the prefix when we create the final package. Not sure how to do that and will be very happy to hear suggestions, or alternative approaches.

Thanks.

```
py_wheel(
    package_root_path = "experimental"
    name = ...
    distribution = ...
    python_tag = ...
    version = ...
    deps = ...
)
```