### PR TITLE
"Skylark" is an outdated name of the language, please use "starlark" …

### DIFF
--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -40,7 +40,7 @@ def _py_package_impl(ctx):
                      [dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps],
     )
 
-    # TODO: '/' is wrong on windows, but the path separator is not available in skylark.
+    # TODO: '/' is wrong on windows, but the path separator is not available in starlark.
     # Fix this once ctx.configuration has directory separator information.
     packages = [p.replace(".", "/") for p in ctx.attr.packages]
     if not packages:


### PR DESCRIPTION
master CI build [is currently failing with](https://buildkite.com/bazel/rules-python-python/builds/834#a478721a-3cda-4b27-903a-abe2d7def4d9): 

```
href="https://github.com/bazelbuild/rules_python/blob/eabd5344d8419eb0077e6be5df948c37a1186202/experimental/python/wheel.bzl#L43">experimental/python/wheel.bzl:43</a>: <a href="https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#skylark-comment">skylark-comment</a>: "Skylark" is an outdated name of the language, please use "starlark" instead.</pre></code>
```