### PR TITLE
Allow controlling the prefix added to repos/packages

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -216,7 +216,7 @@ alias(
 | Name  | Description | Default Value |
 | :-------------: | :-------------: | :-------------: |
 | requirements_lock |  A fully resolved 'requirements.txt' pip requirement file     containing the transitive set of your dependencies. If this file is passed instead     of 'requirements' no resolve will take place and pip_repository will create     individual repositories for each of your dependencies so that wheels are     fetched/built only for the targets specified by 'build/run/test'.   |  none |
-| name |  The name of the generated repository.   |  <code>"pip_parsed_deps"</code> |
+| name |  The name of the generated repository. The generated repositories     containing each requirement will be of the form &lt;name&gt;_&lt;requirement-name&gt;.   |  <code>"pip_parsed_deps"</code> |
 | kwargs |  Additional keyword arguments for the underlying     <code>pip_repository</code> rule.   |  none |
 
 

--- a/examples/pip_parse/BUILD
+++ b/examples/pip_parse/BUILD
@@ -1,9 +1,8 @@
 load(
-    "@pip_parsed_deps//:requirements.bzl",
+    "@pypi//:requirements.bzl",
     "data_requirement",
     "dist_info_requirement",
     "entry_point",
-    "requirement",
 )
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
@@ -38,7 +37,7 @@ py_binary(
     name = "main",
     srcs = ["main.py"],
     deps = [
-        requirement("requests"),
+        "@pypi_requests//:pkg",
     ],
 )
 

--- a/examples/pip_parse/WORKSPACE
+++ b/examples/pip_parse/WORKSPACE
@@ -34,12 +34,11 @@ pip_parse(
     # style env vars are read, but env vars that control requests and urllib3
     # can be passed
     # environment = {"HTTPS_PROXY": "http://my.proxy.fun/"},
-
-    # Uses the default repository name "pip_parsed_deps"
+    name = "pypi",
     requirements_lock = "//:requirements_lock.txt",
 )
 
-load("@pip_parsed_deps//:requirements.bzl", "install_deps")
+load("@pypi//:requirements.bzl", "install_deps")
 
 # Initialize repositories for all packages in requirements_lock.txt.
 install_deps()

--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -46,12 +46,12 @@ class PipInstallTest(unittest.TestCase):
         self.assertListEqual(
             env.split(" "),
             [
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/INSTALL.md",
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/LICENSE",
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/NEWS",
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/README.md",
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/data/share/man/man1/s3cmd.1",
-                "external/pip_parsed_deps_pypi__s3cmd/s3cmd-2.1.0.data/scripts/s3cmd",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/INSTALL.md",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/LICENSE",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/NEWS",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/data/share/doc/packages/s3cmd/README.md",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/data/share/man/man1/s3cmd.1",
+                "external/pypi_s3cmd/s3cmd-2.1.0.data/scripts/s3cmd",
             ],
         )
 
@@ -61,11 +61,11 @@ class PipInstallTest(unittest.TestCase):
         self.assertListEqual(
             env.split(" "),
             [
-                "external/pip_parsed_deps_pypi__requests/requests-2.25.1.dist-info/LICENSE",
-                "external/pip_parsed_deps_pypi__requests/requests-2.25.1.dist-info/METADATA",
-                "external/pip_parsed_deps_pypi__requests/requests-2.25.1.dist-info/RECORD",
-                "external/pip_parsed_deps_pypi__requests/requests-2.25.1.dist-info/WHEEL",
-                "external/pip_parsed_deps_pypi__requests/requests-2.25.1.dist-info/top_level.txt",
+                "external/pypi_requests/requests-2.25.1.dist-info/LICENSE",
+                "external/pypi_requests/requests-2.25.1.dist-info/METADATA",
+                "external/pypi_requests/requests-2.25.1.dist-info/RECORD",
+                "external/pypi_requests/requests-2.25.1.dist-info/WHEEL",
+                "external/pypi_requests/requests-2.25.1.dist-info/top_level.txt",
             ],
         )
 

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -96,6 +96,7 @@ def pip_install(requirements, name = "pip", **kwargs):
     pip_repository(
         name = name,
         requirements = requirements,
+        repo_prefix = "pypi__",
         **kwargs
     )
 
@@ -171,7 +172,8 @@ def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
             of 'requirements' no resolve will take place and pip_repository will create
             individual repositories for each of your dependencies so that wheels are
             fetched/built only for the targets specified by 'build/run/test'.
-        name (str, optional): The name of the generated repository.
+        name (str, optional): The name of the generated repository. The generated repositories
+            containing each requirement will be of the form <name>_<requirement-name>.
         **kwargs (dict): Additional keyword arguments for the underlying
             `pip_repository` rule.
     """
@@ -182,6 +184,7 @@ def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
     pip_repository(
         name = name,
         requirements_lock = requirements_lock,
+        repo_prefix = "{}_".format(name),
         incremental = True,
         **kwargs
     )

--- a/python/pip_install/extract_wheels/__init__.py
+++ b/python/pip_install/extract_wheels/__init__.py
@@ -68,8 +68,8 @@ def main() -> None:
     # relative requirements to be correctly resolved. The --wheel-dir is therefore required to be repointed back to the
     # current calling working directory (the repo root in .../external/name), where the wheel files should be written to
     pip_args = (
-        [sys.executable, "-m", "pip"] + 
-        (["--isolated"] if args.isolated else []) + 
+        [sys.executable, "-m", "pip"] +
+        (["--isolated"] if args.isolated else []) +
         ["wheel", "-r", args.requirements] +
         ["--wheel-dir", os.getcwd()] +
         deserialized_args["extra_pip_args"]
@@ -86,11 +86,14 @@ def main() -> None:
     repo_label = "@%s" % args.repo
 
     targets = [
-        '"%s%s"'
-        % (
+        '"{}{}"'.format(
             repo_label,
             bazel.extract_wheel(
-                whl, extras, deserialized_args["pip_data_exclude"], args.enable_implicit_namespace_pkgs
+                whl,
+                extras,
+                deserialized_args["pip_data_exclude"],
+                args.enable_implicit_namespace_pkgs,
+                args.repo_prefix,
             ),
         )
         for whl in glob.glob("*.whl")

--- a/python/pip_install/extract_wheels/lib/arguments.py
+++ b/python/pip_install/extract_wheels/lib/arguments.py
@@ -30,6 +30,11 @@ def parse_common_args(parser: ArgumentParser) -> ArgumentParser:
         action="store",
         help="Extra environment variables to set on the pip environment.",
     )
+    parser.add_argument(
+        "--repo-prefix",
+        required=True,
+        help="Prefix to prepend to packages",
+    )
     return parser
 
 
@@ -45,4 +50,3 @@ def deserialize_structured_args(args):
         else:
             args[arg_name] = []
     return args
-

--- a/python/pip_install/extract_wheels/lib/arguments_test.py
+++ b/python/pip_install/extract_wheels/lib/arguments_test.py
@@ -10,16 +10,25 @@ class ArgumentsTestCase(unittest.TestCase):
         parser = argparse.ArgumentParser()
         parser = arguments.parse_common_args(parser)
         repo_name = "foo"
+        repo_prefix = "pypi_"
         index_url = "--index_url=pypi.org/simple"
         extra_pip_args = [index_url]
         args_dict = vars(parser.parse_args(
-            args=["--repo", repo_name, f"--extra_pip_args={json.dumps({'arg': extra_pip_args})}"]))
+            args=[
+                "--repo",
+                repo_name,
+                f"--extra_pip_args={json.dumps({'arg': extra_pip_args})}",
+                "--repo-prefix",
+                repo_prefix,
+            ]
+        ))
         args_dict = arguments.deserialize_structured_args(args_dict)
         self.assertIn("repo", args_dict)
         self.assertIn("extra_pip_args", args_dict)
         self.assertEqual(args_dict["pip_data_exclude"], [])
         self.assertEqual(args_dict["enable_implicit_namespace_pkgs"], False)
         self.assertEqual(args_dict["repo"], repo_name)
+        self.assertEqual(args_dict["repo_prefix"], repo_prefix)
         self.assertEqual(args_dict["extra_pip_args"], extra_pip_args)
 
     def test_deserialize_structured_args(self) -> None:

--- a/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
+++ b/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
@@ -24,8 +24,8 @@ class TestWhlFilegroup(unittest.TestCase):
 
     def _run(
         self,
+        repo_prefix: str,
         incremental: bool = False,
-        incremental_repo_prefix: Optional[str] = None,
     ) -> None:
         generated_bazel_dir = bazel.extract_wheel(
             self.wheel_path,
@@ -33,7 +33,7 @@ class TestWhlFilegroup(unittest.TestCase):
             pip_data_exclude=[],
             enable_implicit_namespace_pkgs=False,
             incremental=incremental,
-            incremental_repo_prefix=incremental_repo_prefix
+            repo_prefix=repo_prefix
         )
         # Take off the leading // from the returned label.
         # Assert that the raw wheel ends up in the package.
@@ -44,10 +44,10 @@ class TestWhlFilegroup(unittest.TestCase):
             self.assertIn('filegroup', build_file_content)
 
     def test_nonincremental(self) -> None:
-        self._run()
+        self._run(repo_prefix="prefix_")
 
     def test_incremental(self) -> None:
-        self._run(incremental=True, incremental_repo_prefix="test")
+        self._run(incremental=True, repo_prefix="prefix_")
 
 
 if __name__ == "__main__":

--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -60,16 +60,19 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
     args.setdefault("python_interpreter", sys.executable)
     # Pop this off because it wont be used as a config argument to the whl_library rule.
     requirements_lock = args.pop("requirements_lock")
-    repo_prefix = bazel.whl_library_repo_prefix(args["repo"])
 
     install_req_and_lines = parse_install_requirements(requirements_lock, args["extra_pip_args"])
-    repo_names_and_reqs = repo_names_and_requirements(install_req_and_lines, repo_prefix)
-    all_requirements = ", ".join(
-        [bazel.sanitised_repo_library_label(ir.name, repo_prefix=repo_prefix) for ir, _ in install_req_and_lines]
+    repo_names_and_reqs = repo_names_and_requirements(
+        install_req_and_lines, args["repo_prefix"]
     )
-    all_whl_requirements = ", ".join(
-        [bazel.sanitised_repo_file_label(ir.name, repo_prefix=repo_prefix) for ir, _ in install_req_and_lines]
-    )
+    all_requirements = ", ".join([
+        bazel.sanitised_repo_library_label(ir.name, repo_prefix=args["repo_prefix"])
+        for ir, _ in install_req_and_lines
+    ])
+    all_whl_requirements = ", ".join([
+        bazel.sanitised_repo_file_label(ir.name, repo_prefix=args["repo_prefix"])
+        for ir, _ in install_req_and_lines
+    ])
     return textwrap.dedent("""\
         load("@rules_python//python/pip_install:pip_repository.bzl", "whl_library")
 
@@ -112,7 +115,7 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
             all_whl_requirements=all_whl_requirements,
             repo_names_and_reqs=repo_names_and_reqs,
             args=args,
-            repo_prefix=repo_prefix,
+            repo_prefix=args["repo_prefix"],
             py_library_label=bazel.PY_LIBRARY_LABEL,
             wheel_file_label=bazel.WHEEL_FILE_LABEL,
             data_label=bazel.DATA_LABEL,

--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
@@ -30,7 +30,7 @@ def main() -> None:
 
     pip_args = (
         [sys.executable, "-m", "pip"] +
-        (["--isolated"] if args.isolated else []) + 
+        (["--isolated"] if args.isolated else []) +
         ["wheel", "--no-deps"] +
         deserialized_args["extra_pip_args"]
     )
@@ -67,5 +67,5 @@ def main() -> None:
         deserialized_args["pip_data_exclude"],
         args.enable_implicit_namespace_pkgs,
         incremental=True,
-        incremental_repo_prefix=bazel.whl_library_repo_prefix(args.repo)
+        repo_prefix=args.repo_prefix,
     )

