### PR TITLE
Migrate from bazelbuild/skydoc to bazelbuild/stardoc

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -17,7 +17,7 @@
 ###############################################################################
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -14,41 +14,14 @@ belong to given set of Python packages.
 This rule is intended to be used as data dependency to py_wheel rule
 
 
-### Attributes
+**ATTRIBUTES**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_package-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_package-deps">
-      <td><code>deps</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-      </td>
-    </tr>
-    <tr id="py_package-packages">
-      <td><code>packages</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          List of Python packages to include in the distribution.
-Sub-packages are automatically included.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| packages |  List of Python packages to include in the distribution. Sub-packages are automatically included.   | List of strings | optional | [] |
 
 
 <a name="#py_wheel"></a>
@@ -56,7 +29,9 @@ Sub-packages are automatically included.
 ## py_wheel
 
 <pre>
-py_wheel(<a href="#py_wheel-name">name</a>, <a href="#py_wheel-abi">abi</a>, <a href="#py_wheel-author">author</a>, <a href="#py_wheel-author_email">author_email</a>, <a href="#py_wheel-classifiers">classifiers</a>, <a href="#py_wheel-console_scripts">console_scripts</a>, <a href="#py_wheel-deps">deps</a>, <a href="#py_wheel-description_file">description_file</a>, <a href="#py_wheel-distribution">distribution</a>, <a href="#py_wheel-entry_points">entry_points</a>, <a href="#py_wheel-extra_requires">extra_requires</a>, <a href="#py_wheel-homepage">homepage</a>, <a href="#py_wheel-license">license</a>, <a href="#py_wheel-platform">platform</a>, <a href="#py_wheel-python_requires">python_requires</a>, <a href="#py_wheel-python_tag">python_tag</a>, <a href="#py_wheel-requires">requires</a>, <a href="#py_wheel-strip_path_prefixes">strip_path_prefixes</a>, <a href="#py_wheel-version">version</a>)
+py_wheel(<a href="#py_wheel-name">name</a>, <a href="#py_wheel-abi">abi</a>, <a href="#py_wheel-author">author</a>, <a href="#py_wheel-author_email">author_email</a>, <a href="#py_wheel-classifiers">classifiers</a>, <a href="#py_wheel-console_scripts">console_scripts</a>, <a href="#py_wheel-deps">deps</a>, <a href="#py_wheel-description_file">description_file</a>,
+         <a href="#py_wheel-distribution">distribution</a>, <a href="#py_wheel-entry_points">entry_points</a>, <a href="#py_wheel-extra_requires">extra_requires</a>, <a href="#py_wheel-homepage">homepage</a>, <a href="#py_wheel-license">license</a>, <a href="#py_wheel-platform">platform</a>, <a href="#py_wheel-python_requires">python_requires</a>,
+         <a href="#py_wheel-python_tag">python_tag</a>, <a href="#py_wheel-requires">requires</a>, <a href="#py_wheel-strip_path_prefixes">strip_path_prefixes</a>, <a href="#py_wheel-version">version</a>)
 </pre>
 
 
@@ -71,7 +46,7 @@ Currently only pure-python wheels are supported.
 Examples:
 
 ```python
-# Package just a specific py_libraries, without their dependencies
+# Package some specific py_library targets, without their dependencies
 py_wheel(
     name = "minimal_with_py_library",
     # Package data. We're building "example_minimal_library-0.0.1-py3-none-any.whl"
@@ -104,212 +79,29 @@ py_wheel(
 ```
 
 
-### Attributes
+**ATTRIBUTES**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_wheel-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-abi">
-      <td><code>abi</code></td>
-      <td>
-        String; optional
-        <p>
-          Python ABI tag. 'none' for pure-Python wheels.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-author">
-      <td><code>author</code></td>
-      <td>
-        String; optional
-        <p>
-          A string specifying the author of the package.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-author_email">
-      <td><code>author_email</code></td>
-      <td>
-        String; optional
-        <p>
-          A string specifying the email address of the package author.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-classifiers">
-      <td><code>classifiers</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          A list of strings describing the categories for the package.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-console_scripts">
-      <td><code>console_scripts</code></td>
-      <td>
-        <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>; optional
-        <p>
-          Deprecated console_script entry points, e.g. `{'main': 'examples.wheel.main:main'}`.
 
