### PR TITLE
Add transitive dependencies to install_require of py_wheel.

### DIFF
--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -22,7 +22,10 @@ licenses(["notice"])  # Apache 2.0
 py_library(
     name = "helloworld",
     srcs = ["helloworld.py"],
-    deps = [requirement("futures")],
+    deps = [
+        requirement("futures"),
+        requirement("requests"),
+    ],
 )
 
 py_test(

--- a/examples/helloworld/requirements.txt
+++ b/examples/helloworld/requirements.txt
@@ -1,1 +1,2 @@
-futures>=3.1
+futures==3.1.1
+requests==2.22.0

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -143,3 +143,9 @@ py_test(
         ":minimal_with_py_package",
     ],
 )
+
+py_test(
+    name = "extract_requirements_test",
+    srcs = ["extract_requirements_test.py"],
+    deps = ["//experimental/rules_python:extract_requirements"],
+)

--- a/experimental/examples/wheel/extract_requirements_test.py
+++ b/experimental/examples/wheel/extract_requirements_test.py
@@ -1,0 +1,77 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from rules_python.experimental.rules_python import extract_requirements
+
+# Assume buildifier is not applied to BUILD file
+BUILD_FILES = [
+    """
+    py_library(
+    name = "foo.py",
+    srcs = ["foo.py", "other.py"],
+    deps = [requirement("bar"), requirement("foo")],
+)""",
+    """
+    py_library(
+    name = "foo.py",
+    srcs = [
+    "foo.py", "other.py"
+],
+    deps = [
+    requirement("bar"), requirement("foo")
+],
+)""",
+    """
+    py_library(
+    name = "foo.py",
+    srcs = ["foo.py",
+    "other.py"
+],
+    deps = [
+    requirement("bar"), requirement("foo")],
+)""",
+]
+
+
+class ExtractRequirementTest(unittest.TestCase):
+    def test_parse_build_file(self):
+        """Assert srcs and deps are extracted from BUILD file."""
+        expected = {"foo.py": {"foo", "bar"}, "other.py": {"foo", "bar"}}
+        for build_file in BUILD_FILES:
+            self.assertEqual(
+                extract_requirements.parse_build_file(build_file), expected
+            )
+
+    def test_filter_dependencies(self):
+        """Assert only direct dependencies are returned"""
+        source_code = {
+            "foo.py",
+        }
+        direct_dependencies = [{"foo.py": {"foo", "bar"}, "other.py": {"foo", "bar"}}]
+        all_dependencies = [
+            ("bar", "0.1"),
+            ("bar_transitive1", "0.2"),
+            ("bar_transitive2", "0.3"),
+        ]
+        self.assertEqual(
+            extract_requirements.filter_dependencies(
+                source_code, direct_dependencies, all_dependencies
+            ),
+            [("bar", "0.1")],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -48,7 +48,12 @@ class WheelTest(unittest.TestCase):
                  'example_minimal_package-0.0.1.dist-info/METADATA',
                  'example_minimal_package-0.0.1.dist-info/RECORD'])
             meta_data = zf.read('example_minimal_package-0.0.1.dist-info/METADATA')
-            self.assertIn(b"Requires-Dist: futures==3.3.0", meta_data)
+            # Assert direct deps
+            self.assertIn(b"Requires-Dist: futures==3.1.1", meta_data)
+            self.assertIn(b"Requires-Dist: requests==2.22.0", meta_data)
+            # Assert transitive from requests not in METADATA
+            self.assertNotIn(b"Requires-Dist: chardet==", meta_data)
+            self.assertNotIn(b"Requires-Dist: idna==", meta_data)
 
     def test_customized_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -47,6 +47,8 @@ class WheelTest(unittest.TestCase):
                  'example_minimal_package-0.0.1.dist-info/WHEEL',
                  'example_minimal_package-0.0.1.dist-info/METADATA',
                  'example_minimal_package-0.0.1.dist-info/RECORD'])
+            meta_data = zf.read('example_minimal_package-0.0.1.dist-info/METADATA')
+            self.assertIn(b"Requires-Dist: futures==3.3.0", meta_data)
 
     def test_customized_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -20,6 +20,10 @@ def _extract_requirements(ctx):
     """Extract the transitive dependencies."""
     requirements = []
     for dep in ((ctx.attr.deps)):
