### PR TITLE
Add extra_pip_args option to pip_import

### DIFF
--- a/packaging/piptool.py
+++ b/packaging/piptool.py
@@ -102,6 +102,9 @@ parser.add_argument('--output', action='store',
 parser.add_argument('--directory', action='store',
                     help=('The directory into which to put .whl files.'))
 
+parser.add_argument('--extra_pip_args', action='store',
+                    help=('Extra arguments to pass down to pip.'))
+
 def determine_possible_extras(whls):
   """Determines the list of possible "extras" for each .whl
 
@@ -160,7 +163,10 @@ def main():
   args = parser.parse_args()
 
   # https://github.com/pypa/pip/blob/9.0.1/pip/__init__.py#L209
-  if pip_main(["wheel", "-w", args.directory, "-r", args.input]):
+  pip_args = ["wheel", "-w", args.directory, "-r", args.input]
+  if args.extra_pip_args:
+      pip_args += args.extra_pip_args.strip("\"").split()
+  if pip_main(pip_args):
     sys.exit(1)
 
   # Enumerate the .whl files we downloaded.

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -22,8 +22,7 @@ def _pip_import_impl(repository_ctx):
     # requirements.bzl without it.
     repository_ctx.file("BUILD", "")
 
-    # To see the output, pass: quiet=False
-    result = repository_ctx.execute([
+    args = [
         repository_ctx.attr.python_interpreter,
         repository_ctx.path(repository_ctx.attr._script),
         "--python_interpreter",
@@ -36,13 +35,24 @@ def _pip_import_impl(repository_ctx):
         repository_ctx.path("requirements.bzl"),
         "--directory",
         repository_ctx.path(""),
-    ])
+    ]
+    if repository_ctx.attr.extra_pip_args:
+        args += [
+            "--extra_pip_args",
+            "\"" + " ".join(repository_ctx.attr.extra_pip_args) + "\"",
+        ]
+
+    # To see the output, pass: quiet=False
+    result = repository_ctx.execute(args)
 
     if result.return_code:
         fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
 
 pip_import = repository_rule(
     attrs = {
+        "extra_pip_args": attr.string_list(
+            doc = "Extra arguments to pass on to pip.",
+        ),
         "python_interpreter": attr.string(default = "python", doc = """
 The command to run the Python interpreter used to invoke pip and unpack the
 wheels.


### PR DESCRIPTION
Adds the attr extra_pip_args to pip_import.  These args will be passed along to the pip invocation inside piptool.  This enables special pip usage such as loading packages from an alternate repository or local directory.