### PR TITLE
Pass --isolated to pip

### DIFF
--- a/packaging/piptool.py
+++ b/packaging/piptool.py
@@ -78,7 +78,7 @@ def pip_main(argv):
     atexit.register(lambda: shutil.rmtree(cert_tmpdir, ignore_errors=True))
     with open(cert_path, "wb") as cert:
       cert.write(pkgutil.get_data("pip._vendor.requests", "cacert.pem"))
-    argv = ["--disable-pip-version-check", "--cert", cert_path] + argv
+    argv = ["--isolated", "--disable-pip-version-check", "--cert", cert_path] + argv
     return pip.main(argv)
 
 from packaging.whl import Wheel


### PR DESCRIPTION
This fixes an issue where if you have bad URLs in your ~/.pip/pip.conf,
pip would pick them up and end up failing bazel. This way we make
pip_import more hermetic and ignore user config.

You can reproduce this issue by adding:

```
[global]
extra-index-url =
    https://foo.com/bar
```

To your local `~/.pip/pip.conf`, and executing a `pip_import` rule (it fails faster if your URL returns 500s rather than is just unaccessible)