### PR TITLE
Add python_interpreter attr to pip rules

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -5,7 +5,7 @@
 ## pip_import
 
 <pre>
-pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-requirements">requirements</a>)
+pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-requirements">requirements</a>)
 </pre>
 
 A rule for importing `requirements.txt` dependencies into Bazel.
@@ -64,6 +64,16 @@ py_binary(
         <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
         <p>
           A unique name for this repository.
+        </p>
+      </td>
+    </tr>
+    <tr id="pip_import-python_interpreter">
+      <td><code>python_interpreter</code></td>
+      <td>
+        String; optional
+        <p>
+          The command to run the Python interpreter used to invoke pip and unpack the
+wheels.
         </p>
       </td>
     </tr>

--- a/docs/whl.md
+++ b/docs/whl.md
@@ -5,7 +5,7 @@
 ## whl_library
 
 <pre>
-whl_library(<a href="#whl_library-name">name</a>, <a href="#whl_library-extras">extras</a>, <a href="#whl_library-requirements">requirements</a>, <a href="#whl_library-whl">whl</a>)
+whl_library(<a href="#whl_library-name">name</a>, <a href="#whl_library-extras">extras</a>, <a href="#whl_library-python_interpreter">python_interpreter</a>, <a href="#whl_library-requirements">requirements</a>, <a href="#whl_library-whl">whl</a>)
 </pre>
 
 A rule for importing `.whl` dependencies into Bazel.
@@ -50,6 +50,15 @@ This rule defines `@foo//:pkg` as a `py_library` target.
         <p>
           A subset of the "extras" available from this <code>.whl</code> for which
 <code>requirements</code> has the dependencies.
+        </p>
+      </td>
+    </tr>
+    <tr id="whl_library-python_interpreter">
+      <td><code>python_interpreter</code></td>
+      <td>
+        String; optional
+        <p>
+          The command to run the Python interpreter used when unpacking the wheel.
         </p>
       </td>
     </tr>

--- a/packaging/piptool.py
+++ b/packaging/piptool.py
@@ -86,6 +86,9 @@ from packaging.whl import Wheel
 parser = argparse.ArgumentParser(
     description='Import Python dependencies into Bazel.')
 
+parser.add_argument('--python_interpreter', action='store',
+                    help=('The python python interpreter to use '))
+
 parser.add_argument('--name', action='store',
                     help=('The namespace of the import.'))
 
@@ -177,10 +180,12 @@ def main():
   if "{repo_name}" not in native.existing_rules():
     whl_library(
         name = "{repo_name}",
+        python_interpreter = "{python_interpreter}",
         whl = "@{name}//:{path}",
         requirements = "@{name}//:requirements.bzl",
         extras = [{extras}]
     )""".format(name=args.name, repo_name=wheel.repository_name(),
+                python_interpreter=args.python_interpreter,
                 path=wheel.basename(),
                 extras=','.join([
                   '"%s"' % extra

--- a/packaging/piptool.py
+++ b/packaging/piptool.py
@@ -87,7 +87,8 @@ parser = argparse.ArgumentParser(
     description='Import Python dependencies into Bazel.')
 
 parser.add_argument('--python_interpreter', action='store',
-                    help=('The python python interpreter to use '))
+                    help=('The Python interpreter to use when extracting '
+                          'wheels.'))
 
 parser.add_argument('--name', action='store',
                     help=('The namespace of the import.'))

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -24,8 +24,10 @@ def _pip_import_impl(repository_ctx):
 
     # To see the output, pass: quiet=False
     result = repository_ctx.execute([
-        "python",
+        repository_ctx.attr.python_interpreter,
         repository_ctx.path(repository_ctx.attr._script),
+        "--python_interpreter",
+        repository_ctx.attr.python_interpreter,
         "--name",
         repository_ctx.attr.name,
         "--input",
@@ -41,6 +43,10 @@ def _pip_import_impl(repository_ctx):
 
 pip_import = repository_rule(
     attrs = {
+        "python_interpreter": attr.string(default="python", doc="""
+The command to run the Python interpreter used to invoke pip and unpack the
+wheels.
+"""),
         "requirements": attr.label(
             mandatory = True,
             allow_single_file = True,

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -43,15 +43,15 @@ def _pip_import_impl(repository_ctx):
 
 pip_import = repository_rule(
     attrs = {
+        "python_interpreter": attr.string(default = "python", doc = """
+The command to run the Python interpreter used to invoke pip and unpack the
+wheels.
+"""),
         "requirements": attr.label(
             mandatory = True,
             allow_single_file = True,
             doc = "The label of the requirements.txt file.",
         ),
-        "python_interpreter": attr.string(default = "python", doc = """
-The command to run the Python interpreter used to invoke pip and unpack the
-wheels.
-"""),
         "_script": attr.label(
             executable = True,
             default = Label("//tools:piptool.par"),

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -43,15 +43,15 @@ def _pip_import_impl(repository_ctx):
 
 pip_import = repository_rule(
     attrs = {
-        "python_interpreter": attr.string(default="python", doc="""
-The command to run the Python interpreter used to invoke pip and unpack the
-wheels.
-"""),
         "requirements": attr.label(
             mandatory = True,
             allow_single_file = True,
             doc = "The label of the requirements.txt file.",
         ),
+        "python_interpreter": attr.string(default = "python", doc = """
+The command to run the Python interpreter used to invoke pip and unpack the
+wheels.
+"""),
         "_script": attr.label(
             executable = True,
             default = Label("//tools:piptool.par"),

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -41,6 +41,9 @@ whl_library = repository_rule(
 A subset of the "extras" available from this <code>.whl</code> for which
 <code>requirements</code> has the dependencies.
 """),
