### PR TITLE
feat: multi-package distributions with py_wheel

### DIFF
--- a/examples/multi_package/BUILD
+++ b/examples/multi_package/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:packaging.bzl", "py_wheel", "py_package")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_package(
+    name = "multi_package_example_pkg",
+    packages = [
+        "examples.multi_package.bar",
+        "examples.multi_package.foo",
+    ],
+    deps = [
+        "//examples/multi_package/bar",
+        "//examples/multi_package/foo",
+    ],
+)
+
+py_wheel(
+    name = "multi_package_example",
+    # Package data. We're building "example_multi_package-0.0.1-py3-none-any.whl".
+    distribution = "example_multi_package",
+    python_tag = "py3",
+    strip_path_prefixes = [
+        "examples/multi_package",
+    ],
+    version = "0.0.1",
+    deps = [":multi_package_example_pkg"],
+    packages = [
+        "bar",
+        "foo",
+    ],
+)

--- a/examples/multi_package/bar/BUILD
+++ b/examples/multi_package/bar/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_library(
+    name = "bar",
+    srcs = ["__init__.py"],
+)

--- a/examples/multi_package/bar/__init__.py
+++ b/examples/multi_package/bar/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Bar:
+    def bar(self):
+        return 'bar'

--- a/examples/multi_package/foo/BUILD
+++ b/examples/multi_package/foo/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_library(
+    name = "foo",
+    srcs = ["__init__.py"],
+)

--- a/examples/multi_package/foo/__init__.py
+++ b/examples/multi_package/foo/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Foo:
+    def foo(self):
+        return 'foo'

--- a/examples/multi_package/tests/BUILD
+++ b/examples/multi_package/tests/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:defs.bzl", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_test(
+    name = "multi_package_test",
+    srcs = ["multi_package_test.py"],
+    data = [
+        "//examples/multi_package:multi_package_example",
+        "py_wheel_assert_test.py",
+    ],
+)

--- a/examples/multi_package/tests/multi_package_test.py
+++ b/examples/multi_package/tests/multi_package_test.py
@@ -1,0 +1,53 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+class WheelTest(unittest.TestCase):
+    def test_py_wheel(self):
+        whl = os.path.join(
+            os.environ["TEST_SRCDIR"],
+            "rules_python",
+            "examples",
+            "multi_package",
+            "example_multi_package-0.0.1-py3-none-any.whl")
+
+        env = {
+            "PYTHONUSERBASE": os.environ["TEST_SRCDIR"],
+        }
+        subprocess.run(
+            [sys.executable, "-m", "pip", "--no-cache-dir", "--isolated",
+                "install", "--user", whl],
+            env=env,
+            check=True)
+
+        assert_script = os.path.join(
+            os.environ["TEST_SRCDIR"],
+            "rules_python",
+            "examples",
+            "multi_package",
+            "tests",
+            "py_wheel_assert_test.py")
+        subprocess.run(
+            [sys.executable, assert_script],
+            env=env,
+            check=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/multi_package/tests/py_wheel_assert_test.py
+++ b/examples/multi_package/tests/py_wheel_assert_test.py
@@ -1,0 +1,34 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is executed at runtime during test to assert the installed multi_package distribution
+# works as expected.
+
+import foo
+import bar
+
+
+def main():
+    print("instantiating Foo")
+    f = foo.Foo()
+    print("asserting foo()")
+    assert(f.foo() == 'foo')
+    print("instantiating Bar")
+    b = bar.Bar()
+    print("asserting bar()")
+    assert(b.bar() == 'bar')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -30,6 +30,7 @@ class WheelTest(unittest.TestCase):
                  'examples/wheel/lib/simple_module.py',
                  'example_minimal_library-0.0.1.dist-info/WHEEL',
                  'example_minimal_library-0.0.1.dist-info/METADATA',
+                 'example_minimal_library-0.0.1.dist-info/top_level.txt',
                  'example_minimal_library-0.0.1.dist-info/RECORD'])
 
     def test_py_package_wheel(self):
