### PR TITLE
Fix extract_single_wheel for Windows

### DIFF
--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import sys
 import glob
@@ -29,15 +30,25 @@ def main() -> None:
     if args.extra_pip_args:
         pip_args += json.loads(args.extra_pip_args)["args"]
 
-    with NamedTemporaryFile(mode='wb') as requirement_file:
+    requirement_file = NamedTemporaryFile(mode='wb', delete=False)
+    try:
         requirement_file.write(args.requirement.encode("utf-8"))
         requirement_file.flush()
+        # Close the file so pip is allowed to read it when running on Windows.
+        # For more information, see: https://bugs.python.org/issue14243
+        requirement_file.close()
         # Requirement specific args like --hash can only be passed in a requirements file,
         # so write our single requirement into a temp file in case it has any of those flags.
         pip_args.extend(["-r", requirement_file.name])
 
         # Assumes any errors are logged by pip so do nothing. This command will fail if pip fails
         subprocess.run(pip_args, check=True)
+    finally:
+        try:
+            os.unlink(requirement_file.name)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
     name, extras_for_pkg = requirements._parse_requirement_for_extra(args.requirement)
     extras = {name: extras_for_pkg} if extras_for_pkg and name else dict()


### PR DESCRIPTION
On Windows, when using pip_parse, pip would fail with following error:

    Could not open requirements file: [Errno 13] Permission denied: ...

This is due to Python holding a handle to the temporary file preventing
pip, which is run as a sub-process, from reading it. For more
information, see: https://bugs.python.org/issue14243

Closing the requirements file before running pip solves the problem.

---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

`pip_parse` works on Windows.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

