### PR TITLE
Add `all_whl_requirements` to match `all_requirements`

### DIFF
--- a/python/pip_install/README.md
+++ b/python/pip_install/README.md
@@ -64,7 +64,12 @@ pip_install(
 #### Example `BUILD` file.
 
 ```python
-load("@py_deps//:requirements.bzl", "requirement", "whl_requirement")
+load(
+    "@py_deps//:requirements.bzl",
+    "requirement",
+    "whl_requirement",
+    "all_whl_requirements",
+)
 
 py_binary(
     name = "main",
@@ -81,6 +86,13 @@ filegroup(
     data = [
         whl_requirement("boto3"),
     ]
+)
+
+# If you need all of the wheels, say to upload them to your own
+# private wheelhouse, you can use all_whl_requirements.
+filegroup(
+    name = "all_whls",
+    data = all_whl_requirements,
 )
 ```
 

--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -54,6 +54,17 @@ py_test(
     data = ["//experimental/examples/wheel:minimal_with_py_package"]
 )
 
+py_test(
+    name = "requirements_bzl_test",
+    size = "small",
+    srcs = [
+        "requirements_bzl_test.py",
+    ],
+    deps = [
+        ":lib",
+    ],
+)
+
 filegroup(
     name = "distribution",
     srcs = glob(

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -83,11 +83,11 @@ def generate_requirements_file_contents(repo_name: str, targets: Iterable[str]) 
         """\
         all_requirements = [{requirement_labels}]
 
+        all_whl_requirements = [{whl_requirement_labels}]
+
         def requirement(name):
            name_key = name.replace("-", "_").replace(".", "_").lower()
            return "{repo}//pypi__" + name_key
-
-        all_whl_requirements = [{whl_requirement_labels}]
 
         def whl_requirement(name):
             return requirement(name) + ":whl"

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -74,6 +74,11 @@ def generate_requirements_file_contents(repo_name: str, targets: Iterable[str]) 
         A complete requirements.bzl file as a string
     """
 
+    sorted_targets = sorted(targets)
+    requirement_labels = ",".join(sorted_targets)
+    whl_requirement_labels = ",".join(
+        '"{}:whl"'.format(target.strip('"')) for target in sorted_targets
+    )
     return textwrap.dedent(
         """\
         all_requirements = [{requirement_labels}]
@@ -82,10 +87,14 @@ def generate_requirements_file_contents(repo_name: str, targets: Iterable[str]) 
            name_key = name.replace("-", "_").replace(".", "_").lower()
            return "{repo}//pypi__" + name_key
 
+        all_whl_requirements = [{whl_requirement_labels}]
+
         def whl_requirement(name):
             return requirement(name) + ":whl"
         """.format(
-            repo=repo_name, requirement_labels=",".join(sorted(targets))
+            repo=repo_name,
+            requirement_labels=requirement_labels,
+            whl_requirement_labels=whl_requirement_labels,
         )
     )
 

--- a/python/pip_install/extract_wheels/lib/requirements_bzl_test.py
+++ b/python/pip_install/extract_wheels/lib/requirements_bzl_test.py
@@ -1,0 +1,17 @@
+import unittest
+
+from python.pip_install.extract_wheels.lib import bazel
+
+
+class TestGenerateRequirementsFileContents(unittest.TestCase):
+    def test_all_wheel_requirements(self) -> None:
+        contents = bazel.generate_requirements_file_contents(
+            repo_name='test',
+            targets=['"@test//pypi__pkg1"', '"@test//pypi__pkg2"'],
+        )
+        expected = 'all_whl_requirements = ["@test//pypi__pkg1:whl","@test//pypi__pkg2:whl"]'
+        self.assertIn(expected, contents)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
There isn't an equivalent to `all_requirements` for `whl_requirement`.

## What is the new behavior?
A list `all_whl_requirements` is added to `requirements.bzl` which contains all of the wheel targets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
The `all_whl_requirements` list is handy if you want to write a target that takes all of the wheels built by `rules_python` and upload them to a private wheelhouse say.