@@ -46,6 +47,7 @@ class WheelTest(unittest.TestCase):
                  'examples/wheel/main.py',
                  'example_minimal_package-0.0.1.dist-info/WHEEL',
                  'example_minimal_package-0.0.1.dist-info/METADATA',
+                 'example_minimal_package-0.0.1.dist-info/top_level.txt',
                  'example_minimal_package-0.0.1.dist-info/RECORD'])
 
     def test_customized_wheel(self):
@@ -62,6 +64,7 @@ class WheelTest(unittest.TestCase):
                  'examples/wheel/main.py',
                  'example_customized-0.0.1.dist-info/WHEEL',
                  'example_customized-0.0.1.dist-info/METADATA',
+                 'example_customized-0.0.1.dist-info/top_level.txt',
                  'example_customized-0.0.1.dist-info/entry_points.txt',
                  'example_customized-0.0.1.dist-info/RECORD'])
             record_contents = zf.read(
@@ -72,12 +75,15 @@ class WheelTest(unittest.TestCase):
                 'example_customized-0.0.1.dist-info/METADATA')
             entry_point_contents = zf.read(
                 'example_customized-0.0.1.dist-info/entry_points.txt')
+            top_level_contents = zf.read(
+                'example_customized-0.0.1.dist-info/top_level.txt')
             # The entries are guaranteed to be sorted.
             self.assertEquals(record_contents, b"""\
 example_customized-0.0.1.dist-info/METADATA,sha256=TeeEmokHE2NWjkaMcVJuSAq4_AXUoIad2-SLuquRmbg,372
 example_customized-0.0.1.dist-info/RECORD,,
 example_customized-0.0.1.dist-info/WHEEL,sha256=sobxWSyDDkdg_rinUth-jxhXHqoNqlmNMJY3aTZn2Us,91
 example_customized-0.0.1.dist-info/entry_points.txt,sha256=pqzpbQ8MMorrJ3Jp0ntmpZcuvfByyqzMXXi2UujuXD0,137
+example_customized-0.0.1.dist-info/top_level.txt,sha256=bSdkmtzI11orugV-QWgeMd4T6_4z-QdKZ6LEY-FdDkY,18
 examples/wheel/lib/data.txt,sha256=9vJKEdfLu8bZRArKLroPZJh1XKkK3qFMXiM79MBL2Sg,12
 examples/wheel/lib/module_with_data.py,sha256=K_IGAq_CHcZX0HUyINpD1hqSKIEdCn58d9E9nhWF2EA,636
 examples/wheel/lib/simple_module.py,sha256=72-91Dm6NB_jw-7wYQt7shzdwvk5RB0LujIah8g7kr8,636
@@ -111,6 +117,8 @@ customized_wheel = examples.wheel.main:main
 [group2]
 first = first.main:f
 second = second.main:s""")
+            self.assertEquals(top_level_contents, b"""\
+example_customized""")
 
     def test_custom_package_root_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
@@ -127,6 +135,7 @@ second = second.main:s""")
                  'wheel/main.py',
                  'example_custom_package_root-0.0.1.dist-info/WHEEL',
                  'example_custom_package_root-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root-0.0.1.dist-info/top_level.txt',
                  'example_custom_package_root-0.0.1.dist-info/RECORD'])
 
     def test_custom_package_root_multi_prefix_wheel(self):
@@ -144,6 +153,7 @@ second = second.main:s""")
                  'main.py',
                  'example_custom_package_root_multi_prefix-0.0.1.dist-info/WHEEL',
                  'example_custom_package_root_multi_prefix-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root_multi_prefix-0.0.1.dist-info/top_level.txt',
                  'example_custom_package_root_multi_prefix-0.0.1.dist-info/RECORD'])
 
     def test_custom_package_root_multi_prefix_reverse_order_wheel(self):
