### PR TITLE
pip: 20.3.3 -> 20.3.4

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -6,8 +6,8 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 _RULE_DEPS = [
     (
         "pypi__pip",
-        "https://files.pythonhosted.org/packages/54/eb/4a3642e971f404d69d4f6fa3885559d67562801b99d7592487f1ecc4e017/pip-20.3.3-py2.py3-none-any.whl",
-        "fab098c8a1758295dd9f57413c199f23571e8fde6cc39c22c78c961b4ac6286d",
+        "https://files.pythonhosted.org/packages/27/79/8a850fe3496446ff0d584327ae44e7500daf6764ca1a382d2d02789accf7/pip-20.3.4-py2.py3-none-any.whl",
+        "217ae5161a0e08c0fb873858806e3478c9775caffce5168b50ec885e358c199d",
     ),
     (
         "pypi__pkginfo",
@@ -21,8 +21,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__wheel",
-        "https://files.pythonhosted.org/packages/c9/0b/e0fd299d93cd9331657f415085a4956422959897b333e3791dde40bd711d/wheel-0.36.1-py2.py3-none-any.whl",
-        "906864fb722c0ab5f2f9c35b2c65e3af3c009402c108a709c0aca27bc2c9187b",
+        "https://files.pythonhosted.org/packages/65/63/39d04c74222770ed1589c0eaba06c05891801219272420b40311cd60c880/wheel-0.36.2-py2.py3-none-any.whl",
+        "78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
     ),
 ]
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Updates the vendored version of pip from 20.3.3 to 20.3.4.

Notably, this is slated to be the last version of pip that will support Python 2.
https://github.com/pypa/pip/issues/8936#issuecomment-762080038

It might be prudent to prepare and tag a release of rules_python if this is merged.

I would also suggest that rules_python, at least from the `pip_install` perspective, should target Python 3 only and mention this in the README files. I understand that the Bazel rules_python, in general, will need to support Python 2 until this requirement is removed from Bazel itself (and perhaps internally at Google), but the `pip_install` elements of the rules need not support Python 2 in my opinion. It is EOL and further developments in Python packaging are not going to support Python 2 (or Python <3.5) so it might be time to start enforcing this too.

Note, there is an additional PR [here](https://github.com/groodt/rules_python/pull/1) with pip 21.0 that can be merged after this one. Which I would then consider a clean breaking change for the Python 2 vs Python 3 support for rules_python `pip_install`. In the same way that pip supports Python 2 with `pip<21` it would be possible to point users at a commit or version of rules_python `pip_install` that does work with Python 2 if they need it. 

I suspect my recommendation is overly cautious, I suspect the number of users that are using rules_python (for external pip dependencies) and Python 2 to be 0 or vanishingly close to 0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This PR would not be introducing a breaking change, the breaking change is in the follow-up PR that introduces pip 21.0

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

