### PR TITLE
Remove obsolete TODO in //distro

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -22,9 +22,6 @@ pkg_tar(
     visibility = ["//examples:__pkg__"],
 )
 
-# TODO(brandjon): print_rel_notes doesn't appear to handle our use case of
-# emitting an optional additional deps method from a different file. For now we
-# manually adjust our release notes.
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],


### PR DESCRIPTION
🧹 🧹 ...

Just removing a TODO we don't need anymore. We not longer use a `deps()` function to included dependencies and https://github.com/bazelbuild/rules_pkg/issues/72 shows that it's no longer a desired pattern.

----

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

----

cc @brandjon 
