### PR TITLE
Remove unnecessary import in namespace_pkgs.py

### DIFF
--- a/python/pip_install/extract_wheels/lib/namespace_pkgs.py
+++ b/python/pip_install/extract_wheels/lib/namespace_pkgs.py
@@ -3,8 +3,6 @@ import os
 import textwrap
 from typing import Set, List, Optional
 
-from python.pip_install.extract_wheels.lib import wheel
-
 
 def implicit_namespace_packages(
     directory: str, ignored_dirnames: Optional[List[str]] = None


### PR DESCRIPTION
See https://github.com/dillon-giacoppo/rules_python_external/pull/54/files for change that removed usage of `wheel` module.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



