### PR TITLE
Remove files from py_library data glob() if there is space in the mid…

### DIFF
--- a/packaging/whl.py
+++ b/packaging/whl.py
@@ -149,6 +149,7 @@ load("{requirements}", "requirement")
 py_library(
     name = "pkg",
     srcs = glob(["**/*.py"]),
+    # Remove files and directories with spaces in their names as those are invalid in Bazel.
     data = glob(["**/*"], exclude=["**/*.py", "**/* */**", "**/* *", "BUILD", "WORKSPACE"]),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.

--- a/packaging/whl.py
+++ b/packaging/whl.py
@@ -149,7 +149,7 @@ load("{requirements}", "requirement")
 py_library(
     name = "pkg",
     srcs = glob(["**/*.py"]),
-    data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
+    data = glob(["**/*"], exclude=["**/*.py", "**/* */**", "**/* *", "BUILD", "WORKSPACE"]),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
     imports = ["."],


### PR DESCRIPTION
…dle of path

Directory names may also contain spaces in some cases, that would fail
Bazel.
Files with spaces in their name were already excluded.