### PR TITLE
Don't delete wheels from external repos with pip_parse

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -248,6 +248,7 @@ def extract_wheel(
         )
         build_file.write(contents)
 
-    os.remove(whl.path)
+    if not incremental:
+        os.remove(whl.path)
 
     return "//%s" % directory

--- a/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
+++ b/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
@@ -1,25 +1,51 @@
 import os
+import shutil
+import tempfile
+from typing import Optional
 import unittest
 
 from python.pip_install.extract_wheels.lib import bazel
 
 
-class TestExtractWheel(unittest.TestCase):
-    def test_generated_build_file_has_filegroup_target(self) -> None:
-        wheel_name = "example_minimal_package-0.0.1-py3-none-any.whl"
-        wheel_dir = "examples/wheel/"
-        wheel_path = wheel_dir + wheel_name
+class TestWhlFilegroup(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wheel_name = "example_minimal_package-0.0.1-py3-none-any.whl"
+        self.wheel_dir = tempfile.mkdtemp()
+        self.wheel_path = os.path.join(self.wheel_dir, self.wheel_name)
+        shutil.copy(
+            os.path.join("examples", "wheel", self.wheel_name), self.wheel_dir
+        )
+        self.original_dir = os.getcwd()
+        os.chdir(self.wheel_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.wheel_dir)
+        os.chdir(self.original_dir)
+
+    def _run(
+        self,
+        incremental: bool = False,
+        incremental_repo_prefix: Optional[str] = None,
+    ) -> None:
         generated_bazel_dir = bazel.extract_wheel(
-            wheel_path,
+            self.wheel_path,
             extras={},
             pip_data_exclude=[],
             enable_implicit_namespace_pkgs=False,
+            incremental=incremental,
+            incremental_repo_prefix=incremental_repo_prefix
         )[2:]  # Take off the leading // from the returned label.
         # Assert that the raw wheel ends up in the package.
-        self.assertIn(wheel_name, os.listdir(generated_bazel_dir))
+        self.assertIn(self.wheel_name, os.listdir(generated_bazel_dir))
         with open("{}/BUILD.bazel".format(generated_bazel_dir)) as build_file:
             build_file_content = build_file.read()
             self.assertIn('filegroup', build_file_content)
+
+    def test_nonincremental(self) -> None:
+        self._run()
+
+    def test_incremental(self) -> None:
+        self._run(incremental=True, incremental_repo_prefix="test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: N/A

Wheel targets are broken with `pip_parse`. This is because currently `pip_parse` extracts the wheel into the repository root, but then deletes it here:

https://github.com/bazelbuild/rules_python/blob/master/python/pip_install/extract_wheels/lib/bazel.py#L251

This doesn't happen for `pip_install` because it copies the wheel into the relevant subdirectory:

https://github.com/bazelbuild/rules_python/blob/master/python/pip_install/extract_wheels/lib/bazel.py#L212

## What is the new behavior?

Instead of deleting the wheel unconditionally, only do it for the non-incremental case.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None
