### PR TITLE
Remove inaccuracy in README about default py interpreter used by pip_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ pip_install(
 Note that since pip is executed at WORKSPACE-evaluation time, Bazel has no
 information about the Python toolchain and cannot enforce that the interpreter
 used to invoke pip matches the interpreter used to run `py_binary` targets. By
-default, `pip_install` uses the system command `"python"`, which on most
-platforms is a Python 2 interpreter. This can be overridden by passing the
+default, `pip_install` uses the system command `"python3"`. This can be overridden by passing the
 `python_interpreter` attribute or `python_interpreter_target` attribute to `pip_install`.
 
 You can have multiple `pip_install`s in the same workspace, e.g. for Python 2


### PR DESCRIPTION
Looks like the amended sentence was no longer accurate. See https://github.com/bazelbuild/rules_python/blob/master/python/pip_install/pip_repository.bzl#L85

-------

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