+        for x in ((dep.default_runfiles.files.to_list())):
+            if x.path.startswith("external"):
+                continue
+            requirements.append(ctx.workspace_name + "/" + x.path)
         requirements.extend(dep[PyInfo].imports.to_list())
     return requirements
 

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -98,6 +98,14 @@ def _py_wheel_impl(ctx):
     # Currently this is only the description file (if used).
     other_inputs = []
 
+    # Wrap the inputs into a file to reduce command line length.
+    packageinputfile = ctx.actions.declare_file(ctx.attr.name + '_target_wrapped_inputs.txt')
+    content = ''
+    for input_file in inputs_to_package.to_list():
+        content += _input_file_to_arg(input_file) + '\n'
+    ctx.actions.write(output = packageinputfile, content=content)
+    other_inputs.append(packageinputfile)
+
     args = ctx.actions.args()
     args.add("--name", ctx.attr.distribution)
     args.add("--version", ctx.attr.version)
@@ -107,7 +115,7 @@ def _py_wheel_impl(ctx):
     args.add("--out", outfile.path)
     args.add_all(ctx.attr.strip_path_prefixes, format_each = "--strip_path_prefix=%s")
 
-    args.add_all(inputs_to_package, format_each = "--input_file=%s", map_each = _input_file_to_arg)
+    args.add("--input_file_list", packageinputfile)
 
     extra_headers = []
     if ctx.attr.author:

--- a/experimental/rules_python/BUILD
+++ b/experimental/rules_python/BUILD
@@ -19,3 +19,9 @@ py_binary(
     srcs = ["wheelmaker.py"],
     visibility = ["//visibility:public"],
 )
+
+py_binary(
+    name = "extract_requirements",
+    srcs = ["extract_requirements.py"],
+    visibility = ["//visibility:public"],
+)

--- a/experimental/rules_python/extract_requirements.py
+++ b/experimental/rules_python/extract_requirements.py
@@ -1,0 +1,48 @@
+import argparse
+import glob
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract dependencies from python rule"
+    )
+    parser.add_argument("--output", type=str, required=True, help="requirement file")
+    parser.add_argument(
+        "--requirement",
+        type=str,
+        action="append",
+        help="List of dependencies . Can be supplied multiple times.",
+    )
+    args = parser.parse_args(sys.argv[1:])
+    # This seems fragile. Need a better way to infer `bazel info output_base`
+    OUTPUT_DIR = os.environ["RUNFILES_DIR"].split("sandbox")[0]
+    EXTERNAL = os.path.join(OUTPUT_DIR, "external")
+    requirements = set()
+    for requirement in args.requirement:
+        file_path = os.path.join(EXTERNAL, requirement)
+        if not os.path.exists(file_path):
+            continue
+        meta_data_dict = {}
+        for meta_data in glob.glob(
+            os.path.join(file_path, "**/METADATA"), recursive=True
+        ):
+            with open(meta_data) as fhandle:
+                for line in fhandle.read().splitlines():
+                    if line.startswith(("Name:", "Version:")):
+                        key, value = line.split(":")
+                        meta_data_dict[key.strip()] = value.strip()
+        requirements.add((meta_data_dict["Name"], meta_data_dict["Version"]))
+
+    requirement_txt = ""
+    for name, version in requirements:
+        requirement_txt = "{requirement_txt}\n{name}=={version}".format(
+            requirement_txt=requirement_txt, name=name, version=version
+        )
+
+    with open(args.output, "w") as fhandle:
+        fhandle.write(requirement_txt)
+
+if __name__ == "__main__":
+    main()

--- a/experimental/rules_python/extract_requirements.py
+++ b/experimental/rules_python/extract_requirements.py
@@ -1,7 +1,98 @@
+"""Parse bazel BUILD files and extract direct pip dependencies."""
+import re
+import ast
 import argparse
 import glob
 import os
 import sys