-Deprecated: prefer the `entry_points` attribute, which supports `console_scripts` as well as other entry points.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-deps">
-      <td><code>deps</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-        <p>
-          Targets to be included in the distribution.
-
-The targets to package are usually `py_library` rules or filesets (for packaging data files).
-
-Note it's usually better to package `py_library` targets and use
-`entry_points` attribute to specify `console_scripts` than to package
-`py_binary` rules. `py_binary` targets would wrap a executable script that
-tries to locate `.runfiles` directory which is not packaged in the wheel.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-description_file">
-      <td><code>description_file</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
-        <p>
-          A file containing text describing the package in a single line.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-distribution">
-      <td><code>distribution</code></td>
-      <td>
-        String; required
-        <p>
-          Name of the distribution.
-
-This should match the project name onm PyPI. It's also the name that is used to
-refer to the package in other packages' dependencies.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-entry_points">
-      <td><code>entry_points</code></td>
-      <td>
-        <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a>; optional
-        <p>
-          entry_points, e.g. `{'console_scripts': ['main = examples.wheel.main:main']}`.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-extra_requires">
-      <td><code>extra_requires</code></td>
-      <td>
-        <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a>; optional
-        <p>
-          List of optional requirements for this package
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-homepage">
-      <td><code>homepage</code></td>
-      <td>
-        String; optional
-        <p>
-          A string specifying the URL for the package homepage.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-license">
-      <td><code>license</code></td>
-      <td>
-        String; optional
-        <p>
-          A string specifying the license of the package.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-platform">
-      <td><code>platform</code></td>
-      <td>
-        String; optional
-        <p>
-          Supported platform. Use 'any' for pure-Python wheel.
-
-If you have included platform-specific data, such as a .pyd or .so
-extension module, you will need to specify the platform in standard
-pip format. If you support multiple platforms, you can define
-platform constraints, then use a select() to specify the appropriate
-specifier, eg:
-
-<code>
-platform = select({
-    "//platforms:windows_x86_64": "win_amd64",
-    "//platforms:macos_x86_64": "macosx_10_7_x86_64",
-    "//platforms:linux_x86_64": "manylinux2014_x86_64",
-})
-</code>
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-python_requires">
-      <td><code>python_requires</code></td>
-      <td>
-        String; optional
-        <p>
-          A string specifying what other distributions need to be installed when this one is. See the section on [Declaring required dependency](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-dependencies) for details and examples of the format of this argument.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-python_tag">
-      <td><code>python_tag</code></td>
-      <td>
-        String; optional
-        <p>
-          Supported Python version(s), eg `py3`, `cp35.cp36`, etc
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-requires">
-      <td><code>requires</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          List of requirements for this package
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-strip_path_prefixes">
-      <td><code>strip_path_prefixes</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          path prefixes to strip from files added to the generated package
-        </p>
-      </td>
-    </tr>
-    <tr id="py_wheel-version">
-      <td><code>version</code></td>
-      <td>
-        String; required
-        <p>
-          Version number of the package
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| abi |  Python ABI tag. 'none' for pure-Python wheels.   | String | optional | "none" |
+| author |  A string specifying the author of the package.   | String | optional | "" |
+| author_email |  A string specifying the email address of the package author.   | String | optional | "" |
+| classifiers |  A list of strings describing the categories for the package. For valid classifiers see https://pypi.org/classifiers   | List of strings | optional | [] |
+| console_scripts |  Deprecated console_script entry points, e.g. <code>{'main': 'examples.wheel.main:main'}</code>.<br><br>Deprecated: prefer the <code>entry_points</code> attribute, which supports <code>console_scripts</code> as well as other entry points.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| deps |  Targets to be included in the distribution.<br><br>The targets to package are usually <code>py_library</code> rules or filesets (for packaging data files).<br><br>Note it's usually better to package <code>py_library</code> targets and use <code>entry_points</code> attribute to specify <code>console_scripts</code> than to package <code>py_binary</code> rules. <code>py_binary</code> targets would wrap a executable script that tries to locate <code>.runfiles</code> directory which is not packaged in the wheel.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| description_file |  A file containing text describing the package in a single line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| distribution |  Name of the distribution.<br><br>This should match the project name onm PyPI. It's also the name that is used to refer to the package in other packages' dependencies.   | String | required |  |
+| entry_points |  entry_points, e.g. <code>{'console_scripts': ['main = examples.wheel.main:main']}</code>.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional | {} |
+| extra_requires |  List of optional requirements for this package   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional | {} |
+| homepage |  A string specifying the URL for the package homepage.   | String | optional | "" |
+| license |  A string specifying the license of the package.   | String | optional | "" |
+| platform |  Supported platform. Use 'any' for pure-Python wheel.<br><br>If you have included platform-specific data, such as a .pyd or .so extension module, you will need to specify the platform in standard pip format. If you support multiple platforms, you can define platform constraints, then use a select() to specify the appropriate specifier, eg:<br><br>&lt;code&gt; platform = select({     "//platforms:windows_x86_64": "win_amd64",     "//platforms:macos_x86_64": "macosx_10_7_x86_64",     "//platforms:linux_x86_64": "manylinux2014_x86_64", }) &lt;/code&gt;   | String | optional | "any" |
+| python_requires |  A string specifying what other distributions need to be installed when this one is. See the section on [Declaring required dependency](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-dependencies) for details and examples of the format of this argument.   | String | optional | "" |
+| python_tag |  Supported Python version(s), eg <code>py3</code>, <code>cp35.cp36</code>, etc   | String | optional | "py3" |
+| requires |  List of requirements for this package   | List of strings | optional | [] |
+| strip_path_prefixes |  path prefixes to strip from files added to the generated package   | List of strings | optional | [] |
+| version |  Version number of the package   | String | required |  |
 
 

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -5,149 +5,81 @@
 ## pip_import
 
 <pre>
