### PR TITLE
Add support for relative requirements in pip_install

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run tools/bazel_integration_test/update_deleted_packages.sh
-build --deleted_packages=examples/legacy_pip_import/boto,examples/legacy_pip_import/extras,examples/legacy_pip_import/helloworld,examples/pip_install
-query --deleted_packages=examples/legacy_pip_import/boto,examples/legacy_pip_import/extras,examples/legacy_pip_import/helloworld,examples/pip_install
+build --deleted_packages=examples/legacy_pip_import/boto,examples/legacy_pip_import/extras,examples/legacy_pip_import/helloworld,examples/pip_install,examples/relative_requirements
+query --deleted_packages=examples/legacy_pip_import/boto,examples/legacy_pip_import/extras,examples/legacy_pip_import/helloworld,examples/pip_install,examples/relative_requirements
 
 test --test_output=errors

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -26,3 +26,8 @@ bazel_integration_test(
     name = "pip_install_example",
     timeout = "long",
 )
+
+bazel_integration_test(
+    name = "relative_requirements_example",
+    timeout = "long",
+)

--- a/examples/relative_requirements/BUILD
+++ b/examples/relative_requirements/BUILD
@@ -1,0 +1,10 @@
+load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
+
+py_test(
+    name = "main",
+    srcs = ["main.py"],
+    deps = [
+        requirement("relative_package_name"),
+    ],
+)

--- a/examples/relative_requirements/README.md
+++ b/examples/relative_requirements/README.md
@@ -1,0 +1,4 @@
+# relative_requirements example
+
+This example shows how to use pip to fetch relative dependencies from a requirements.txt file,
+then use them in BUILD files as dependencies of Bazel targets.

--- a/examples/relative_requirements/WORKSPACE
+++ b/examples/relative_requirements/WORKSPACE
@@ -1,0 +1,15 @@
+workspace(name = "example_repo")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+)
+
+load("@rules_python//python:pip.bzl", "pip_install")
+
+pip_install(
+    requirements = "//:requirements.txt",
+)

--- a/examples/relative_requirements/main.py
+++ b/examples/relative_requirements/main.py
@@ -1,0 +1,5 @@
+import relative_package_name
+
+if __name__ == "__main__":
+    # Run a function from the relative package
+    print(relative_package_name.test())

--- a/examples/relative_requirements/relative_package/relative_package_name/__init__.py
+++ b/examples/relative_requirements/relative_package/relative_package_name/__init__.py
@@ -1,0 +1,2 @@
+def test():
+    return True

--- a/examples/relative_requirements/relative_package/setup.py
+++ b/examples/relative_requirements/relative_package/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='relative_package_name',
+    version='1.0.0',
+    packages=['relative_package_name'],
+)

--- a/examples/relative_requirements/requirements.txt
+++ b/examples/relative_requirements/requirements.txt
@@ -1,0 +1,1 @@
+./relative_package

--- a/tools/bazel_integration_test/bazel_integration_test.bzl
+++ b/tools/bazel_integration_test/bazel_integration_test.bzl
@@ -13,8 +13,8 @@ _ATTRS = {
 It is assumed by the test runner that the bazel binary is found at label_workspace/bazel (wksp/bazel.exe on Windows)""",
     ),
     "bazel_commands": attr.string_list(
-        default = ["info", "test ..."],
-        doc = """The list of bazel commands to run. Defaults to `["info", "test ..."]`.
+        default = ["info", "test --test_output=errors ..."],
+        doc = """The list of bazel commands to run. Defaults to `["info", "test --test_output=errors ..."]`.
 
 Note that if a command contains a bare `--` argument, the --test_arg passed to Bazel will appear before it.
 """,


### PR DESCRIPTION
Alternate to #367 with a better implementation, thanks to @LouisStAmour

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #366

Relative requirements do not work due to pip wheel being run from the generated repository root.

## What is the new behavior?

Pip is now run with the working directory being the folder containing the requirements.txt file, with `--wheel-dir` pointed back at the correct location to write the wheels.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

A new example has been added to satisfy the desire for this to be tested from the other PR. I'm happy to shuffle this around elsewhere if you prefer.