### PR TITLE
Fix for when there are so many file arguments it creates the Command To Long error

### DIFF
--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//experimental/python:wheel.bzl", "py_package", "py_wheel", "py_wrapped_input_files")
+load("//experimental/python:wheel.bzl", "py_package", "py_wheel")
 load("//python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -53,11 +53,6 @@ py_package(
     deps = [":main"],
 )
 
-py_wrapped_input_files(
-    name = "wrapped_example_package",
-    deps = [":example_pkg"],
-)
-
 py_wheel(
     name = "minimal_with_py_package",
     # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl"
@@ -66,17 +61,6 @@ py_wheel(
     version = "0.0.1",
     deps = [":example_pkg"],
 )
-
-py_wheel(
-    name = "minimal_with_py_package_wrapped",
-    # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl"
-    distribution = "example_minimal_package_wrapped_inputs",
-    python_tag = "py3",
-    version = "0.0.1",
-    wrapped_package_lists = [":wrapped_example_package"],
-    deps = [":example_pkg", ":wrapped_example_package"],
-)
-
 
 # An example that uses all features provided by py_wheel.
 py_wheel(

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -39,6 +39,7 @@ def _py_package_impl(ctx):
         transitive = [dep[DefaultInfo].data_runfiles.files for dep in ctx.attr.deps] +
                      [dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps],
     )
+
     # TODO: '/' is wrong on windows, but the path separator is not available in skylark.
     # Fix this once ctx.configuration has directory separator information.
     packages = [p.replace(".", "/") for p in ctx.attr.packages]
@@ -53,9 +54,8 @@ def _py_package_impl(ctx):
             for package in packages:
                 if wheel_path.startswith(package):
                     filtered_files.append(input_file)
-    
         filtered_inputs = depset(direct = filtered_files)
-    
+
     return [DefaultInfo(
         files = filtered_inputs,
     )]

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -148,7 +148,6 @@ def _py_wheel_impl(ctx):
         args.add("--description_file", description_file)
         other_inputs.append(description_file)
 
-
     ctx.actions.run(
         inputs = depset(direct = other_inputs, transitive = [inputs_to_package]),
         outputs = [outfile],


### PR DESCRIPTION
When there are to many file arguments to py_wheel from py_package on Windows 10 I was getting 
this error related to wheelmaker.exe 
```
command is longer than CreateProcessW's limit (32768 characters)
```
Added additional rules to get around this issue.