### PR TITLE
Fix WORKSPACE/distro boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/<RELEASE>/rules_python-<RELEASE>.tar.gz",
     sha256 = "<SHA>",
 )
-load("@rules_python//python:repositories.bzl", "py_repositories", "rules_python_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
-rules_python_toolchains()
+# Only needed if using the packaging rules.
+load("@rules_python//python:pip.bzl", "pip_repositories")
+pip_repositories()
 ```
 
 Otherwise, you may import rules_python in a standalone way by copying the
@@ -63,10 +65,9 @@ git_repository(
     # NOT VALID: Replace with actual Git commit SHA.
     commit = "{HEAD}",
 )
-# This call should always be present.
 load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
-# This one is only needed if you're using the packaging rules.
+# Only needed if using the packaging rules.
 load("@rules_python//python:pip.bzl", "pip_repositories")
 pip_repositories()
 ```

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -21,12 +21,14 @@ pkg_tar(
     strip_prefix = ".",
 )
 
+# TODO(brandjon): print_rel_notes doesn't appear to handle our use case of
+# emitting an optional additional deps method from a different file. For now we
+# manually adjust our release notes.
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
     deps_method = "py_repositories",
     repo = "rules_python",
     setup_file = "python:repositories.bzl",
-    toolchains_method = "rules_python_toolchains",
     version = version,
 )


### PR DESCRIPTION
We don't have a toolchain method, so don't try to call one in WORKSPACE. Add
optional pip_repositories() call to README and add note that relnotes need
manual editing for this.

+aiuto FYI but force-submitting.