### PR TITLE
Work around breakage in a dep of the examples

### DIFF
--- a/examples/boto/requirements.txt
+++ b/examples/boto/requirements.txt
@@ -1,1 +1,4 @@
 boto3==1.4.7
+# Release 0.15 appears to have a broken wheel.
+# See https://github.com/bazelbuild/rules_python/issues/205.
+docutils<0.15


### PR DESCRIPTION
The boto example indirectly requires docutils, but the docutils-0.15.post1
release appears to have a broken wheel: its dist-info directory omits the
`post1` suffix which is part of the version identifier.

We simply prohibit this particular release in requirements.txt.

Fixes #205.