### PR TITLE
Support python interpreter target in pip_import.

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -5,7 +5,7 @@
 ## pip_import
 
 <pre>
-pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-extra_pip_args">extra_pip_args</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-requirements">requirements</a>, <a href="#pip_import-timeout">timeout</a>)
+pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-extra_pip_args">extra_pip_args</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-python_interpreter_target">python_interpreter_target</a>, <a href="#pip_import-requirements">requirements</a>, <a href="#pip_import-timeout">timeout</a>)
 </pre>
 
 A rule for importing `requirements.txt` dependencies into Bazel.
@@ -83,6 +83,18 @@ py_binary(
         <p>
           The command to run the Python interpreter used to invoke pip and unpack the
 wheels.
+        </p>
+      </td>
+    </tr>
+    <tr id="pip_import-python_interpreter_target">
+      <td><code>python_interpreter_target</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
+        <p>
+          If you are using a custom python interpreter built by another repository rule,
+use this attribute to specify its BUILD target. This allows pip_import to invoke
+pip using the same interpreter as your toolchain. If set, takes precedence over
+python_interpreter.
         </p>
       </td>
     </tr>

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -28,7 +28,7 @@ def _pip_import_impl(repository_ctx):
         interpreter_path = repository_ctx.path(target)
 
     args = [
-        repository_ctx.attr.python_interpreter,
+        interpreter_path,
         repository_ctx.path(repository_ctx.attr._script),
         "--python_interpreter",
         interpreter_path,

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -22,11 +22,16 @@ def _pip_import_impl(repository_ctx):
     # requirements.bzl without it.
     repository_ctx.file("BUILD", "")
 
+    interpreter_path = repository_ctx.attr.python_interpreter
+    if repository_ctx.attr.python_interpreter_target != None:
+        target = repository_ctx.attr.python_interpreter_target
+        interpreter_path = repository_ctx.path(target)
+
     args = [
         repository_ctx.attr.python_interpreter,
         repository_ctx.path(repository_ctx.attr._script),
         "--python_interpreter",
-        repository_ctx.attr.python_interpreter,
+        interpreter_path,
         "--name",
         repository_ctx.attr.name,
         "--input",
@@ -56,6 +61,12 @@ pip_import = repository_rule(
         "python_interpreter": attr.string(default = "python", doc = """
 The command to run the Python interpreter used to invoke pip and unpack the
 wheels.
+"""),
+        "python_interpreter_target": attr.label(allow_single_file = True, doc = """
+If you are using a custom python interpreter built by another repository rule,
+use this attribute to specify its BUILD target. This allows pip_import to invoke
+pip using the same interpreter as your toolchain. If set, takes precedence over
+python_interpreter.
 """),
         "requirements": attr.label(
             mandatory = True,


### PR DESCRIPTION
This allows users to use a custom python interpreter that is built by
another repository rule instead of using a pre-built interpreter binary
that is checked-in.

This tangentially addresses #257 since a common setup is to use the
custom built interpreter in the python toolchain.

For example, see: https://github.com/kku1993/bazel-hermetic-python