### PR TITLE
support binary wheels

### DIFF
--- a/experimental/examples/wheel/BUILD
+++ b/experimental/examples/wheel/BUILD
@@ -146,6 +146,16 @@ py_wheel(
     ],
 )
 
+py_wheel(
+    name = "python_abi3_binary_wheel",
+    abi = "abi3",
+    distribution = "example_python_abi3_binary_wheel",
+    platform = "manylinux2014_x86_64",
+    python_requires = ">=3.8",
+    python_tag = "cp38",
+    version = "0.0.1",
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],
@@ -156,6 +166,7 @@ py_test(
         ":customized",
         ":minimal_with_py_library",
         ":minimal_with_py_package",
-        ":python_requires_in_a_package"
+        ":python_abi3_binary_wheel",
+        ":python_requires_in_a_package",
     ],
 )

--- a/experimental/examples/wheel/wheel_test.py
+++ b/experimental/examples/wheel/wheel_test.py
@@ -181,6 +181,44 @@ Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 UNKNOWN
 """)
 
+    def test_python_abi3_binary_wheel(self):
+        filename = os.path.join(
+            os.environ["TEST_SRCDIR"],
+            "rules_python",
+            "experimental",
+            "examples",
+            "wheel",
+            "example_python_abi3_binary_wheel-0.0.1-cp38-abi3-manylinux2014_x86_64.whl",
+        )
+        with zipfile.ZipFile(filename) as zf:
+            metadata_contents = zf.read(
+                "example_python_abi3_binary_wheel-0.0.1.dist-info/METADATA"
+            )
+            # The entries are guaranteed to be sorted.
+            self.assertEqual(
+                metadata_contents,
+                b"""\
+Metadata-Version: 2.1
+Name: example_python_abi3_binary_wheel
+Version: 0.0.1
+Requires-Python: >=3.8
+
+UNKNOWN
+""",
+            )
+            wheel_contents = zf.read(
+                "example_python_abi3_binary_wheel-0.0.1.dist-info/WHEEL"
+            )
+            self.assertEqual(
+                wheel_contents,
+                b"""\
+Wheel-Version: 1.0
+Generator: bazel-wheelmaker 1.0
+Root-Is-Purelib: false
+Tag: cp38-abi3-manylinux2014_x86_64
+""",
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -203,15 +203,13 @@ This should match the project name onm PyPI. It's also the name that is used to
 refer to the package in other packages' dependencies.
 """,
     ),
-    # TODO(pstradomski): Support non-pure wheels
     "platform": attr.string(
         default = "any",
         doc = "Supported platforms. 'any' for pure-Python wheel.",
     ),
     "python_tag": attr.string(
         default = "py3",
-        doc = "Supported Python major version. 'py2' or 'py3'",
-        values = ["py2", "py3"],
+        doc = "Supported Python version(s), eg 'py3', 'cp35.cp36', etc",
     ),
     "version": attr.string(
         mandatory = True,

--- a/experimental/python/wheel.bzl
+++ b/experimental/python/wheel.bzl
@@ -205,7 +205,21 @@ refer to the package in other packages' dependencies.
     ),
     "platform": attr.string(
         default = "any",
-        doc = "Supported platforms. 'any' for pure-Python wheel.",
+        doc = """\
+Supported platform. Use 'any' for pure-Python wheel.
+
+If you have included platform-specific data, such as a .pyd or .so
+extension module, you will need to specify the platform in standard
+pip format. If you support multiple platforms, you can define
+platform constraints, then use a select() to specify the appropriate
+specifier, eg:
+
+    platform = select({
+        "//platforms:windows_x86_64": "win_amd64",
+        "//platforms:macos_x86_64": "macosx_10_7_x86_64",
+        "//platforms:linux_x86_64": "manylinux2014_x86_64",
+    })
+""",
     ),
     "python_tag": attr.string(
         default = "py3",

--- a/experimental/tools/wheelmaker.py
+++ b/experimental/tools/wheelmaker.py
@@ -123,8 +123,8 @@ class WheelMaker(object):
         wheel_contents = """\
 Wheel-Version: 1.0
 Generator: bazel-wheelmaker 1.0
-Root-Is-Purelib: true
-"""
+Root-Is-Purelib: {}
+""".format("true" if self._platform == "any" else "false")
         for tag in self.disttags():
             wheel_contents += "Tag: %s\n" % tag
         self.add_string(self.distinfo_path('WHEEL'), wheel_contents)
@@ -254,9 +254,6 @@ def main():
         help="List of optional requirements in a 'requirement;option name'. "
              "Can be supplied multiple times.")
     arguments = parser.parse_args(sys.argv[1:])
-
-    # add_wheelfile and add_metadata currently assume pure-Python.
-    assert arguments.platform == 'any', "Only pure-Python wheels are supported"
 
     if arguments.input_file:
         input_files = [i.split(';') for i in arguments.input_file]


### PR DESCRIPTION
Also allow other Python tag specifiers like cp35, as binary wheels
typically list their required Python versions in the filename.

Was successfully able to upload a binary wheel created with this to PyPI,
and install it with pip.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the code refuses to build a binary wheel.

Issue Number: N/A


## What is the new behavior?

It accepts platforms other than 'any'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

