### PR TITLE
packaging/piptool: sort wheels and extras for deterministic output

### DIFF
--- a/packaging/piptool.py
+++ b/packaging/piptool.py
@@ -105,6 +105,10 @@ parser.add_argument('--directory', action='store',
 parser.add_argument('--extra_pip_args', action='store',
                     help=('Extra arguments to pass down to pip.'))
 
+def sort_wheels(whls):
+  """Sorts a list of wheels deterministically."""
+  return sorted(whls, key=lambda w: w.distribution() + '_' + w.version())
+
 def determine_possible_extras(whls):
   """Determines the list of possible "extras" for each .whl
 
@@ -153,7 +157,7 @@ def determine_possible_extras(whls):
   return {
     whl: [
       extra
-      for extra in whl.extras()
+      for extra in sorted(whl.extras())
       if is_possible(whl.distribution(), extra)
     ]
     for whl in whls
@@ -177,7 +181,7 @@ def main():
         if fname.endswith('.whl'):
           yield os.path.join(root, fname)
 
-  whls = [Wheel(path) for path in list_whls()]
+  whls = sort_wheels(Wheel(path) for path in list_whls())
   possible_extras = determine_possible_extras(whls)
 
   def repository_name(wheel):


### PR DESCRIPTION
I ran into this while updating `gvisor` in NixOS (https://github.com/NixOS/nixpkgs/pull/80875); the `requirements.bzl` file generated by `rules_python` isn't reproducible, differing based on the filesystem-order-dependent return from `os.walk`.

This PR is a minimal fix that sorts the repositories in `requirements.bzl` and the return value from `Wheel.extras()`.