### PR TITLE
Fix failing build on CI by specifying pip package version

### DIFF
--- a/examples/extras/requirements.txt
+++ b/examples/extras/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-language==0.27.0
+googleapis-common-protos==1.51.0


### PR DESCRIPTION
`bazel build //...` was failing due to "googleapis-common-protos[grpc]"
pip package being unavailable.

It seems to be caused by latest googleapis-common-protos release.
Specify googleapis-common-protos in requirements.txt to be in the previous
version (1.51.0) to fix this.

Fixes #321.