@@ -161,6 +171,7 @@ second = second.main:s""")
                  'main.py',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/WHEEL',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/METADATA',
+                 'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/top_level.txt',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/RECORD'])
 
     def test_python_requires_wheel(self):
@@ -231,6 +242,7 @@ Tag: cp38-abi3-manylinux2014_x86_64
                  'examples/wheel/someDir/foo.py',
                  'use_genrule_with_dir_in_outs-0.0.1.dist-info/WHEEL',
                  'use_genrule_with_dir_in_outs-0.0.1.dist-info/METADATA',
+                 'use_genrule_with_dir_in_outs-0.0.1.dist-info/top_level.txt',
                  'use_genrule_with_dir_in_outs-0.0.1.dist-info/RECORD'])
 
 

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -134,6 +134,9 @@ def _py_wheel_impl(ctx):
     for c in ctx.attr.classifiers:
         args.add("--classifier", c)
 
+    for p in ctx.attr.packages:
+        args.add("--package", p)
+
     for r in ctx.attr.requires:
         args.add("--requires", r)
 
@@ -327,6 +330,11 @@ Note it's usually better to package `py_library` targets and use
 `entry_points` attribute to specify `console_scripts` than to package
 `py_binary` rules. `py_binary` targets would wrap a executable script that
 tries to locate `.runfiles` directory which is not packaged in the wheel.
+""",
+            ),
+            "packages": attr.string_list(
+                doc = """\
+A list of packages the distribution provides to be included in the top_level.txt file.
 """,
             ),
             "_wheelmaker": attr.label(

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -336,9 +336,8 @@ def main():
                            requires=requires,
                            extra_requires=extra_requires)
 
-        packages = arguments.package or []
-        if len(packages) > 0:
-            maker.add_top_level_txt(packages)
+        packages = arguments.package or [arguments.name]
+        maker.add_top_level_txt(packages)
 
         if arguments.entry_points_file:
             maker.add_file(maker.distinfo_path(

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -124,6 +124,15 @@ class WheelMaker(object):
                 size += len(block)
         self._add_to_record(arcname, self._serialize_digest(hash), size)
 
+    def add_top_level_txt(self, packages):
+        """Write top_level.txt file for the distribution"""
+        top_level_packages = set()
+        for pkg in packages:
+            top_level_packages.add(pkg)
+        top_level_packages = sorted(top_level_packages)
+        self.add_string(self.distinfo_path('top_level.txt'),
+                        "\n".join(top_level_packages))
+
     def add_wheelfile(self):
         """Write WHEEL file to the distribution"""
         # TODO(pstradomski): Support non-purelib wheels.
@@ -252,6 +261,11 @@ def main():
         help='A file that has all the input files defined as a list to avoid the long command'
     )
 
+    packages_group = parser.add_argument_group("Packages")
+    packages_group.add_argument(
+        '--package', type=str, action='append',
+        help="List of packages the distribution provides. Can be supplied multiple times.")
+
     requirements_group = parser.add_argument_group("Package requirements")
     requirements_group.add_argument(
         '--requires', type=str, action='append',
@@ -260,6 +274,7 @@ def main():
         '--extra_requires', type=str, action='append',
         help="List of optional requirements in a 'requirement;option name'. "
              "Can be supplied multiple times.")
+
     arguments = parser.parse_args(sys.argv[1:])
 
     if arguments.input_file:
@@ -320,6 +335,10 @@ def main():
                            python_requires=python_requires,
                            requires=requires,
                            extra_requires=extra_requires)
+
+        packages = arguments.package or []
+        if len(packages) > 0:
+            maker.add_top_level_txt(packages)
 
         if arguments.entry_points_file:
             maker.add_file(maker.distinfo_path(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Adds multi-package feature to `py_wheel` - it allows a distribution to contain multiple packages. Also, it writes a `top_level.txt` file with the specified packages contained in the distribution.

I added an example that serves as a test to this new feature as well. It basically contains packages `foo` and `bar` in a distribution named `example-multi-package`. The test installs the built `.whl` using `pip` and asserts that a program can import `foo` and `bar` correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

