### PR TITLE
Add documentation of community / Bazel team ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,19 @@
-* @brandjon @lberki
+# NB: Last matching rule takes precedence in CODEOWNERS.
+
+# Fall-through to community maintainers.
+* @thundergolfer @andyscott
+
+# Core Python rules belong to the Bazel team.
+/python/ @brandjon @lberki
+# But not everything under python/ is the core Python rules.
+/python/pip.bzl @thundergolfer @andyscott
+/python/whl.bzl @thundergolfer @andyscott
+/python/requirements.txt @thundergolfer @andyscott
+
+# The proposals dir corresponds to the Bazel proposals process, documented
+# here: https://bazel.build/designs/index.html
+/proposals/ @brandjon @lberki
+
+# Certain repo metadata files should stay as-is, particularly these.
+/LICENSE @brandjon @lberki
+/CONTRIBUTING.md @brandjon @lberki

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,12 @@ directory except for `pip.bzl`, `whl.bzl`, and `requirements.txt`.
 Issues should be triaged as follows:
 
 - Anything concerning the way Bazel implements the core Python rules should be
-  filed under bazelbuild/bazel, using the label `team-Rules-python`.
+  filed under [bazelbuild/bazel](https://github.com/bazelbuild/bazel), using
+  the label `team-Rules-python`.
 
 - If the issue specifically concerns the rules_python stubs, it should be filed
-  in this repository and use the label `core-rules`.
+  here in this repository and use the label `core-rules`.
 
 - Anything else, such as feature requests not related to existing core rules
-  functionality, should be filed in this repository without the `core-rules`
-  label.
+  functionality, should also be filed in this repository but without the
+  `core-rules` label.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,26 @@ pull request.
 
 <sup>1</sup> See "[Reflections on Trusting Trust](https://en.wikipedia.org/wiki/Backdoor_(computing)#Compiler_backdoors)".
 
+## Core rules
+
+The bulk of this repo is owned and maintained by the Bazel Python community.
+However, since the core Python rules (`py_binary` and friends) are still
+bundled with Bazel itself, the Bazel team retains ownership of their stubs in
+this repository. This will be the case at least until the Python rules are
+fully migrated to Starlark code.
+
+Practically, this means that a Bazel team member should approve any PR
+concerning the core Python logic. This includes everything under the `python/`
+directory except for `pip.bzl`, `whl.bzl`, and `requirements.txt`.
+
+Issues should be triaged as follows:
+
+- Anything concerning the way Bazel implements the core Python rules should be
+  filed under bazelbuild/bazel, using the label `team-Rules-python`.
+
+- If the issue specifically concerns the rules_python stubs, it should be filed
+  in this repository and use the label `core-rules`.
+
+- Anything else, such as feature requests not related to existing core rules
+  functionality, should be filed in this repository without the `core-rules`
+  label.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ changes as they evolve. There are no guarantees for rules underneath the
 `experimental/` directory.
 
 This repository is maintained by the Bazel community. Neither Google, nor the
-Bazel team provides support for the code. However, this repository is part of
+Bazel team, provides support for the code. However, this repository is part of
 the test suite used to vet new Bazel releases. See the [How to
 contribute](CONTRIBUTING.md) page for information on our development workflow.
 


### PR DESCRIPTION
This adds a more nuanced CODEOWNERS and explains its purpose in CONTRIBUTING.md.

Fixes #291.