### PR TITLE
Comply with the standards of the Bazel federation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@bazel_federation//:repositories.bzl", "rules_python_deps")
 rules_python_deps()
 
 load("@bazel_federation//setup:rules_python.bzl",  "rules_python_setup")
-rules_python_setup()
+rules_python_setup(use_pip=True)
 
 load("//:internal_deps.bzl", "rules_python_internal_deps")
 rules_python_internal_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,160 +14,23 @@
 
 workspace(name = "rules_python")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-
-#################################
-# Stardoc and its dependencies. #
-#################################
-
-# Initialization taken from:
-# https://skydoc.bazel.build/docs/getting_started_stardoc.html
-
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/bazelbuild/skydoc.git",
-    tag = "0.3.0",
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_federation",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/4da9b5f83ffae17613fa025a0701fa9db9350d41.zip",
+    sha256 = "5b1cf980e327a8f30fc81c00c04007c543e17c09ed612fb645753936de790ed7",
+    strip_prefix = "bazel-federation-4da9b5f83ffae17613fa025a0701fa9db9350d41",
+    type = "zip",
 )
 
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
+load("@bazel_federation//:repositories.bzl", "rules_python_deps")
+rules_python_deps()
 
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
+load("@bazel_federation//setup:rules_python.bzl",  "rules_python_setup")
+rules_python_setup()
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
+load("//:internal_deps.bzl", "rules_python_internal_deps")
+rules_python_internal_deps()
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
-
-##########################################
-# Requirements for building our piptool. #
-##########################################
-
-load("//python:pip.bzl", "pip_import")
-
-pip_import(
-    name = "piptool_deps",
-    requirements = "//python:requirements.txt",
-)
-
-load(
-    "@piptool_deps//:requirements.bzl",
-    _piptool_install = "pip_install",
-)
-
-_piptool_install()
-
-git_repository(
-    name = "subpar",
-    remote = "https://github.com/google/subpar",
-    commit = "2917d275ee27d7935f7809413c74eddf71a46e5c",  # 2019-08-02
-)
-
-###################################
-# Test data for WHL tool testing. #
-###################################
-
-http_file(
-    name = "grpc_whl",
-    downloaded_file_path = "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
-    sha256 = "c232d6d168cb582e5eba8e1c0da8d64b54b041dd5ea194895a2fe76050916561",
-    # From https://pypi.python.org/pypi/grpcio/1.6.0
-    urls = [("https://pypi.python.org/packages/c6/28/" +
-             "67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/" +
-             "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl")],
-)
-
-http_file(
-    name = "futures_3_1_1_whl",
-    downloaded_file_path = "futures-3.1.1-py2-none-any.whl",
-    sha256 = "c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
-    # From https://pypi.python.org/pypi/futures
-    urls = [("https://pypi.python.org/packages/a6/1c/" +
-             "72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/" +
-             "futures-3.1.1-py2-none-any.whl")],
-)
-
-http_file(
-    name = "futures_2_2_0_whl",
-    downloaded_file_path = "futures-2.2.0-py2.py3-none-any.whl",
-    sha256 = "9fd22b354a4c4755ad8c7d161d93f5026aca4cfe999bd2e53168f14765c02cd6",
-    # From https://pypi.python.org/pypi/futures/2.2.0
-    urls = [("https://pypi.python.org/packages/d7/1d/" +
-             "68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/" +
-             "futures-2.2.0-py2.py3-none-any.whl")],
-)
-
-http_file(
-    name = "mock_whl",
-    downloaded_file_path = "mock-2.0.0-py2.py3-none-any.whl",
-    sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
-    # From https://pypi.python.org/pypi/mock
-    urls = [("https://pypi.python.org/packages/e6/35/" +
-             "f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/" +
-             "mock-2.0.0-py2.py3-none-any.whl")],
-)
-
-http_file(
-    name = "google_cloud_language_whl",
-    downloaded_file_path = "google_cloud_language-0.29.0-py2.py3-none-any.whl",
-    sha256 = "a2dd34f0a0ebf5705dcbe34bd41199b1d0a55c4597d38ed045bd183361a561e9",
-    # From https://pypi.python.org/pypi/google-cloud-language
-    urls = [("https://pypi.python.org/packages/6e/86/" +
-             "cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/" +
-             "google_cloud_language-0.29.0-py2.py3-none-any.whl")],
-)
-
-#########################
-# Imports for examples. #
-#########################
-
-pip_import(
-    name = "examples_helloworld",
-    requirements = "//examples/helloworld:requirements.txt",
-)
-
-load(
-    "@examples_helloworld//:requirements.bzl",
-    _helloworld_install = "pip_install",
-)
-
-_helloworld_install()
-
-pip_import(
-    name = "examples_version",
-    requirements = "//examples/version:requirements.txt",
-)
-
-load(
-    "@examples_version//:requirements.bzl",
-    _version_install = "pip_install",
-)
-
-_version_install()
-
-pip_import(
-    name = "examples_boto",
-    requirements = "//examples/boto:requirements.txt",
-)
-
-load(
-    "@examples_boto//:requirements.bzl",
-    _boto_install = "pip_install",
-)
-
-_boto_install()
-
-pip_import(
-    name = "examples_extras",
-    requirements = "//examples/extras:requirements.txt",
-)
-
-load(
-    "@examples_extras//:requirements.bzl",
-    _extras_install = "pip_install",
-)
-
-_extras_install()
+load("//:internal_setup.bzl", "rules_python_internal_setup")
+rules_python_internal_setup()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -20,7 +20,7 @@ def rules_python_internal_deps():
     examples()
 
 
