### PR TITLE
pin upstream bazel to 0.24

### DIFF
--- a/tools/update_tools/Dockerfile
+++ b/tools/update_tools/Dockerfile
@@ -1,10 +1,9 @@
 FROM gcr.io/gcp-runtimes/ubuntu_16_0_4:latest
 
 # Install Bazel (https://docs.bazel.build/versions/master/install-ubuntu.html)
-RUN apt-get update -y && apt-get install openjdk-8-jdk -y
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update -y && apt-get install bazel -y
+RUN apt-get update -y && apt-get install openjdk-8-jdk wget git unzip build-essential -y
+RUN wget https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-installer-linux-x86_64.sh -O /tmp/bazel-installer.sh
+RUN chmod +x /tmp/bazel-installer.sh && /tmp/bazel-installer.sh
 RUN bazel help info >/dev/null 2>&1
 
 # Install Python 2.7.12
@@ -18,4 +17,3 @@ CMD cp -r /opt/rules_python_source /opt/rules_python && \
     bazel build //rules_python:piptool.par //rules_python:whltool.par && \
     cp bazel-bin/rules_python/piptool.par bazel-bin/rules_python/whltool.par /opt/rules_python_source/tools/ && \
     chown --reference=/opt/rules_python_source/update_tools.sh /opt/rules_python_source/tools/piptool.par /opt/rules_python_source/tools/whltool.par
-


### PR DESCRIPTION
Fixes: #208
It looks like you just reference the latest bazel, which means your builds will just break on bazel releases. Instead I suggest pinning to a certain version and then you can walk the version up at your leisure without master sitting there broken.