### PR TITLE
Allow overriding CUSTOM_COMPILE_COMMAND

### DIFF
--- a/python/pip_install/pip_compile.py
+++ b/python/pip_install/pip_compile.py
@@ -54,7 +54,7 @@ update_target_pkg = "/".join(requirements_in.split('/')[:-1])
 # $(rootpath) in the workspace root gives ./requirements.in
 if update_target_pkg == ".":
     update_target_pkg = ""
-update_command = "bazel run //%s:%s" % (update_target_pkg, update_target_name)
+update_command = os.getenv("CUSTOM_COMPILE_COMMAND") or "bazel run //%s:%s" % (update_target_pkg, update_target_name)
 
 os.environ["CUSTOM_COMPILE_COMMAND"] = update_command
 


### PR DESCRIPTION
This way if users have bazel wrappers the error message can be correct

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently the output recommendation is always `bazel run TARGET`

Issue Number: N/A

## What is the new behavior?

If users add `env = {"CUSTOM_COMPILE_COMMAND": "foo"}` the output recommendation will be `foo`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

We might prefer an attribute over an env var override here, happy to go down either path