### PR TITLE
Make whltool python version configurable

### DIFF
--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -17,7 +17,7 @@ def _whl_impl(repository_ctx):
     """Core implementation of whl_library."""
 
     args = [
-        "python",
+        repository_ctx.attr.python_target,
         repository_ctx.path(repository_ctx.attr._script),
         "--whl",
         repository_ctx.path(repository_ctx.attr.whl),
@@ -48,6 +48,9 @@ whl_library = repository_rule(
             default = Label("//tools:whltool.par"),
             cfg = "host",
         ),
+        "python_target": attr.string(
+            default = "python"
+        )
     },
     implementation = _whl_impl,
 )
@@ -77,4 +80,7 @@ Args:
 
   extras: A subset of the "extras" available from this <code>.whl</code> for which
     <code>requirements</code> has the dependencies.
+
+  python_target: The python interpreter that will be used to run this library
+    (may affect how dependencies are calculated)
 """


### PR DESCRIPTION
As part of the `whl_library` rule, we run a python script (packaged here as `whltool.par`) to generate `py_library` instances for each wheel. One of the functions of running that script is to parse the wheels' declared dependencies. In some cases, the sets of dependencies may vary depending on what python version is being used, even for a wheel file that is compatible with both python 2 and 3. This pull request adds an argument to the `whl_library` rule allowing the user to specify the desired version of python to run the `whltool` script - in my case, I pass the value `python3`. It defaults to the original behavior of just running `python` by itself.

To give a concrete example of where this can come up, the `cryptography` package relies on a backported package when used under python<3.4, but does not require that backport for newer python versions: https://github.com/pyca/cryptography/blob/master/setup.py#L239-L240 . When attempting to install this library with python 3.7, it's not possible to find that backported library, and so we can't resolve the dependencies.

I'm very open to renaming things here if desired, or to (say) attempt to resolve the path to the python interpreter using something like https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#which. I elected to use `python_target` so that the user would understand that this should correspond to the target python version that will eventually run whatever code relies on the `whl_library`.