### PR TITLE
Make .whl file present in pip_parse subrepos

### DIFF
--- a/examples/pip_parse/BUILD
+++ b/examples/pip_parse/BUILD
@@ -30,11 +30,11 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 py_binary(
     name = "main",
     srcs = ["main.py"],
+    data = [
+        whl_requirement("requests"),
+    ],
     deps = [
         requirement("requests"),
-    ],
-    data = [
-        whl_requirement("requests")
     ],
 )
 

--- a/examples/pip_parse/BUILD
+++ b/examples/pip_parse/BUILD
@@ -1,4 +1,4 @@
-load("@pip_parsed_deps//:requirements.bzl", "requirement")
+load("@pip_parsed_deps//:requirements.bzl", "requirement", "whl_requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 # Toolchain setup, this is optional.
@@ -32,6 +32,9 @@ py_binary(
     srcs = ["main.py"],
     deps = [
         requirement("requests"),
+    ],
+    data = [
+        whl_requirement("requests")
     ],
 )
 

--- a/examples/pip_parse/main.py
+++ b/examples/pip_parse/main.py
@@ -1,5 +1,9 @@
 import requests
+import glob
 
 
 def version():
     return requests.__version__
+
+def requests_wheels():
+    return glob.glob("external/**/*.whl")

--- a/examples/pip_parse/test.py
+++ b/examples/pip_parse/test.py
@@ -5,6 +5,7 @@ import main
 class ExampleTest(unittest.TestCase):
     def test_main(self):
         self.assertEqual("2.24.0", main.version())
+        self.assertTrue(len(main.requests_wheels()))
 
 
 if __name__ == '__main__':

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -248,6 +248,9 @@ def extract_wheel(
         )
         build_file.write(contents)
 
-    os.remove(whl.path)
+    if not incremental:
+        # In non-incremental mode we copy the wheel into 'directory` above,
+        # so we should delete the original.
+        os.remove(whl.path)
 
     return "//%s" % directory

--- a/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
+++ b/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
@@ -1,25 +1,55 @@
 import os
 import unittest
+import tempfile
+from pathlib import Path
+
+import shutil
 
 from python.pip_install.extract_wheels.lib import bazel
 
 
 class TestExtractWheel(unittest.TestCase):
+    def setUp(self):
+        self.original_workdir = Path(os.getcwd())
+        self.extraction_dir = tempfile.mkdtemp()
+        os.chdir(self.extraction_dir)
+        self.wheel_path = Path("examples/wheel/example_minimal_package-0.0.1-py3-none-any.whl")
+        shutil.copy(str(self.original_workdir / self.wheel_path), self.wheel_path.name)
+
+    def tearDown(self):
+        os.chdir(self.original_workdir)
+        shutil.rmtree(self.extraction_dir)
+
     def test_generated_build_file_has_filegroup_target(self) -> None:
-        wheel_name = "example_minimal_package-0.0.1-py3-none-any.whl"
-        wheel_dir = "examples/wheel/"
-        wheel_path = wheel_dir + wheel_name
         generated_bazel_dir = bazel.extract_wheel(
-            wheel_path,
+            self.wheel_path.name,
             extras={},
             pip_data_exclude=[],
             enable_implicit_namespace_pkgs=False,
         )[2:]  # Take off the leading // from the returned label.
         # Assert that the raw wheel ends up in the package.
-        self.assertIn(wheel_name, os.listdir(generated_bazel_dir))
+        self.assertIn(self.wheel_path.name, os.listdir(generated_bazel_dir))
+        # Original file should be deleted from the root dir.
+        self.assertNotIn(self.wheel_path.name, os.listdir(os.getcwd()))
         with open("{}/BUILD.bazel".format(generated_bazel_dir)) as build_file:
             build_file_content = build_file.read()
             self.assertIn('filegroup', build_file_content)
+
+    def test_extract_wheel_incremental(self) -> None:
+        generated_bazel_dir = bazel.extract_wheel(
+            self.wheel_path.name,
+            extras={},
+            pip_data_exclude=[],
+            enable_implicit_namespace_pkgs=False,
+            incremental=True,
+            incremental_repo_prefix="pypi__",
+        )[2:]  # Take off the leading // from the returned label.
+        # Assert that the raw wheel ends up in the package.
+        self.assertIn(self.wheel_path.name, os.listdir(generated_bazel_dir))
+        with open("{}/BUILD.bazel".format(generated_bazel_dir)) as build_file:
+            build_file_content = build_file.read()
+            self.assertIn('filegroup', build_file_content)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When using pip_parse the .whl file which is part of the filegroup that we create in the BUILD file gets deleted.

Issue Number: N/A


## What is the new behavior?
The .whl file isn't deleted from the root of a whl_library repo anymore, so it can be consumed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

