### PR TITLE
Adds the "Requires-Python" metadata support. Fixes #378

### DIFF
--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -156,5 +156,6 @@ py_test(
         ":customized",
         ":minimal_with_py_library",
         ":minimal_with_py_package",
+        ":python_requires_in_a_package"
     ],
 )

--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -135,6 +135,17 @@ py_wheel(
     ],
 )
 
+py_wheel(
+    name = "python_requires_in_a_package",
+    distribution = "example_python_requires_in_a_package",
+    python_tag = "py3",
+    python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    version = "0.0.1",
+    deps = [
+        ":example_pkg",
+    ],
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -70,7 +70,8 @@ class WheelTest(unittest.TestCase):
                 'example_customized-0.0.1.dist-info/WHEEL')
             metadata_contents = zf.read(
                 'example_customized-0.0.1.dist-info/METADATA')
-            entry_point_contents = zf.read('example_customized-0.0.1.dist-info/entry_points.txt')
+            entry_point_contents = zf.read(
+                'example_customized-0.0.1.dist-info/entry_points.txt')
             # The entries are guaranteed to be sorted.
             self.assertEquals(record_contents, b"""\
 example_customized-0.0.1.dist-info/METADATA,sha256=TeeEmokHE2NWjkaMcVJuSAq4_AXUoIad2-SLuquRmbg,372
@@ -161,6 +162,24 @@ second = second.main:s""")
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/WHEEL',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/METADATA',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/RECORD'])
+
+    def test_python_requires_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'rules_python', 'experimental',
+                                'examples', 'wheel',
+                                'example_python_requires_in_a_package-0.0.1-py3-none-any.whl')
+        with zipfile.ZipFile(filename) as zf:
+            metadata_contents = zf.read(
+                'example_python_requires_in_a_package-0.0.1.dist-info/METADATA')
+            # The entries are guaranteed to be sorted.
+            self.assertEquals(metadata_contents, b"""\
+Metadata-Version: 2.1
+Name: example_python_requires_in_a_package
+Version: 0.0.1
+Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+
+UNKNOWN
+""")
 
 
 if __name__ == '__main__':

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -110,6 +110,7 @@ def _py_wheel_impl(ctx):
     args.add("--name", ctx.attr.distribution)
     args.add("--version", ctx.attr.version)
     args.add("--python_tag", ctx.attr.python_tag)
+    args.add("--python_requires", ctx.attr.python_requires)
     args.add("--abi", ctx.attr.abi)
     args.add("--platform", ctx.attr.platform)
     args.add("--out", outfile.path)
@@ -249,6 +250,7 @@ _other_attrs = {
     "description_file": attr.label(allow_single_file = True),
     "homepage": attr.string(default = ""),
     "license": attr.string(default = ""),
+    "python_requires": attr.string(default = ""),
     "strip_path_prefixes": attr.string_list(
         default = [],
         doc = "path prefixes to strip from files added to the generated package",

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -129,8 +129,8 @@ Root-Is-Purelib: true
             wheel_contents += "Tag: %s\n" % tag
         self.add_string(self.distinfo_path('WHEEL'), wheel_contents)
 
-    def add_metadata(self, extra_headers, description, classifiers, requires,
-                     extra_requires):
+    def add_metadata(self, extra_headers, description, classifiers, python_requires,
+                     requires, extra_requires):
         """Write METADATA file to the distribution."""
         # https://www.python.org/dev/peps/pep-0566/
         # https://packaging.python.org/specifications/core-metadata/
@@ -141,6 +141,7 @@ Root-Is-Purelib: true
         metadata.extend(extra_headers)
         for classifier in classifiers:
             metadata.append("Classifier: %s" % classifier)
+        metadata.append("Requires-Python: %s" % python_requires)
         for requirement in requires:
             metadata.append("Requires-Dist: %s" % requirement)
 
@@ -225,6 +226,8 @@ def main():
     wheel_group.add_argument('--classifier', action='append',
                              help="Classifiers to embed in package metadata. "
                                   "Can be supplied multiple times")
+    wheel_group.add_argument('--python_requires',
+                             help="Version of python that the wheel will work with")
     wheel_group.add_argument('--description_file',
                              help="Path to the file with package description")
     wheel_group.add_argument('--entry_points_file',
@@ -302,17 +305,20 @@ def main():
                 req, option = extra.rsplit(';', 1)
                 extra_requires[option].append(req)
         classifiers = arguments.classifier or []
+        python_requires = arguments.python_requires or ""
         requires = arguments.requires or []
         extra_headers = arguments.header or []
 
         maker.add_metadata(extra_headers=extra_headers,
                            description=description,
                            classifiers=classifiers,
+                           python_requires=python_requires,
                            requires=requires,
                            extra_requires=extra_requires)
 
         if arguments.entry_points_file:
-            maker.add_file(maker.distinfo_path("entry_points.txt"), arguments.entry_points_file)
+            maker.add_file(maker.distinfo_path(
+                "entry_points.txt"), arguments.entry_points_file)
 
         maker.add_recordfile()
 

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -141,7 +141,8 @@ Root-Is-Purelib: true
         metadata.extend(extra_headers)
         for classifier in classifiers:
             metadata.append("Classifier: %s" % classifier)
-        metadata.append("Requires-Python: %s" % python_requires)
+        if python_requires:
+            metadata.append("Requires-Python: %s" % python_requires)
         for requirement in requires:
             metadata.append("Requires-Dist: %s" % requirement)
 


### PR DESCRIPTION
This adds support for allowing people to specify which versions
of python a wheel should run on. This was added in PEP 440

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

This adds support for PEP 440 to wheels

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #378


## What is the new behavior?

Allows people to specify which versions of python a wheel can support.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