--- a/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
+++ b/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
@@ -6,7 +6,6 @@ from tempfile import NamedTemporaryFile
 from python.pip_install.parse_requirements_to_bzl import generate_parsed_requirements_contents
 from python.pip_install.extract_wheels.lib.bazel import (
     sanitised_repo_library_label,
-    whl_library_repo_prefix,
     sanitised_repo_file_label
 )
 
@@ -21,7 +20,7 @@ class TestParseRequirementsToBzl(unittest.TestCase):
             requirements_lock.flush()
             args = argparse.Namespace()
             args.requirements_lock = requirements_lock.name
-            args.repo = "pip_parsed_deps"
+            args.repo_prefix = "pip_parsed_deps_pypi__"
             extra_pip_args = ["--index-url=pypi.org/simple"]
             pip_data_exclude = ["**.foo"]
             args.extra_pip_args = json.dumps({"arg": extra_pip_args})

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -138,7 +138,7 @@ def _pip_repository_impl(rctx):
             rctx.path(rctx.attr.requirements),
         ]
 
-    args += ["--repo", rctx.attr.name]
+    args += ["--repo", rctx.attr.name, "--repo-prefix", rctx.attr.repo_prefix]
     args = _parse_optional_attrs(rctx, args)
 
     result = rctx.execute(
@@ -206,6 +206,18 @@ python_interpreter.
     "quiet": attr.bool(
         default = True,
         doc = "If True, suppress printing stdout and stderr output to the terminal.",
+    ),
+    "repo_prefix": attr.string(
+        doc = """
+Prefix for the generated packages. For non-incremental mode the
+packages will be of the form
+
+@<name>//<prefix><sanitized-package-name>/...
+
+For incremental mode the packages will be of the form
+
+@<prefix><sanitized-package-name>//...
+""",
     ),
     # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
     "timeout": attr.int(
@@ -293,6 +305,8 @@ def _impl_whl_library(rctx):
         rctx.attr.requirement,
         "--repo",
         rctx.attr.repo,
+        "--repo-prefix",
+        rctx.attr.repo_prefix,
     ]
     args = _parse_optional_attrs(rctx, args)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number:
- https://github.com/bazelbuild/rules_python/issues/414
- Closes https://github.com/bazelbuild/rules_python/issues/450

Currently the prefix added to the generated repos for `pip_parse` is hard-coded to `<pip-parse-name>_pypi__` and the prefix added to the generated packages for `pip_install` is hard-coded to `pypi__`.

## What is the new behavior?
Allow the user to control the prefix. You still need some prefix to avoid https://github.com/bazelbuild/rules_python/issues/414#issuecomment-789416360, but for `pip_parse` in particular you can make the external repository names more memorable:

```
$ cat requirements.txt
attrs==20.3.0
$ cat WORKSPACE
local_repository(
    name = "rules_python",
    path = "../rules_python",
)

load("@rules_python//python:pip.bzl", "pip_install", "pip_parse")

pip_parse(
    name = "deps",
    requirements_lock = "//:requirements.txt",
    repo_prefix="pypi_",
)

load("@deps//:requirements.bzl", "install_deps")
install_deps()
$ bazelisk build @pypi_attrs//:pkg
INFO: Analyzed target @pypi_attrs//:pkg (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @pypi_attrs//:pkg up-to-date (nothing to build)
INFO: Elapsed time: 0.095s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None