-def  piptool():
+def piptool():
     pip_import(
         name = "piptool_deps",
         requirements = "@rules_python//python:requirements.txt",

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,0 +1,46 @@
+load("@bazel_federation//:repositories.bzl", "bazel_stardoc", "rules_sass")
+load("@bazel_federation//:third_party_repositories.bzl", "futures_2_whl", "futures_3_whl", "google_cloud_language_whl", "grpc_whl", "mock_whl", "subpar")
+load("@rules_python//python:pip.bzl", "pip_import")
+
+
+def rules_python_internal_deps():
+    bazel_stardoc()
+    rules_sass()
+
+    subpar()
+
+    # Test data for WHL tool testing.
+    futures_2_whl()
+    futures_3_whl()
+    google_cloud_language_whl()
+    grpc_whl()
+    mock_whl()
+
+    piptool()
+    examples()
+
+
+def  piptool():
+    pip_import(
+        name = "piptool_deps",
+        requirements = "@rules_python//python:requirements.txt",
+    )
+
+
+def examples():
+    pip_import(
+        name = "examples_helloworld",
+        requirements = "@rules_python//examples/helloworld:requirements.txt",
+    )
+    pip_import(
+        name = "examples_version",
+        requirements = "@rules_python//examples/version:requirements.txt",
+    )
+    pip_import(
+        name = "examples_boto",
+        requirements = "@rules_python//examples/boto:requirements.txt",
+    )
+    pip_import(
+        name = "examples_extras",
+        requirements = "@rules_python//examples/extras:requirements.txt",
+    )

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,0 +1,47 @@
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
+
+# Requirements for building our piptool.
+load(
+    "@piptool_deps//:requirements.bzl",
+    _piptool_install = "pip_install",
+)
+
+# Imports for examples.
+load(
+    "@examples_helloworld//:requirements.bzl",
+    _helloworld_install = "pip_install",
+)
+load(
+    "@examples_version//:requirements.bzl",
+    _version_install = "pip_install",
+)
+load(
+    "@examples_boto//:requirements.bzl",
+    _boto_install = "pip_install",
+)
+load(
+    "@examples_extras//:requirements.bzl",
+    _extras_install = "pip_install",
+)
+
+
+def rules_python_internal_setup():
+    # TODO(fweikert): The following four function calls should be replaced with
+    # bazel_stardoc_setup(), rules_sass_setup() and rules_nodejs_setup().
+    # However, those setup functions don't exist yet.
+    skydoc_repositories()
+    rules_sass_dependencies()
+    node_repositories()
+    sass_repositories()
+
+    # Requirements for building our piptool.
+    _piptool_install()
+
+    # Imports for examples.
+    _helloworld_install()
+    _version_install()
+    _boto_install()
+    _extras_install()


### PR DESCRIPTION
This commit allows rules_python to be a member of the Bazel federation, since it adds the required bzl files related to setup and dependencies.
Moreover, it also changes the WORKSPACE to fetch all non-pip_import dependencies through the federation.

rules_python_internal_setup() in internal_setup.bzl still needs some work since some of the dependencies don't export their proper setup functions yet, which means that the present commit has to work around that particular problem.