### PR TITLE
Fix immutable frozen set bug in defs.bzl

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,6 +13,7 @@ all_targets: &all_targets
     - "//experimental/..."
     - "//packaging/..."
     - "//python/..."
+    - "//tests/..."
     - "//tools/..."
     # As a regression test for #225, check that wheel targets still build when
     # their package path is qualified with the repo name.

--- a/python/defs.bzl
+++ b/python/defs.bzl
@@ -36,7 +36,7 @@ _MIGRATION_TAG = "__PYTHON_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:
-        attrs["tags"] += [_MIGRATION_TAG]
+        attrs["tags"] = attrs["tags"] + [_MIGRATION_TAG]
     else:
         attrs["tags"] = [_MIGRATION_TAG]
     return attrs

--- a/tests/load_from_macro/BUILD
+++ b/tests/load_from_macro/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:defs.bzl", "py_library")
+load(":tags.bzl", "TAGS")
+
+licenses(["notice"])
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    tags = TAGS,
+)

--- a/tests/load_from_macro/foo.py
+++ b/tests/load_from_macro/foo.py
@@ -1,0 +1,13 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/load_from_macro/tags.bzl
+++ b/tests/load_from_macro/tags.bzl
@@ -1,0 +1,18 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example tags defined in a separate file.
+"""
+TAGS = ["first_tag", "second_tag"]


### PR DESCRIPTION
When adding tags to a native `py_library` rule that is created through a macro we
were not properly considering the case where the tags came from a different
file and therefore were frozen. This caused an error.

Analog of https://github.com/bazelbuild/rules_cc/commit/cfe68f6bc79dea602f2f6a767797f94a5904997f.
