### PR TITLE
pip_install: avoid assuming 'Root-Is-Purelib' is provided in all WHEEL files

### DIFF
--- a/python/pip_install/extract_wheels/lib/purelib.py
+++ b/python/pip_install/extract_wheels/lib/purelib.py
@@ -15,13 +15,9 @@ def spread_purelib_into_root(wheel_dir: str) -> None:
     wheel_metadata_file_path = pathlib.Path(dist_info, "WHEEL")
     wheel_metadata_dict = wheel.parse_wheel_meta_file(str(wheel_metadata_file_path))
 
-    if "Root-Is-Purelib" not in wheel_metadata_dict:
-        raise ValueError(
-            "Invalid WHEEL file '%s'. Expected key 'Root-Is-Purelib'."
-            % wheel_metadata_file_path
-        )
-    root_is_purelib = wheel_metadata_dict["Root-Is-Purelib"]
-
+    # It is not guaranteed that a WHEEL file author populates 'Root-Is-Purelib'.
+    # See: https://github.com/bazelbuild/rules_python/issues/435
+    root_is_purelib: str = wheel_metadata_dict.get("Root-Is-Purelib", "")
     if root_is_purelib.lower() == "true":
         # The Python package code is in the root of the Wheel, so no need to 'spread' anything.
         return


### PR DESCRIPTION
Fixing https://github.com/bazelbuild/rules_python/issues/435

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: https://github.com/bazelbuild/rules_python/issues/435

`pip_install` can't install `catboost <= 2.25.0` because it doesn't specify 'Root-Is-Purelib' at all.


## What is the new behavior?

Absence of `'Root-Is-Purelib'` in wheel metadata means the value is assumed false.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


