### PR TITLE
Remove reference to 'rules_python_external'

### DIFF
--- a/python/pip_install/extract_wheels/lib/namespace_pkgs.py
+++ b/python/pip_install/extract_wheels/lib/namespace_pkgs.py
@@ -68,7 +68,7 @@ def add_pkgutil_style_namespace_pkg_init(dir_path: str) -> None:
         ns_pkg_init_f.write(
             textwrap.dedent(
                 """\
-                # __path__ manipulation added by rules_python_external to support namespace pkgs.
+                # __path__ manipulation added by bazelbuild/rules_python to support namespace pkgs.
                 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
                 """
             )


### PR DESCRIPTION
Noticed this a couple of week ago. How did it survive this long 😓. 

----

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

