### PR TITLE
Remove commentary indicating that 'all_requirements' is deprecated

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -64,7 +64,7 @@ def generate_requirements_file_contents(repo_name: str, targets: Iterable[str]) 
     """Generate a requirements.bzl file for a given pip repository
 
     The file allows converting the PyPI name to a bazel label. Additionally, it adds a function which can glob all the
-    installed dependencies. This is provided for legacy reasons and can be considered deprecated.
+    installed dependencies.
 
     Args:
         repo_name: the name of the pip repository
@@ -76,7 +76,6 @@ def generate_requirements_file_contents(repo_name: str, targets: Iterable[str]) 
 
     return textwrap.dedent(
         """\
-        # Deprecated. This will be removed in a future release
         all_requirements = [{requirement_labels}]
 
         def requirement(name):


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_python/issues/375. 

From looking at the `git blame`, this commentary was introduced when https://github.com/dillon-giacoppo/rules_python_external was still a WIP project. I don't think the commentary reflects any current active intent of the maintainers to remove `all_requirements`. 

cc'ing @dillon-giacoppo to possibly learn original intent of deprecation. 
cc'ing @person142, issue #375 creator. 

-----

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: https://github.com/bazelbuild/rules_python/issues/375

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


