### PR TITLE
Remove leading ./ in compile_pip_requirements

### DIFF
--- a/examples/pip_install/requirements.txt
+++ b/examples/pip_install/requirements.txt
@@ -7,7 +7,7 @@
 boto3==1.14.51 \
     --hash=sha256:a6bdb808e948bd264af135af50efb76253e85732c451fa605b7a287faf022432 \
     --hash=sha256:f9dbccbcec916051c6588adbccae86547308ac4cd154f1eb7cf6422f0e391a71
-    # via -r ./requirements.in
+    # via -r requirements.in
 botocore==1.17.63 \
     --hash=sha256:40f13f6c9c29c307a9dc5982739e537ddce55b29787b90c3447b507e3283bcd6 \
     --hash=sha256:aa88eafc6295132f4bc606f1df32b3248e0fa611724c0a216aceda767948ac75

--- a/python/pip_install/pip_compile.py
+++ b/python/pip_install/pip_compile.py
@@ -13,7 +13,7 @@ if len(sys.argv) < 4:
     )
     sys.exit(1)
 
-requirements_in = sys.argv.pop(1)
+requirements_in = os.path.relpath(sys.argv.pop(1))
 requirements_txt = sys.argv.pop(1)
 update_target_name = sys.argv.pop(1)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The `compile_pip_requirements` rule will list the requirements as coming from `./requirements.in`.

Issue Number: closes https://github.com/bazelbuild/rules_python/issues/470

## What is the new behavior?

It will be attributed to `requirements.in`, which lets it work out-of-the-box with tools like dependabot.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

None