+        "python_interpreter": attr.string(default = "python", doc = """
+The command to run the Python interpreter used when unpacking the wheel.
+"""),
         "requirements": attr.string(doc = """
 The name of the <code>pip_import</code> repository rule from which to load this
 <code>.whl</code>'s dependencies.
@@ -53,9 +56,6 @@ The path to the <code>.whl</code> file. The name is expected to follow [this
 convention](https://www.python.org/dev/peps/pep-0427/#file-name-convention)).
 """,
         ),
-        "python_interpreter": attr.string(default = "python", doc = """
-The command to run the Python interpreter used when unpacking the wheel.
-"""),
         "_script": attr.label(
             executable = True,
             default = Label("//tools:whltool.par"),

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -17,7 +17,7 @@ def _whl_impl(repository_ctx):
     """Core implementation of whl_library."""
 
     args = [
-        "python",
+        repository_ctx.attr.python_interpreter,
         repository_ctx.path(repository_ctx.attr._script),
         "--whl",
         repository_ctx.path(repository_ctx.attr.whl),
@@ -44,6 +44,9 @@ A subset of the "extras" available from this <code>.whl</code> for which
         "requirements": attr.string(doc = """
 The name of the <code>pip_import</code> repository rule from which to load this
 <code>.whl</code>'s dependencies.
+"""),
+        "python_interpreter": attr.string(default="python", doc="""
+The command to run the Python interpreter used when unpacking the wheel.
 """),
         "whl": attr.label(
             mandatory = True,

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -45,9 +45,6 @@ A subset of the "extras" available from this <code>.whl</code> for which
 The name of the <code>pip_import</code> repository rule from which to load this
 <code>.whl</code>'s dependencies.
 """),
-        "python_interpreter": attr.string(default="python", doc="""
-The command to run the Python interpreter used when unpacking the wheel.
-"""),
         "whl": attr.label(
             mandatory = True,
             allow_single_file = True,
@@ -56,6 +53,9 @@ The path to the <code>.whl</code> file. The name is expected to follow [this
 convention](https://www.python.org/dev/peps/pep-0427/#file-name-convention)).
 """,
         ),
+        "python_interpreter": attr.string(default = "python", doc = """
+The command to run the Python interpreter used when unpacking the wheel.
+"""),
         "_script": attr.label(
             executable = True,
             default = Label("//tools:whltool.par"),


### PR DESCRIPTION
This is a rebase of @acumon's #158. It adds a `python_interpreter` attribute to `pip_import` and `whl_library` to allow customizing the command used to launch the Python interpreter. We'll follow this up with creating `pip2_import` and `pip3_import` as wrappers around this feature.

Diffbased against #251, which fixes documentation for these rules.

Work toward #249. Closes #158.