-pip_import(<a href="#pip_import-name">name</a>, <a href="#pip_import-extra_pip_args">extra_pip_args</a>, <a href="#pip_import-python_interpreter">python_interpreter</a>, <a href="#pip_import-python_interpreter_target">python_interpreter_target</a>, <a href="#pip_import-requirements">requirements</a>, <a href="#pip_import-timeout">timeout</a>)
+pip_import(<a href="#pip_import-kwargs">kwargs</a>)
 </pre>
 
-A rule for importing `requirements.txt` dependencies into Bazel.
 
-This rule imports a `requirements.txt` file and generates a new
-`requirements.bzl` file.  This is used via the `WORKSPACE` pattern:
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a name="#pip_install"></a>
+
+## pip_install
+
+<pre>
+pip_install(<a href="#pip_install-requirements">requirements</a>, <a href="#pip_install-name">name</a>, <a href="#pip_install-kwargs">kwargs</a>)
+</pre>
+
+Imports a `requirements.txt` file and generates a new `requirements.bzl` file.
+
+This is used via the `WORKSPACE` pattern:
 
 ```python
-pip_import(
-    name = "foo",
+pip_install(
     requirements = ":requirements.txt",
 )
-load("@foo//:requirements.bzl", "pip_install")
-pip_install()
 ```
 
 You can then reference imported dependencies from your `BUILD` file with:
 
 ```python
-load("@foo//:requirements.bzl", "requirement")
+load("@pip//:requirements.bzl", "requirement")
 py_library(
     name = "bar",
     ...
     deps = [
        "//my/other:dep",
-       requirement("futures"),
-       requirement("mock"),
+       requirement("requests"),
+       requirement("numpy"),
     ],
 )
 ```
 
-Or alternatively:
-```python
-load("@foo//:requirements.bzl", "all_requirements")
-py_binary(
-    name = "baz",
-    ...
-    deps = [
-       ":foo",
-    ] + all_requirements,
-)
-```
+
+**PARAMETERS**
 
 
-### Attributes
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="pip_import-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this repository.
-        </p>
-      </td>
-    </tr>
-    <tr id="pip_import-extra_pip_args">
-      <td><code>extra_pip_args</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          Extra arguments to pass on to pip. Must not contain spaces.
-        </p>
-      </td>
-    </tr>
-    <tr id="pip_import-python_interpreter">
-      <td><code>python_interpreter</code></td>
-      <td>
-        String; optional
-        <p>
-          The command to run the Python interpreter used to invoke pip and unpack the
-wheels.
-        </p>
-      </td>
-    </tr>
-    <tr id="pip_import-python_interpreter_target">
-      <td><code>python_interpreter_target</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
-        <p>
-          If you are using a custom python interpreter built by another repository rule,
-use this attribute to specify its BUILD target. This allows pip_import to invoke
-pip using the same interpreter as your toolchain. If set, takes precedence over
-python_interpreter.
-        </p>
-      </td>
-    </tr>
-    <tr id="pip_import-requirements">
-      <td><code>requirements</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
-        <p>
-          The label of the requirements.txt file.
-        </p>
-      </td>
-    </tr>
-    <tr id="pip_import-timeout">
-      <td><code>timeout</code></td>
-      <td>
-        Integer; optional
-        <p>
-          Timeout (in seconds) for repository fetch.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| requirements |  A 'requirements.txt' pip requirements file.   |  none |
+| name |  A unique name for the created external repository (default 'pip').   |  <code>"pip"</code> |
+| kwargs |  Keyword arguments passed directly to the <code>pip_repository</code> repository rule.   |  none |
 
 
-<a name="#pip3_import"></a>
+<a name="#pip_parse"></a>
 
