### PR TITLE
Add a timeout attribute to pip_import rules.

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -5,7 +5,7 @@
 ## pip_import
 
 <pre>
-pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-extra_pip_args">extra_pip_args</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-requirements">requirements</a>)
+pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-extra_pip_args">extra_pip_args</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-requirements">requirements</a>, <a href="#pip_import-timeout">timeout</a>)
 </pre>
 
 A rule for importing `requirements.txt` dependencies into Bazel.
@@ -92,6 +92,15 @@ wheels.
         <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
         <p>
           The label of the requirements.txt file.
+        </p>
+      </td>
+    </tr>
+    <tr id="pip_import-timeout">
+      <td><code>timeout</code></td>
+      <td>
+        Integer; optional
+        <p>
+          Timeout (in seconds) for repository fetch.
         </p>
       </td>
     </tr>

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -43,7 +43,7 @@ def _pip_import_impl(repository_ctx):
         ]
 
     # To see the output, pass: quiet=False
-    result = repository_ctx.execute(args)
+    result = repository_ctx.execute(args, timeout=repository_ctx.attr.timeout)
 
     if result.return_code:
         fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
@@ -61,6 +61,10 @@ wheels.
             mandatory = True,
             allow_single_file = True,
             doc = "The label of the requirements.txt file.",
+        ),
+        "timeout": attr.int(
+            default = 600,
+            doc = "Timeout (in seconds) for repository fetch."
         ),
         "_script": attr.label(
             executable = True,


### PR DESCRIPTION
The combination of a large `requirements.txt` file and a slow network can
cause the default timeout for `repository_ctx.execute()` to be reached.
This patch exposes that timeout to the `pip_import()` caller so they can
manually specify a longer timeout. E.g.

    pip_import(
        name = "requirements",
        requirements = "//long_list_of_requirements.txt",
        timeout = 3600,
    )