### PR TITLE
Address project's github pages 404 error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+## Contents
+
+* [pip](https://bazelbuild.github.io/rules_python/pip.html)
+* [python](https://bazelbuild.github.io/rules_python/python.html)
+* [whl](https://bazelbuild.github.io/rules_python/whl.html)


### PR DESCRIPTION
Not a great fix, but should remove the 404 problem.

----

### PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


### What is the current behavior?

**Issue Number:** https://github.com/bazelbuild/rules_python/issues/343

https://bazelbuild.github.io/rules_python is a 404. 

![image](https://user-images.githubusercontent.com/12058921/117566856-6785c800-b0fc-11eb-838d-604ad90cb063.png)

However each Markdown page in `docs/` has a HTML page. This page is working: https://bazelbuild.github.io/rules_python/pip.html

### What is the new behavior?

With this PR's file addition the Github pages site should get an `index.html` file and thus https://bazelbuild.github.io/rules_python will stop being a 404.


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