+
+
+def parse_enclosed_expression(source, start, opening_token):
+    """Parse an expression enclosed by a token and its counterpart.
+    Args:
+        source (str): Source code of a Bazel BUILD file, for example.
+        start (int): Index at which an expression starts.
+        opening_token (str): A character '(' or '[' that opens an expression.
+    Returns:
+        expression (str): The whole expression that contains the opening and closing tokens.
+    Raises:
+        NotImplementedError: If parsing is not implemented for the given opening token.
+    """
+    if opening_token == "(":
+        closing_token = ")"
+    elif opening_token == "[":
+        closing_token = "]"
+    else:
+        raise NotImplementedError("No closing token defined for %s." % opening_token)
+
+    start2 = source.find(opening_token, start)
+    assert start2 > start, "Could not locate the opening token %s." % opening_token
+    open_tokens = 0
+    end = None
+
+    for end_idx, char in enumerate(source[start2:], start2):
+        if char == opening_token:
+            open_tokens += 1
+        elif char == closing_token:
+            open_tokens -= 1
+
+        if open_tokens == 0:
+            end = end_idx + 1
+            break
+
+    assert end, "Could not locate the closing token %s." % closing_token
+
+    expression = source[start:end]
+
+    return expression, end
+
+
+def parse_build_file(text):
+    """Find rules and extract srcs and deps."""
+    text = " ".join([x for x in text.splitlines() if not x.startswith("#")])
+    source_deps = {}
+    start = 0
+    expressions = []
+    expression, start = parse_enclosed_expression(text, start, "(")
+    expressions.append(expression)
+    while True:
+        try:
+            expression, start = parse_enclosed_expression(text, start, "(")
+            expressions.append(expression)
+        except AssertionError:
+            break
+
+    for rule in expressions:
+        for srcs in re.findall(r"srcs\s*=\s*\[(.*?)\]", rule):
+            for src in srcs.split(","):
+                src = ast.literal_eval(src.strip())
+                if src not in source_deps:
+                    source_deps[src] = set()
+                for dep in re.findall(r"deps\s*=\s*\[(.*?)\]", rule):
+                    req = re.findall(r"requirement\((.*?)\)", dep)
+                    source_deps[src] = source_deps[src] | {
+                        ast.literal_eval(r.strip()) for r in req
+                    }
+
+    return source_deps
+
+
+def filter_dependencies(source_code, direct_dependencies, all_dependencies):
+    """Limit dependencies to direct dependencies.
+    Args:
+        source_code: Set[str] source code in srcs attribute used to identify BUILD targets.
+        direct_dependencies: Dict[str Set[str]] source code (key) direct dependencies (values)
+        all_dependencies: List[Tuple[str, str]] all dependencies ( direct + transitive ) from py_wheel rule.
+    Return
+        Set[str] direct dependencies only
+    """
+
+    required_dependencies = set()
+    for src in source_code:
+        for direct_dep in direct_dependencies:
+            if src in direct_dep:
+                required_dependencies = required_dependencies | direct_dep[src]
+    return [dep for dep in all_dependencies if dep[0] in required_dependencies]
 
 
 def main():
@@ -16,13 +107,29 @@ def main():
         help="List of dependencies . Can be supplied multiple times.",
     )
     args = parser.parse_args(sys.argv[1:])
+    runfiles_dir = os.environ["RUNFILES_DIR"]
+
     # This seems fragile. Need a better way to infer `bazel info output_base`
-    OUTPUT_DIR = os.environ["RUNFILES_DIR"].split("sandbox")[0]
-    EXTERNAL = os.path.join(OUTPUT_DIR, "external")
+    # Will break if not using sandbox
+    output_dir = runfiles_dir.split("sandbox")[0]
+    external = os.path.join(output_dir, "external")
+    source_dir = os.path.join(output_dir, "execroot")
     requirements = set()
+    direct_dependencies = list()
+    source_code = set()
+
     for requirement in args.requirement:
-        file_path = os.path.join(EXTERNAL, requirement)
+        src, src_dir = os.path.basename(requirement), os.path.dirname(requirement)
+        source_code.add(src)
+        build_file = os.path.join(source_dir, src_dir, "BUILD")
+        if os.path.exists(build_file):
+            with open(build_file) as file_object:
+                text = file_object.read()
+                direct_dependencies.append(parse_build_file(text))
+        file_path = os.path.join(external, requirement)
         if not os.path.exists(file_path):
