### PR TITLE
Remove py_repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ http_archive(
     strip_prefix = "rules_python-{}".format(rules_python_version),
     url = "https://github.com/bazelbuild/rules_python/archive/{}.zip".format(rules_python_version),
 )
-
-# Then load and call py_repositories() as
-# above.
 ```
 
 Once you've imported the rule set into your `WORKSPACE` using any of these

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -28,7 +28,6 @@ pkg_tar(
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
-    deps_method = "py_repositories",
     repo = "rules_python",
     setup_file = "python:repositories.bzl",
     version = version,

--- a/examples/pip_install/WORKSPACE
+++ b/examples/pip_install/WORKSPACE
@@ -8,10 +8,6 @@ http_archive(
     sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
 )
 
-load("@rules_python//python:repositories.bzl", "py_repositories")
-
-py_repositories()
-
 load("@rules_python//python:pip.bzl", "pip_install")
 
 pip_install(

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -4,10 +4,5 @@ For historic reasons, pip_repositories() is defined in //python:pip.bzl.
 """
 
 def py_repositories():
-    """Pull in dependencies needed to use the core Python rules."""
-
-    # At the moment this is a placeholder hook, in that it does not actually
-    # pull in any dependencies. Users should still call this function to make
-    # it less likely that they need to update their WORKSPACE files, in case
-    # this function is changed in the future.
-    pass
+    # buildifier: disable=print
+    print("py_repositories is a no-op and is deprecated. You can remove this from your WORKSPACE file")


### PR DESCRIPTION
This adds useless setup code to a users WORKSPACE file.

The idea that we could add some transitive WORKSPACE dependencies is flawed without a working support for this in Bazel. Anything we add in that function later is a breaking change for users, in that they might call our py_repositories() before fetching rules_xx, and we already installed an incompatible rules_xx.

Since adding anything here is a breaking change, we can always put it back later as a breaking change to the rules.

However I would argue strongly that rules_python is too core in the dependency chain for it to *ever* grow transitive dependencies. Like rules_nodejs we should either vendor code we need privately or strip development-only dependencies from our distribution, and never suggest that users call a rules_python function that installs other starlark code.
