### PR TITLE
Also name the BUILD file in external repository roots BUILD.bazel

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -12,7 +12,7 @@ def _construct_pypath(rctx):
         rctx: Handle to the repository_context.
     Returns: String of the PYTHONPATH.
     """
-    rctx.file("BUILD", "")
+    rctx.file("BUILD.bazel", "")
 
     # Get the root directory of these rules
     rules_root = rctx.path(Label("//:BUILD")).dirname

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -12,7 +12,6 @@ def _construct_pypath(rctx):
         rctx: Handle to the repository_context.
     Returns: String of the PYTHONPATH.
     """
-    rctx.file("BUILD.bazel", "")
 
     # Get the root directory of these rules
     rules_root = rctx.path(Label("//:BUILD")).dirname
@@ -63,6 +62,9 @@ def _pip_repository_impl(rctx):
 
     if rctx.attr.incremental and not rctx.attr.requirements_lock:
         fail("Incremental mode requires a requirements_lock attribute be specified.")
+
+    # We need a BUILD file to load the generated requirements.bzl
+    rctx.file("BUILD.bazel", "")
 
     pypath = _construct_pypath(rctx)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Closes https://github.com/bazelbuild/rules_python/issues/440

The build file in the repository roots generated by `pip_repository` is still `BUILD` and not `BUILD.bazel`. Since `pip_parse` has only one layer of directories, the external repository then ends up with a `BUILD` and a `BUILD.bazel`.

## What is the new behavior?

It's now called `BUILD.bazel`, which means `pip_parse` later overwrites it with the final `BUILD.bazel`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This prevents a regression of https://github.com/bazelbuild/rules_python/pull/427 with `pip_parse`.