### PR TITLE
Do not show 'pip3_import' as alternative to 'pip_install' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ load("@rules_python//python:pip.bzl", "pip_install")
 
 # Create a central repo that knows about the dependencies needed for
 # requirements.txt.
-pip_install(   # or pip3_import
+pip_install(
    name = "my_deps",
    requirements = "//path/to:requirements.txt",
 )


### PR DESCRIPTION
Partially addresses https://github.com/bazelbuild/rules_python/issues/397, specifically: 

> Then I read the instructions again, tried `pip3_import`, which doesn't exist (under pip.bzl). ...

`pip3_import` is legacy now and not provided in `python/pip.bzl`, so shouldn't be commented as an alternative to `pip_install`. 

cc @dayfine

----

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

