### PR TITLE
Use BUILD.bazel file when creating py_library rules of extracted whls

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -27,7 +27,7 @@ def generate_build_file_contents(
     there may be no Python sources whatsoever (e.g. packages written in Cython: like `pymssql`).
     """
 
-    data_exclude = ["*.whl", "**/*.py", "**/* *", "BUILD", "WORKSPACE"] + pip_data_exclude
+    data_exclude = ["*.whl", "**/*.py", "**/* *", "BUILD.bazel", "WORKSPACE"] + pip_data_exclude
 
     return textwrap.dedent(
         """\
@@ -184,7 +184,7 @@ def extract_wheel(
         '"//%s:%s"' % (sanitise_name(d), WHEEL_FILE_LABEL) for d in whl_deps
     ]
 
-    with open(os.path.join(directory, "BUILD"), "w") as build_file:
+    with open(os.path.join(directory, "BUILD.bazel"), "w") as build_file:
         contents = generate_build_file_contents(
             sanitise_name(whl.name), sanitised_dependencies, sanitised_wheel_file_dependencies, pip_data_exclude
         )

--- a/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
+++ b/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
@@ -17,7 +17,7 @@ class TestExtractWheel(unittest.TestCase):
         )[2:]  # Take off the leading // from the returned label.
         # Assert that the raw wheel ends up in the package.
         self.assertIn(wheel_name, os.listdir(generated_bazel_dir))
-        with open("{}/BUILD".format(generated_bazel_dir)) as build_file:
+        with open("{}/BUILD.bazel".format(generated_bazel_dir)) as build_file:
             build_file_content = build_file.read()
             self.assertIn('filegroup', build_file_content)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using wheels like keyring (https://pypi.org/project/keyring) , `pip_install` fails with an error like
```
  File "/private/var/tmp/_bazel_gkorlam/a1f9cb65ef7d02cf04534e97e406c6b9/external/rules_python/python/pip_install/extract_wheels/lib/bazel.py", line 187, in extract_wheel
    with open(os.path.join(directory, "BUILD"), "w") as build_file:
IsADirectoryError: [Errno 21] Is a directory: 'pypi__keyring/BUILD'
```

This is because the extracted whl file has a `build` directory in it.
![Screen Shot 2021-03-02 at 2 00 39 PM](https://user-images.githubusercontent.com/291148/109721028-aed16480-7b5f-11eb-878b-e833241c0cf9.png)


Issue Number: N/A


## What is the new behavior?
By changing the build file to `BUILD.bazel` it is much less likely to encounter this issue. `pip_install` succeeds in importing the keyring whl after this change.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

