### PR TITLE
Updated 'helloworld' example

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples/helloworld

--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@examples_helloworld//:requirements.bzl", "requirement")
-load("//python:defs.bzl", "py_library", "py_test")
+load("@helloworld_pypi_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,6 +22,7 @@ licenses(["notice"])  # Apache 2.0
 py_library(
     name = "helloworld",
     srcs = ["helloworld.py"],
+    srcs_version = "PY2ONLY",
     deps = [requirement("futures")],
 )
 

--- a/examples/helloworld/WORKSPACE
+++ b/examples/helloworld/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "examples_helloworld")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # If copying this WORKSPACE file to start a new Bazel workspace, replace this with a
 # `http_archive` repository rule as specified here: https://github.com/bazelbuild/rules_python/releases
 local_repository(
@@ -14,11 +12,9 @@ load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
 
 # Only needed if using the packaging rules.
-load("@rules_python//python:pip.bzl", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip_import")
 
 pip_repositories()
-
-load("@rules_python//python:pip.bzl", "pip_import")
 
 pip_import(
     name = "helloworld_pypi_deps",

--- a/examples/helloworld/WORKSPACE
+++ b/examples/helloworld/WORKSPACE
@@ -1,0 +1,31 @@
+workspace(name = "examples_helloworld")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# If copying this WORKSPACE file to start a new Bazel workspace, replace this with a
+# `http_archive` repository rule as specified here: https://github.com/bazelbuild/rules_python/releases
+local_repository(
+    name = "rules_python",
+    path = "../../",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+# Only needed if using the packaging rules.
+load("@rules_python//python:pip.bzl", "pip_repositories")
+
+pip_repositories()
+
+load("@rules_python//python:pip.bzl", "pip_import")
+
+pip_import(
+    name = "helloworld_pypi_deps",
+    python_interpreter = "python2",
+    requirements = "//:requirements.txt",
+)
+
+load("@helloworld_pypi_deps//:requirements.bzl", "pip_install")
+
+pip_install()

--- a/examples/helloworld/helloworld_test.py
+++ b/examples/helloworld/helloworld_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from examples.helloworld import helloworld
+import helloworld
 
 
 class HelloWorldTest(unittest.TestCase):


### PR DESCRIPTION
Update is motivated by https://github.com/bazelbuild/rules_python/issues/301

This change makes the 'helloworld' example much more copy-pasteable by beginners, by decoupling the code from project's `WORKSPACE`. I think it can be harder to understand this example given it's coupling to the main project, like with load statements like this: `load("//python:defs.bzl", "py_library", "py_test")`

I think I would prefer it if all the examples in the `examples/` folder were managed by one `WORKSPACE`, instead of a `WORKSPACE` per example, but I'll leave it as is for now and wait for comment. _Edit:_ @alexeagle has [good rebuttal to this below.](https://github.com/bazelbuild/rules_python/pull/326#issuecomment-655527483)

----

cc @oconnore