### PR TITLE
rules_python_external: fill missing docstrings

### DIFF
--- a/experimental/rules_python_external/defs.bzl
+++ b/experimental/rules_python_external/defs.bzl
@@ -98,9 +98,78 @@ python_interpreter.
         "wheel_env": attr.string_dict(),
     },
     implementation = _pip_repository_impl,
+    doc = """A rule for importing `requirements.txt` dependencies into Bazel.
+
+This rule imports a `requirements.txt` file and generates a new
+`requirements.bzl` file.  This is used via the `WORKSPACE` pattern:
+
+```python
+pip_repository(
+    name = "foo",
+    requirements = ":requirements.txt",
+)
+```
+
+You can then reference imported dependencies from your `BUILD` file with:
+
+```python
+load("@foo//:requirements.bzl", "requirement")
+py_library(
+    name = "bar",
+    ...
+    deps = [
+       "//my/other:dep",
+       requirement("requests"),
+       requirement("numpy"),
+    ],
+)
+```
+
+Or alternatively:
+```python
+load("@foo//:requirements.bzl", "all_requirements")
+py_binary(
+    name = "baz",
+    ...
+    deps = [
+       ":foo",
+    ] + all_requirements,
+)
+```
+""",
 )
 
 def pip_install(requirements, name = DEFAULT_REPOSITORY_NAME, **kwargs):
+    """Imports a `requirements.txt` file and generates a new `requirements.bzl` file.
+
+    This is used via the `WORKSPACE` pattern:
+
+    ```python
+    pip_install(
+        requirements = ":requirements.txt",
+    )
+    ```
+
+    You can then reference imported dependencies from your `BUILD` file with:
+
+    ```python
+    load("@pip//:requirements.bzl", "requirement")
+    py_library(
+        name = "bar",
+        ...
+        deps = [
+           "//my/other:dep",
+           requirement("requests"),
+           requirement("numpy"),
+        ],
+    )
+    ```
+
+    Args:
+      requirements: A 'requirements.txt' pip requirements file.
+      name: A unique name for the created external repository (default 'pip').
+      **kwargs: Keyword arguments passed directly to the `pip_repository` repository rule.
+    """
     pip_repository(
         name = name,
         requirements = requirements,

--- a/experimental/rules_python_external/defs.bzl
+++ b/experimental/rules_python_external/defs.bzl
@@ -91,10 +91,20 @@ use this attribute to specify its BUILD target. This allows pip_repository to in
 pip using the same interpreter as your toolchain. If set, takes precedence over
 python_interpreter.
 """),
-        "quiet": attr.bool(default = True),
-        "requirements": attr.label(allow_single_file = True, mandatory = True),
+        "quiet": attr.bool(
+            default = True,
+            doc = "If True, suppress printing stdout and stderr output to the terminal.",
+        ),
+        "requirements": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "A 'requirements.txt' pip requirements file."
+        ),
         # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
-        "timeout": attr.int(default = 600),
+        "timeout": attr.int(
+            default = 600,
+            doc = "Timeout (in seconds) on the rule's execution duration.",
+        ),
     },
     implementation = _pip_repository_impl,
     doc = """A rule for importing `requirements.txt` dependencies into Bazel.

--- a/experimental/rules_python_external/defs.bzl
+++ b/experimental/rules_python_external/defs.bzl
@@ -95,7 +95,6 @@ python_interpreter.
         "requirements": attr.label(allow_single_file = True, mandatory = True),
         # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
         "timeout": attr.int(default = 600),
-        "wheel_env": attr.string_dict(),
     },
     implementation = _pip_repository_impl,
     doc = """A rule for importing `requirements.txt` dependencies into Bazel.

--- a/experimental/rules_python_external/defs.bzl
+++ b/experimental/rules_python_external/defs.bzl
@@ -98,7 +98,7 @@ python_interpreter.
         "requirements": attr.label(
             allow_single_file = True,
             mandatory = True,
-            doc = "A 'requirements.txt' pip requirements file."
+            doc = "A 'requirements.txt' pip requirements file.",
         ),
         # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
         "timeout": attr.int(

--- a/experimental/rules_python_external/repositories.bzl
+++ b/experimental/rules_python_external/repositories.bzl
@@ -45,7 +45,7 @@ py_library(
 all_requirements = [name for (name, _, _) in _RULE_DEPS]
 
 def requirement(pkg):
-    return "@pypi__"+ pkg + "//:lib"
+    return "@pypi__" + pkg + "//:lib"
 
 def rules_python_external_dependencies():
     """
@@ -55,8 +55,8 @@ def rules_python_external_dependencies():
         maybe(
             http_archive,
             name,
-            url=url,
-            sha256=sha256,
-            type="zip",
-            build_file_content=_GENERIC_WHEEL,
+            url = url,
+            sha256 = sha256,
+            type = "zip",
+            build_file_content = _GENERIC_WHEEL,
         )

--- a/experimental/rules_python_external/repositories.bzl
+++ b/experimental/rules_python_external/repositories.bzl
@@ -48,6 +48,9 @@ def requirement(pkg):
     return "@pypi__"+ pkg + "//:lib"
 
 def rules_python_external_dependencies():
+    """
+    Fetch dependencies these rules depend on. Workspaces that use the rules_python_external should call this.
+    """
     for (name, url, sha256) in _RULE_DEPS:
         maybe(
             http_archive,


### PR DESCRIPTION
## Description 

Adding missing docstrings for `experimental/rules_python_external`. Does not add new rules into Stardoc yet. That will be a subsequent pull request.

### Plan 🛣

Our plan is in multiple steps:
- ~bring in the repo to a subdirectory, preserving git history and contributors~
- ~clean up the code, remove mypy, get it functional in that subdirectory~
- ~add an example/integration test proving that it works~
- ~cut a patch release and get some users to test it out~
- communicate our deprecation plan to rules_python users
- **fill in any missing docstrings and include new rules in stardoc** ← **PR is doing part one of this**
- BIG SWITCH: move the rules_python_external implementation to the root, make a legacy/ directory for current impl
- cut a breaking release (a minor, since semver starting with 0. states that minors are breaking)
- help users switch over
- in a later breaking release, actually remove the old implementation


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


