### PR TITLE
Exclude autogenerated BUILD file from wheel library runfiles

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -29,7 +29,10 @@ def generate_build_file_contents(
     there may be no Python sources whatsoever (e.g. packages written in Cython: like `pymssql`).
     """
 
-    data_exclude = ["*.whl", "**/*.py", "**/* *", "BUILD.bazel", "WORKSPACE"] + pip_data_exclude
+    data_exclude = (
+        ["*.whl", "**/*.py", "**/* *", "BUILD", "BUILD.bazel", "WORKSPACE"]
+        + pip_data_exclude
+    )
 
     return textwrap.dedent(
         """\


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Bazel appears to inject a `BUILD` file into the root of an external repository. For the non-incremental `pip_install` the external repository root ends up looking something like this:

```
BUILD            WORKSPACE        pypi__attrs      requirements.bzl
```

Since `pip_parse` doesn't have the extra layers of directories you end up with the external repository looking something like this:

```
BUILD                  WORKSPACE              attrs-20.3.0.dist-info
BUILD.bazel            attr
```

The build file is then picked up in the data glob and injected into the runfiles. 

Issue Number: https://github.com/bazelbuild/rules_python/issues/440

## What is the new behavior?

This adds the autogenerated `BUILD` to the `exclude` so that it doesn't end up in the runfiles. It still won't fix the issue identified in https://github.com/bazelbuild/rules_python/pull/427 however, but AFAICT that will require changes to Bazel itself to not autogenerate the `BUILD` files?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

None