### PR TITLE
Remove mention and usage of Bazel Federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,32 +50,7 @@ contribute](CONTRIBUTING.md) page for information on our development workflow.
 ## Getting started
 
 To import rules_python in your project, you first need to add it to your
-`WORKSPACE` file. If you are using the [Bazel
-Federation](https://github.com/bazelbuild/bazel-federation), you just need to
-[import the Federation](https://github.com/bazelbuild/bazel-federation#example-workspace)
-and call the rules_python setup methods:
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/releases/download/0.0.1/bazel_federation-0.0.1.tar.gz",
-    sha256 = "506dfbfd74ade486ac077113f48d16835fdf6e343e1d4741552b450cfc2efb53",
-)
-
-load("@bazel_federation//:repositories.bzl", "rules_python_deps")
-
-rules_python_deps()
-load("@bazel_federation//setup:rules_python.bzl",  "rules_python_setup")
-rules_python_setup(use_pip=True)
-```
-
-Note the `use_pip` argument: rules_python may be imported either with or
-without support for the packaging rules.
-
-If you are not using the Federation, you can simply import rules_python
-directly and call its initialization methods as follows:
+`WORKSPACE` file:
 
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -85,9 +60,11 @@ http_archive(
     strip_prefix = "rules_python-0.0.2",
     sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
 )
-load("@rules_python//python:repositories.bzl", "py_repositories")
-py_repositories()
-# Only needed if using the packaging rules.
+```
+
+If you want to use the pip packaging rules, also add:
+
+```python
 load("@rules_python//python:pip.bzl", "pip_repositories")
 pip_repositories()
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,25 +14,9 @@
 
 workspace(name = "rules_python")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//python:pip.bzl", "pip_repositories")
 
-# Load our production dependencies using the federation, except that instead of
-# calling rules_python() (which would define the @rules_python repo), we just
-# call rules_python_deps().
-
-http_archive(
-    name = "bazel_federation",
-    sha256 = "506dfbfd74ade486ac077113f48d16835fdf6e343e1d4741552b450cfc2efb53",
-    url = "https://github.com/bazelbuild/bazel-federation/releases/download/0.0.1/bazel_federation-0.0.1.tar.gz",
-)
-
-load("@bazel_federation//:repositories.bzl", "rules_python_deps")
-
-rules_python_deps()
-
-load("@bazel_federation//setup:rules_python.bzl", "rules_python_setup")
-
-rules_python_setup(use_pip = True)
+pip_repositories()
 
 # Everything below this line is used only for developing rules_python. Users
 # should not copy it to their WORKSPACE.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,34 +1,117 @@
 """Dependencies that are needed for rules_python tests and tools."""
 
-load("@bazel_federation//:repositories.bzl", "bazel_stardoc", "rules_pkg")
-load("@bazel_federation//:third_party_repositories.bzl", "futures_2_whl", "futures_3_whl", "google_cloud_language_whl", "grpc_whl", "mock_whl", "subpar")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@rules_python//python:pip.bzl", "pip_import")
 
 def rules_python_internal_deps():
     """Fetches all required dependencies for rules_python tests and tools."""
-    bazel_stardoc()
 
-    subpar()
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        strip_prefix = "bazel-skylib-1.0.2",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.zip",
+        type = "zip",
+        sha256 = "64ad2728ccdd2044216e4cec7815918b7bb3bb28c95b7e9d951f9d4eccb07625",
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_pkg",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+        ],
+        sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
+    )
+
+    maybe(
+        http_archive,
+        name = "io_bazel_skydoc",
+        url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
+        sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
+        strip_prefix = "skydoc-0.3.0",
+    )
 
     # Test data for WHL tool testing.
-    futures_2_whl()
-    futures_3_whl()
-    google_cloud_language_whl()
-    grpc_whl()
-    mock_whl()
+    maybe(
+        http_file,
+        name = "futures_2_2_0_whl",
+        downloaded_file_path = "futures-2.2.0-py2.py3-none-any.whl",
+        sha256 = "9fd22b354a4c4755ad8c7d161d93f5026aca4cfe999bd2e53168f14765c02cd6",
+        # From https://pypi.python.org/pypi/futures/2.2.0
+        urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
+            "https://pypi.python.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
+        ],
+    )
 
-    piptool()
-    examples()
+    maybe(
+        http_file,
+        name = "futures_3_1_1_whl",
+        downloaded_file_path = "futures-3.1.1-py2-none-any.whl",
+        sha256 = "c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
+        # From https://pypi.python.org/pypi/futures
+        urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
+            "https://pypi.python.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
+        ],
+    )
 
-    # For packaging and distribution
-    rules_pkg()
+    maybe(
+        http_file,
+        name = "google_cloud_language_whl",
+        downloaded_file_path = "google_cloud_language-0.29.0-py2.py3-none-any.whl",
+        sha256 = "a2dd34f0a0ebf5705dcbe34bd41199b1d0a55c4597d38ed045bd183361a561e9",
+        # From https://pypi.python.org/pypi/google-cloud-language
+        urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
+            "https://pypi.python.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
+        ],
+    )
 
-def piptool():
-    """Fetches all required dependencies for pip."""
-    pip_import(
+    maybe(
+        http_file,
+        name = "grpc_whl",
+        downloaded_file_path = "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
+        sha256 = "c232d6d168cb582e5eba8e1c0da8d64b54b041dd5ea194895a2fe76050916561",
+        # From https://pypi.python.org/pypi/grpcio/1.6.0
+        urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
+            "https://pypi.python.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
+        ],
+    )
+
+    maybe(
+        http_file,
+        name = "mock_whl",
+        downloaded_file_path = "mock-2.0.0-py2.py3-none-any.whl",
+        sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+        # From https://pypi.python.org/pypi/mock
+        urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
+            "https://pypi.python.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
+        ],
+    )
+
+    maybe(
+        git_repository,
+        name = "subpar",
+        remote = "https://github.com/google/subpar",
+        # tag = "2.0.0",
+        commit = "35bb9f0092f71ea56b742a520602da9b3638a24f",
+        shallow_since = "1557863961 -0400",
+    )
+
+    maybe(
+        pip_import,
         name = "piptool_deps",
         requirements = "@rules_python//python:requirements.txt",
     )
+
+    examples()
 
 def examples():
     """Fetches all required dependencies for rules_python examples."""


### PR DESCRIPTION
It's currently a stalled project so it's not useful for us to direct new users there in our README.
Separately it is harder to develop on rules_python since it is currently not self-contained.
For example it's hard to find or adjust the version of rules_pkg without looking/editing in the federation repo.

Tony says this is an okay change: https://github.com/bazelbuild/bazel-federation/commit/63f9746afd4e8564d1033c529ce5065f69d6c7f9#commitcomment-40577834
