### PR TITLE
`requirements.bzl` is now visible outside `pip_repository`s

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -49,6 +49,13 @@ def _parse_optional_attrs(rctx, args):
 
     return args
 
+_BUILD_FILE_CONTENTS = """\
+package(default_visibility = ["//visibility:public"])
+
+# Ensure the `requirements.bzl` source can be accessed outside the workspace.
+exports_files(["requirements.bzl"])
+"""
+
 def _pip_repository_impl(rctx):
     python_interpreter = rctx.attr.python_interpreter
     if rctx.attr.python_interpreter_target != None:
@@ -64,7 +71,7 @@ def _pip_repository_impl(rctx):
         fail("Incremental mode requires a requirements_lock attribute be specified.")
 
     # We need a BUILD file to load the generated requirements.bzl
-    rctx.file("BUILD.bazel", "")
+    rctx.file("BUILD.bazel", _BUILD_FILE_CONTENTS)
 
     pypath = _construct_pypath(rctx)
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -52,7 +52,7 @@ def _parse_optional_attrs(rctx, args):
 _BUILD_FILE_CONTENTS = """\
 package(default_visibility = ["//visibility:public"])
 
-# Ensure the `requirements.bzl` source can be accessed outside the workspace.
+# Ensure the `requirements.bzl` source can be accessed by stardoc, since users load() from it
 exports_files(["requirements.bzl"])
 """
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I have a `.bzl` file which loads the `requirements.bzl` file of a [pip_repository](https://github.com/bazelbuild/rules_python/blob/017eb4ffb87b97a66be968df33391ef36ba474cb/python/pip_install/pip_repository.bzl#L170-L212) and I want to use [stardoc](https://github.com/bazelbuild/stardoc) to generate documentation it. However, I'm not able to access `requirements.bzl` because it's not publicly visible outside of the repository.

Issue Number: N/A


## What is the new behavior?

The change in this PR exports the file so it can be used for generating documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

