### PR TITLE
Terminology update 'master' to 'main' in DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Releasing
 
-Start from a clean checkout at `master`.
+Start from a clean checkout at `main`.
 
 Before running through the release it's good to run the build and the tests locally, and make sure CI is passing. You can
 also test-drive the commit in an existing Bazel workspace to sanity check functionality.
@@ -23,7 +23,7 @@ those with only bug fixes and other minor changes bump the patch digit.
 5. Create commit called "Release X.Y.Z"
     1. ["release 0.1.0"](https://github.com/bazelbuild/rules_python/commit/c8c79aae9aa1b61d199ad03d5fe06338febd0774) is an example commit.
 6. Tag that commit as `X.Y.Z`. Eg. `git tag X.Y.Z`
-7. Push the commit and the new tag to `master`.
+7. Push the commit and the new tag to `main`.
 8. Run `bazel build //distro:relnotes` from within workspace and then from repo root run `cat bazel-bin/distro/relnotes.txt` to get the 'install instructions' that are added as release notes.
     1. Check the `sha256` value matches the one you calculated earlier.
 9. ["Draft a new release"](https://github.com/bazelbuild/rules_python/releases/new) in Github (manual for now), selecting the recently pushed `X.Y.Z` tag.


### PR DESCRIPTION
Change directly related to #500 

As far as I can see these are the only relevant `master` refs in the codebase.

----

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