-## pip3_import
+## pip_parse
 
 <pre>
-pip3_import(<a href="#pip3_import-kwargs">kwargs</a>)
+pip_parse(<a href="#pip_parse-requirements_lock">requirements_lock</a>, <a href="#pip_parse-name">name</a>, <a href="#pip_parse-kwargs">kwargs</a>)
 </pre>
 
-A wrapper around pip_import that uses the `python3` system command.
 
-Use this for requirements of PY3 programs.
 
-### Parameters
+**PARAMETERS**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="pip3_import-kwargs">
-      <td><code>kwargs</code></td>
-      <td>
-        optional.
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| requirements_lock |  <p align="center"> - </p>   |  none |
+| name |  <p align="center"> - </p>   |  <code>"pip_parsed_deps"</code> |
+| kwargs |  <p align="center"> - </p>   |  none |
 
 
 <a name="#pip_repositories"></a>
@@ -158,7 +90,9 @@ Use this for requirements of PY3 programs.
 pip_repositories()
 </pre>
 
-Pull in dependencies needed to use the packaging rules.
+
+
+**PARAMETERS**
 
 
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,5 +1,33 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+<a name="#py_import"></a>
+
+## py_import
+
+<pre>
+py_import(<a href="#py_import-name">name</a>, <a href="#py_import-deps">deps</a>, <a href="#py_import-srcs">srcs</a>)
+</pre>
+
+This rule allows the use of Python packages as dependencies.
+
+    It imports the given `.egg` file(s), which might be checked in source files,
+    fetched externally as with `http_file`, or produced as outputs of other rules.
+
+    It may be used like a `py_library`, in the `deps` of other Python rules.
+
+    This is similar to [java_import](https://docs.bazel.build/versions/master/be/java.html#java_import).
+    
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| deps |  The list of other libraries to be linked in to the binary target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| srcs |  The list of Python package files provided to Python targets that depend on this target. Note that currently only the .egg format is accepted. For .whl files, try the whl_library rule. We accept contributions to extend py_import to handle .whl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+
+
 <a name="#py_runtime_pair"></a>
 
 ## py_runtime_pair
@@ -68,45 +96,14 @@ register_toolchains("//my_pkg:my_toolchain")
 ```
 
 
-### Attributes
+**ATTRIBUTES**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_runtime_pair-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_runtime_pair-py2_runtime">
-      <td><code>py2_runtime</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
-        <p>
-          The runtime to use for Python 2 targets. Must have `python_version` set to
-`PY2`.
-        </p>
-      </td>
-    </tr>
-    <tr id="py_runtime_pair-py3_runtime">
-      <td><code>py3_runtime</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
-        <p>
-          The runtime to use for Python 3 targets. Must have `python_version` set to
-`PY3`.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| py2_runtime |  The runtime to use for Python 2 targets. Must have <code>python_version</code> set to <code>PY2</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| py3_runtime |  The runtime to use for Python 3 targets. Must have <code>python_version</code> set to <code>PY3</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a name="#py_binary"></a>
@@ -119,25 +116,12 @@ py_binary(<a href="#py_binary-attrs">attrs</a>)
 
 See the Bazel core [py_binary](https://docs.bazel.build/versions/master/be/python.html#py_binary) documentation.
 
-### Parameters
+**PARAMETERS**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_binary-attrs">
-      <td><code>attrs</code></td>
-      <td>
-        optional.
-        <p>
-          Rule attributes
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| attrs |  Rule attributes   |  none |
 
 
 <a name="#py_library"></a>
@@ -150,25 +134,12 @@ py_library(<a href="#py_library-attrs">attrs</a>)
 
 See the Bazel core [py_library](https://docs.bazel.build/versions/master/be/python.html#py_library) documentation.
 
-### Parameters
+**PARAMETERS**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_library-attrs">
-      <td><code>attrs</code></td>
-      <td>
-        optional.
-        <p>
-          Rule attributes
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| attrs |  Rule attributes   |  none |
 
 
 <a name="#py_runtime"></a>
@@ -181,25 +152,12 @@ py_runtime(<a href="#py_runtime-attrs">attrs</a>)
 
 See the Bazel core [py_runtime](https://docs.bazel.build/versions/master/be/python.html#py_runtime) documentation.
 
-### Parameters
+**PARAMETERS**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_runtime-attrs">
-      <td><code>attrs</code></td>
-      <td>
-        optional.
-        <p>
-          Rule attributes
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| attrs |  Rule attributes   |  none |
 
 
 <a name="#py_test"></a>
@@ -212,24 +170,40 @@ py_test(<a href="#py_test-attrs">attrs</a>)
 
 See the Bazel core [py_test](https://docs.bazel.build/versions/master/be/python.html#py_test) documentation.
 
-### Parameters
+**PARAMETERS**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="py_test-attrs">
-      <td><code>attrs</code></td>
-      <td>
-        optional.
-        <p>
-          Rule attributes
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| attrs |  Rule attributes   |  none |
+
+
+<a name="#find_requirements"></a>
+
+## find_requirements
+
+<pre>
+find_requirements(<a href="#find_requirements-name">name</a>)
+</pre>
+
+The aspect definition. Can be invoked on the command line as
+
+    bazel build //pkg:my_py_binary_target         --aspects=@rules_python//python:defs.bzl%find_requirements         --output_groups=pyversioninfo
+
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :-------------: | :-------------: |
+| deps| String |
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 
 

--- a/docs/whl.md
+++ b/docs/whl.md
@@ -26,63 +26,15 @@ whl_library(
 This rule defines `@foo//:pkg` as a `py_library` target.
 
 
-### Attributes
+**ATTRIBUTES**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="whl_library-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this repository.
-        </p>
-      </td>
-    </tr>
-    <tr id="whl_library-extras">
-      <td><code>extras</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          A subset of the "extras" available from this <code>.whl</code> for which
-<code>requirements</code> has the dependencies.
-        </p>
-      </td>
-    </tr>
-    <tr id="whl_library-python_interpreter">
-      <td><code>python_interpreter</code></td>
-      <td>
-        String; optional
-        <p>
-          The command to run the Python interpreter used when unpacking the wheel.
-        </p>
-      </td>
-    </tr>
-    <tr id="whl_library-requirements">
-      <td><code>requirements</code></td>
-      <td>
-        String; optional
-        <p>
-          The name of the <code>pip_import</code> repository rule from which to load this
-<code>.whl</code>'s dependencies.
-        </p>
-      </td>
-    </tr>
-    <tr id="whl_library-whl">
-      <td><code>whl</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
-        <p>
-          The path to the <code>.whl</code> file. The name is expected to follow [this
-convention](https://www.python.org/dev/peps/pep-0427/#file-name-convention)).
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| extras |  A subset of the "extras" available from this &lt;code&gt;.whl&lt;/code&gt; for which &lt;code&gt;requirements&lt;/code&gt; has the dependencies.   | List of strings | optional | [] |
+| python_interpreter |  The command to run the Python interpreter used when unpacking the wheel.   | String | optional | "python" |
+| requirements |  The name of the &lt;code&gt;pip_import&lt;/code&gt; repository rule from which to load this &lt;code&gt;.whl&lt;/code&gt;'s dependencies.   | String | optional | "" |
+| whl |  The path to the &lt;code&gt;.whl&lt;/code&gt; file. The name is expected to follow [this convention](https://www.python.org/dev/peps/pep-0427/#file-name-convention)).   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -29,10 +29,10 @@ def rules_python_internal_deps():
 
     maybe(
         http_archive,
-        name = "io_bazel_skydoc",
-        url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
-        sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
-        strip_prefix = "skydoc-0.3.0",
+        name = "io_bazel_stardoc",
+        url = "https://github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
+        sha256 = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
+        strip_prefix = "stardoc-0.4.0",
     )
 
     # Test data for WHL tool testing.

--- a/update_docs.sh
+++ b/update_docs.sh
@@ -21,3 +21,4 @@ bazel build //docs/...
 cp bazel-bin/docs/python.md docs/
 cp bazel-bin/docs/pip.md docs/
 cp bazel-bin/docs/whl.md docs/
+cp bazel-bin/docs/packaging.md docs/


### PR DESCRIPTION
Using https://github.com/bazelbuild/stardoc/releases/tag/0.4.0

> First release of Stardoc under the new repository location bazelbuild/stardoc. Please use this repository for future Stardoc releases instead of its old location.

Begins addressing https://github.com/bazelbuild/rules_python/issues/255. We can close that issue once we've removed needless `<code>` tags in docs, and instead use backticks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
