### PR TITLE
feat: add public filegroups containing bzl files to allow downstream rulesets to generate docs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,3 +33,20 @@ filegroup(
     ],
     visibility = ["//distro:__pkg__"],
 )
+
+# Reexport of all bzl files used to allow downstream rules to generate docs
+# without shipping with a dependency on Skylib
+filegroup(
+    name = "bzl",
+    srcs = [
+        "//python/pip_install:bzl",
+        "//python:bzl",
+        # Requires Bazel 0.29 onward for public visibility of these .bzl files.
+        "@bazel_tools//tools/python:private/defs.bzl",
+        "@bazel_tools//tools/python:python_version.bzl",
+        "@bazel_tools//tools/python:srcs_version.bzl",
+        "@bazel_tools//tools/python:toolchain.bzl",
+        "@bazel_tools//tools/python:utils.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/python/BUILD
+++ b/python/BUILD
@@ -38,6 +38,20 @@ filegroup(
     visibility = ["//:__pkg__"],
 )
 
+# Filegroup of bzl files that can be used by downstream rules for documentation generation
+# Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
+filegroup(
+    name = "bzl",
+    srcs = [
+        "defs.bzl",
+        "packaging.bzl",
+        "pip.bzl",
+        "whl.bzl",
+        "private/reexports.bzl",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
 # ========= Core rules =========
 
 exports_files([

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -8,6 +8,15 @@ filegroup(
     visibility = ["//:__pkg__"],
 )
 
+filegroup(
+    name = "bzl",
+    srcs = [
+        "pip_repository.bzl",
+        "repositories.bzl",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
 exports_files(
     ["pip_repository.bzl", "repositories.bzl"],
     visibility = ["//docs:__pkg__"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
A patch is required to access the required bzl files for docs in external rulesets

Issue Number: N/A


## What is the new behavior?
Downstream rulesets can depend on `//:bzl` to provide all `.bzl` sources needed to build docs for bzl files that include loads from rules_python

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
We do a similar approach in rules_nodejs 🙂 
