### PR TITLE
point README readers to new 0.0.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_python",
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+    strip_prefix = "rules_python-0.0.2",
     sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
 )
 load("@rules_python//python:repositories.bzl", "py_repositories")

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ directly and call its initialization methods as follows:
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
-    sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+    sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
 )
 load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()


### PR DESCRIPTION
[`0.0.2`](https://github.com/bazelbuild/rules_python/releases/tag/0.0.2) is out.

Mainly addresses https://github.com/bazelbuild/rules_python/issues/261.

**Related:** https://github.com/bazelbuild/rules_python/pull/303