### PR TITLE
Remove TODO: Now past Bazel 0.29 so can go back to using '...' in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,20 +1,10 @@
-# We exclude docs/ from build_targets. Since we can't blacklist specific target
-# patterns (bazelbuild/continuous-integration#779), we have to explicitly
-# list every other top-level package in build_targets.
-# TODO(#144): When Bazel 0.29 is released, the docgen workflow will work, and
-# we can go back to using `...` for build_targets.
 ---
 buildifier:
   version: latest
   warnings: "all"
 all_targets: &all_targets
     build_targets:
-    - "//examples/..."
-    - "//experimental/..."
-    - "//packaging/..."
-    - "//python/..."
-    - "//tests/..."
-    - "//tools/..."
+    - "..."
     # As a regression test for #225, check that wheel targets still build when
     # their package path is qualified with the repo name.
     - "@rules_python//examples/wheel/..."


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Description

This TODO was introduced here: https://github.com/brandjon/rules_python/commit/29260b3203fec444a4a8d17038c6ce238de86a7f

I figure this TODO is now well obsolete and we can undo it. CI should still pass, and it does. 

_Note:_ I don't know why it shouldn't just be `//...` instead of `...`. Both work in CI, but `bazel build ...` is invalid when run locally. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

cc @brandjon 
