### PR TITLE
Ensure pip_compile_requirements' py_binary target can recieve 'tags'

### DIFF
--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -9,6 +9,7 @@ def compile_pip_requirements(
         visibility = ["//visibility:private"],
         requirements_in = None,
         requirements_txt = None,
+        tags = None,
         **kwargs):
     """
     Macro creating targets for running pip-compile
@@ -28,6 +29,7 @@ def compile_pip_requirements(
         visibility: passed to both the _test and .update rules
         requirements_in: file expressing desired dependencies
         requirements_txt: result of "compiling" the requirements.in file
+        tags: tagging attribute common to all build rules, passed to both the _test and .update rules
         **kwargs: other bazel attributes passed to the "_test" rule
     """
     requirements_in = name + ".in" if requirements_in == None else requirements_in
@@ -69,6 +71,7 @@ def compile_pip_requirements(
         "deps": deps,
         "main": pip_compile,
         "srcs": [pip_compile],
+        "tags": tags,
         "visibility": visibility,
     }
 


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


### What is the current behavior?

The `py_test` target created by `compile_pip_requirements` can receive tags via `**kwargs` but the `py_binary` target (.update) cannot. 

### What is the new behavior?

Both targets created by the `compile_pip_requirements` macro can receive tags.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

