### PR TITLE
pip_import: support python_interpeter as label

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ information about the Python toolchain and cannot enforce that the interpreter
 used to invoke pip matches the interpreter used to run `py_binary` targets. By
 default, `pip_import` uses the system command `"python"`, which on most
 platforms is a Python 2 interpreter. This can be overridden by passing the
-`python_interpreter` attribute to `pip_import`. `pip3_import` just acts as a
-wrapper that sets `python_interpreter` to `"python3"`.
+`python_interpreter` or `python_interpreter_label` attribute to `pip_import`.
+`pip3_import` just acts as a wrapper that sets `python_interpreter` to
+`"python3"`.
 
 You can have multiple `pip_import`s in the same workspace, e.g. for Python 2
 and Python 3. This will create multiple central repos that have no relation to

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -22,12 +22,17 @@ def _pip_import_impl(repository_ctx):
     # requirements.bzl without it.
     repository_ctx.file("BUILD", "")
 
+    if repository_ctx.attr.python_interpreter_label:
+        python_interpreter = repository_ctx.path(repository_ctx.attr.python_interpreter_label)
+    else:
+        python_interpreter = repository_ctx.attr.python_interpreter
+
     # To see the output, pass: quiet=False
     result = repository_ctx.execute([
-        repository_ctx.attr.python_interpreter,
+        python_interpreter,
         repository_ctx.path(repository_ctx.attr._script),
         "--python_interpreter",
-        repository_ctx.attr.python_interpreter,
+        python_interpreter,
         "--name",
         repository_ctx.attr.name,
         "--input",
@@ -47,6 +52,13 @@ pip_import = repository_rule(
 The command to run the Python interpreter used to invoke pip and unpack the
 wheels.
 """),
+        "python_interpreter_label": attr.label(
+            allow_single_file = True,
+            doc = """
+The command, as a Bazel label, to run the Python interpreter used to invoke
+pip and unpack the wheels.  Takes precedence over `python_interpreter`.
+""",
+        ),
         "requirements": attr.label(
             mandatory = True,
             allow_single_file = True,


### PR DESCRIPTION
This commit adds a `python_interpreter_label` attr to `pip_import` to allow
users to specify a Python interpreter for pip as a Bazel label.