### PR TITLE
Remove bzl_library from python/pip_install/BUILD so that skylib dep is not exposed to end-users

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -22,9 +22,6 @@ pkg_tar(
     visibility = ["//examples:__pkg__"],
 )
 
-# TODO(brandjon): print_rel_notes doesn't appear to handle our use case of
-# emitting an optional additional deps method from a different file. For now we
-# manually adjust our release notes.
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -54,6 +54,14 @@ bzl_library(
     deps = [":bazel_python_tools"],
 )
 
+bzl_library(
+    name = "pip_install_bzl",
+    srcs = [
+        "//python/pip_install:pip_repository.bzl",
+        "//python/pip_install:repositories.bzl",
+    ],
+)
+
 stardoc(
     name = "core-docs",
     out = "python.md",
@@ -71,7 +79,7 @@ stardoc(
     input = "//python:pip.bzl",
     deps = [
         ":bazel_repo_tools",
-        "//python/pip_install:bzl",
+        "pip_install_bzl",
     ],
 )
 

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -79,7 +79,7 @@ stardoc(
     input = "//python:pip.bzl",
     deps = [
         ":bazel_repo_tools",
-        "pip_install_bzl",
+        ":pip_install_bzl",
     ],
 )
 

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -1,5 +1,3 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
 filegroup(
     name = "distribution",
     srcs = glob(["*.bzl"]) + [
@@ -9,11 +7,7 @@ filegroup(
     visibility = ["//:__pkg__"],
 )
 
-bzl_library(
-    name = "bzl",
-    srcs = [
-        "pip_repository.bzl",
-        "repositories.bzl",
-    ],
+exports_files(
+    ["pip_repository.bzl", "repositories.bzl"],
     visibility = ["//docs:__pkg__"],
 )


### PR DESCRIPTION
Addressing https://github.com/bazelbuild/rules_python/issues/372

---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

> expanding rules_python-0.1.0.tar.gz we see that `/python/pip_install/BUILD` has a load statement from `@bazel_skylib`.

> Users weren't told to depend on that, nor did our WORKSPACE dependencies install such a thing.
Moreover until the new Bazel external deps story is landed, adding such a dependency is a nasty breaking change for users where they may have a hard time getting the right version of bazel_skylib to satisfy rules_python along with anything else that transitively depends on it.

Issue Number: https://github.com/bazelbuild/rules_python/issues/372


## What is the new behavior?

`/python/pip_install/BUILD` no longer has a load statement from `@bazel_skylib`. 

I've run `./update_docs.sh` to check that this doesn't break anything, and it seems fine.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