+            continue
+        if os.path.isfile(file_path):
             continue
         meta_data_dict = {}
         for meta_data in glob.glob(
@@ -33,9 +140,12 @@ def main():
                     if line.startswith(("Name:", "Version:")):
                         key, value = line.split(":")
                         meta_data_dict[key.strip()] = value.strip()
+        if not meta_data_dict:
+            continue
         requirements.add((meta_data_dict["Name"], meta_data_dict["Version"]))
 
     requirement_txt = ""
+    requirements = filter_dependencies(source_code, direct_dependencies, requirements)
     for name, version in requirements:
         requirement_txt = "{requirement_txt}\n{name}=={version}".format(
             requirement_txt=requirement_txt, name=name, version=version
@@ -43,6 +153,7 @@ def main():
 
     with open(args.output, "w") as fhandle:
         fhandle.write(requirement_txt)
+
 
 if __name__ == "__main__":
     main()

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -243,6 +243,10 @@ def main():
              "files to be included in the wheel. "
              "Can be supplied multiple times.")
     contents_group.add_argument(
+        '--input_file_list', action='append',
+        help='A file that has all the input files defined as a list to avoid the long command'
+    )
+    contents_group.add_argument(
         '--console_script', action='append',
         help="Defines a 'console_script' entry point. "
              "Can be supplied multiple times.")
@@ -264,6 +268,14 @@ def main():
         input_files = [i.split(';') for i in arguments.input_file]
     else:
         input_files = []
+
+    if arguments.input_file_list:
+        for input_file in arguments.input_file_list:
+            with open(input_file) as _file:
+                input_file_list = _file.read().splitlines()
+            for _input_file in input_file_list:
+                input_files.append(_input_file.split(';'))
+
     all_files = get_files_to_package(input_files)
     # Sort the files for reproducible order in the archive.
     all_files = sorted(all_files.items())

--- a/experimental/rules_python/wheelmaker.py
+++ b/experimental/rules_python/wheelmaker.py
@@ -250,6 +250,10 @@ def main():
         '--console_script', action='append',
         help="Defines a 'console_script' entry point. "
              "Can be supplied multiple times.")
+    contents_group.add_argument(
+                '--requirements', action='append',
+                help='A file that has all the transitive dependencies.'
+    )
 
     requirements_group = parser.add_argument_group("Package requirements")
     requirements_group.add_argument(
@@ -313,6 +317,10 @@ def main():
                 extra_requires[option].append(req)
         classifiers = arguments.classifier or []
         requires = arguments.requires or []
+        if arguments.requirements:
+            for req_file in arguments.requirements:
+                with open(req_file) as _file:
+                    requires.extend([r for r in _file.read().splitlines() if r.strip()])
         extra_headers = arguments.header or []
         console_scripts = arguments.console_script or []
 


### PR DESCRIPTION
py_wheel does not add `pip requirments` to the output wheel as Requires-Dist

Given the following example of building wheel

https://github.com/bazelbuild/rules_python/blob/cfcc67538262cd592a372e8f4d03621c50857419/experimental/examples/wheel/BUILD#L49-L63

The `:main` target depends on  ` "//examples/helloworld", ` that depends of the `futures==3.3.0` library.

https://github.com/bazelbuild/rules_python/blob/cfcc67538262cd592a372e8f4d03621c50857419/experimental/examples/wheel/BUILD#L22-L32

To build a complete wheel with all requirements should be py_wheel should be declared as.

py_wheel( 
     name = "minimal_with_py_package", 
     # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl" 
     distribution = "example_minimal_package", 
     python_tag = "py3", 
     version = "0.0.1", 
     deps = [":example_pkg"], 
    **requires = ["futures==3.3.0",]**
 ) 


This PR attempts to add `futures==3.3.0` to the final wheels, without specifying the futures library in the `py_wheel` declaration.
The futures library will then be part of METADATA as a  `Requires-Dist`.
