### PR TITLE
Upgrading rules_pkg broke //distro:relnotes. Fix target by removing 'setup_file' as it's a no-op now

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -29,6 +29,5 @@ print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
     repo = "rules_python",
-    setup_file = "python:repositories.bzl",
     version = version,
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

Fix for release related workspace target.


## What is the current behavior?

```bash
bazel build //distro:relnotes --sandbox_debug
INFO: Analyzed target //distro:relnotes (2 packages loaded, 14 targets configured).
INFO: Found 1 target...
ERROR: /Users/jonathon/work/rules_python/distro/BUILD:28:16: Executing genrule //distro:relnotes failed (Exit 1) sandbox-exec failed: error executing command
  (cd /private/var/tmp/_bazel_jonathon/29bb5d8ab2ff174b67c235f3ce7964dd/sandbox/darwin-sandbox/8/execroot/rules_python && \
  exec env - \
    PATH=/Users/jonathon/Library/Caches/bazelisk/downloads/bazelbuild/bazel-3.3.1-darwin-x86_64/bin:/Users/jonathon/.nix-profile/bin:/usr/local/opt/scala@2.11/bin:/Users/jonathon/.yarn/bin:/Users/jonathon/.config/yarn/global/node_modules/.bin:/Users/jonathon/.cargo/bin:/Users/jonathon/bin:/Users/jonathon/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/jonathon/go/bin:/usr/local/opt/go/libexec/bin:/Users/jonathon/.rvm/bin \
    TMPDIR=/var/folders/nd/gpn3vrt9793bpr1c_x0wy7kr0000gn/T/ \
  /usr/bin/sandbox-exec -f /private/var/tmp/_bazel_jonathon/29bb5d8ab2ff174b67c235f3ce7964dd/sandbox/darwin-sandbox/8/sandbox.sb /var/tmp/_bazel_jonathon/install/e74efe234cbfbe8b17b6baeb8c33e7ff/process-wrapper '--timeout=0' '--kill_delay=15' /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; bazel-out/host/bin/external/rules_pkg/releasing/print_rel_notes --repo=rules_python --version=0.1.0 --tarball=bazel-out/darwin-fastbuild/bin/distro/rules_python-0.1.0.tar.gz --setup_file=python:repositories.bzl >bazel-out/darwin-fastbuild/bin/distro/relnotes.txt')
setup_file can only be set if at least one of (deps_method, toolchains_method) is set.
Target //distro:relnotes failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.314s, Critical Path: 1.13s
INFO: 1 process: 1 darwin-sandbox.
FAILED: Build did NOT complete successfully
```


## What is the new behavior?

Commit 5be1f76e3ecd1f743f4213f3087c2a0961411782 upgraded `rules_pkg` and broke `//distro:relnotes` (checked with `git bisect`). The same commit made the use of `setup_file` in the broken target unnecessary, so the fix is to just remove it.

```
bazel build //distro:relnotes --sandbox_debug
INFO: Analyzed target //distro:relnotes (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //distro:relnotes up-to-date:
  bazel-bin/distro/relnotes.txt
INFO: Elapsed time: 0.111s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
```

Producing... 

```bash
cat bazel-bin/distro/relnotes.txt
------------------------ snip ----------------------------
**New Features**

**Incompatible Changes**

**WORKSPACE setup**

\```
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "rules_python",
    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
    sha256 = "a95cc0980de136b777f4e3b1a9e6d2ad8e725b5cd9816352922d427d7f9394f7",
)
\```

**Using the rules**

See [the source](https://github.com/bazelbuild/rules_python/tree/master).
------------------------ snip ----------------------------
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

