### PR TITLE
Check if input_file is directory and then add all files within that directory

### DIFF
--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -31,6 +31,14 @@ py_library(
     ],
 )
 
+py_library(
+    name = "main_with_gen_data",
+    srcs = ["main.py"],
+    data = [
+        ":gen_dir",
+    ],
+)
+
 # Package just a specific py_libraries, without their dependencies
 py_wheel(
     name = "minimal_with_py_library",
@@ -51,6 +59,12 @@ py_package(
     # Only include these Python packages.
     packages = ["experimental.examples.wheel"],
     deps = [":main"],
+)
+
+py_package(
+    name = "example_pkg_with_data",
+    packages = ["experimental.examples.wheel"],
+    deps = [":main_with_gen_data"]
 )
 
 py_wheel(
@@ -144,6 +158,19 @@ py_wheel(
     deps = [
         ":example_pkg",
     ],
+    name = "use_genrule_with_dir_in_outs",
+    distribution = "use_genrule_with_dir_in_outs",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        ":example_pkg_with_data"
+    ]
+)
+
+genrule(
+    name = "gen_dir",
+    outs = ["someDir"],
+    cmd = "mkdir -p $@",
 )
 
 py_wheel(

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -40,9 +40,9 @@ py_library(
 )
 
 genrule(
-    name="gen_dir",
-    outs=["someDir"],
-    cmd="mkdir -p $@ && touch $@/foo.py",
+    name = "gen_dir",
+    outs = ["someDir"],
+    cmd = "mkdir -p $@ && touch $@/foo.py",
 )
 
 # Package just a specific py_libraries, without their dependencies

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -158,6 +158,9 @@ py_wheel(
     deps = [
         ":example_pkg",
     ],
+)
+
+py_wheel(
     name = "use_genrule_with_dir_in_outs",
     distribution = "use_genrule_with_dir_in_outs",
     python_tag = "py3",

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -39,6 +39,12 @@ py_library(
     ],
 )
 
+genrule(
+    name="gen_dir",
+    outs=["someDir"],
+    cmd="mkdir -p $@ && touch $@/foo.py",
+)
+
 # Package just a specific py_libraries, without their dependencies
 py_wheel(
     name = "minimal_with_py_library",
@@ -170,12 +176,6 @@ py_wheel(
     ]
 )
 
-genrule(
-    name = "gen_dir",
-    outs = ["someDir"],
-    cmd = "mkdir -p $@",
-)
-
 py_wheel(
     name = "python_abi3_binary_wheel",
     abi = "abi3",
@@ -198,5 +198,6 @@ py_test(
         ":minimal_with_py_package",
         ":python_abi3_binary_wheel",
         ":python_requires_in_a_package",
+        ":use_genrule_with_dir_in_outs",
     ],
 )

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -219,6 +219,21 @@ Tag: cp38-abi3-manylinux2014_x86_64
 """,
             )
 
+    def test_genrule_creates_directory_and_is_included_in_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'use_genrule_with_dir_in_outs-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['experimental/examples/wheel/main.py',
+                 'experimental/examples/wheel/someDir/foo.py',
+                 'use_genrule_with_dir_in_outs-0.0.1.dist-info/WHEEL',
+                 'use_genrule_with_dir_in_outs-0.0.1.dist-info/METADATA',
+                 'use_genrule_with_dir_in_outs-0.0.1.dist-info/RECORD'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -102,21 +102,25 @@ class WheelMaker(object):
 
             return normalized_arcname
 
+        # If anywhere in the dependency tree a directory is set
+        # it will be passed in as an input file and we need to
+        # ignore.
+        if os.path.isdir(real_filename):
+            return
         arcname = arcname_from(package_filename)
 
         self._zipfile.write(real_filename, arcname=arcname)
         # Find the hash and length
         hash = hashlib.sha256()
         size = 0
-        if not os.path.isdir(real_filename):
-            with open(real_filename, 'rb') as f:
-                while True:
-                    block = f.read(2 ** 20)
-                    if not block:
-                        break
-                    hash.update(block)
-                    size += len(block)
-            self._add_to_record(arcname, self._serialize_digest(hash), size)
+        with open(real_filename, 'rb') as f:
+            while True:
+                block = f.read(2 ** 20)
+                if not block:
+                    break
+                hash.update(block)
+                size += len(block)
+        self._add_to_record(arcname, self._serialize_digest(hash), size)
 
     def add_wheelfile(self):
         """Write WHEEL file to the distribution"""

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -102,11 +102,13 @@ class WheelMaker(object):
 
             return normalized_arcname
 
-        # If anywhere in the dependency tree a directory is set
-        # it will be passed in as an input file and we need to
-        # ignore.
         if os.path.isdir(real_filename):
+            directory_contents = os.listdir(real_filename)
+            for file_ in directory_contents:
+                self.add_file(f"{package_filename}/{file_}",
+                              f"{real_filename}/{file_}")
             return
+
         arcname = arcname_from(package_filename)
 
         self._zipfile.write(real_filename, arcname=arcname)

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -108,14 +108,15 @@ class WheelMaker(object):
         # Find the hash and length
         hash = hashlib.sha256()
         size = 0
-        with open(real_filename, 'rb') as f:
-            while True:
-                block = f.read(2 ** 20)
-                if not block:
-                    break
-                hash.update(block)
-                size += len(block)
-        self._add_to_record(arcname, self._serialize_digest(hash), size)
+        if not os.path.isdir(real_filename):
+            with open(real_filename, 'rb') as f:
+                while True:
+                    block = f.read(2 ** 20)
+                    if not block:
+                        break
+                    hash.update(block)
+                    size += len(block)
+            self._add_to_record(arcname, self._serialize_digest(hash), size)
 
     def add_wheelfile(self):
         """Write WHEEL file to the distribution"""

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -105,8 +105,8 @@ class WheelMaker(object):
         if os.path.isdir(real_filename):
             directory_contents = os.listdir(real_filename)
             for file_ in directory_contents:
-                self.add_file(f"{package_filename}/{file_}",
-                              f"{real_filename}/{file_}")
+                self.add_file("{}/{}".format(package_filename, file_),
+                              "{}/{}".format(real_filename, file_))
             return
 
         arcname = arcname_from(package_filename)


### PR DESCRIPTION
If in a dependency tree a directory is used as out this is passed as
input_file to wheelmaker which then generates an unhandled error as
it tries to write the directory as a file.