### PR TITLE
Fix regression in pip parse for finding implicit namespace packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,39 +76,43 @@ py_binary(
 
 ## Using the packaging rules
 
-The packaging rules create two kinds of repositories: A central repo that holds
-downloaded wheel files, and individual repos for each wheel's extracted
-contents. Users only need to interact with the central repo; the wheel repos
-are essentially an implementation detail. The central repo provides a
-`WORKSPACE` macro to create the wheel repos, as well as a function to call in
-`BUILD` files to translate a pip package name into the label of a `py_library`
+Usage of the packaging rules involves two main steps.
+
+1. [Installing `pip` dependencies](#installing-pip-dependencies)
+2. [Consuming `pip` dependencies](#consuming-pip-dependencies)
+
+The packaging rules create two kinds of repositories: A central external repo that holds
+downloaded wheel files, and individual external repos for each wheel's extracted
+contents. Users only need to interact with the central external repo; the wheel repos
+are essentially an implementation detail. The central external repo provides a
+`WORKSPACE` macro to create the wheel repos, as well as a function, `requirement()`, for use in
+`BUILD` files that translates a pip package name into the label of a `py_library`
 target in the appropriate wheel repo.
 
-### Importing `pip` dependencies
+### Installing `pip` dependencies
 
-To add pip dependencies to your `WORKSPACE` load
-the `pip_install` function, and call it to create the
-individual wheel repos.
+To add pip dependencies to your `WORKSPACE`, load the `pip_install` function, and call it to create the
+central external repo and individual wheel external repos.
 
 
 ```python
 load("@rules_python//python:pip.bzl", "pip_install")
 
-# Create a central repo that knows about the dependencies needed for
-# requirements.txt.
+# Create a central external repo, @my_deps, that contains Bazel targets for all the
+# third-party packages specified in the requirements.txt file.
 pip_install(
    name = "my_deps",
    requirements = "//path/to:requirements.txt",
 )
 ```
 
-Note that since pip is executed at WORKSPACE-evaluation time, Bazel has no
+Note that since `pip_install` is a repository rule and therefore executes pip at WORKSPACE-evaluation time, Bazel has no
 information about the Python toolchain and cannot enforce that the interpreter
 used to invoke pip matches the interpreter used to run `py_binary` targets. By
 default, `pip_install` uses the system command `"python3"`. This can be overridden by passing the
 `python_interpreter` attribute or `python_interpreter_target` attribute to `pip_install`.
 
-You can have multiple `pip_install`s in the same workspace. This will create multiple central repos that have no relation to
+You can have multiple `pip_install`s in the same workspace. This will create multiple external repos that have no relation to
 one another, and may result in downloading the same wheels multiple times.
 
 As with any repository rule, if you would like to ensure that `pip_install` is

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -184,7 +184,7 @@ def extract_wheel(
     enable_implicit_namespace_pkgs: bool,
     incremental: bool = False,
     incremental_repo_prefix: Optional[str] = None,
-) -> str:
+) -> Optional[str]:
     """Extracts wheel into given directory and creates py_library and filegroup targets.
 
     Args:
@@ -251,3 +251,4 @@ def extract_wheel(
     if not incremental:
         os.remove(whl.path)
         return f"//{directory}"
+    return None

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -250,5 +250,4 @@ def extract_wheel(
 
     if not incremental:
         os.remove(whl.path)
-
-    return "//%s" % directory
+        return f"//{directory}"

--- a/python/pip_install/extract_wheels/lib/namespace_pkgs.py
+++ b/python/pip_install/extract_wheels/lib/namespace_pkgs.py
@@ -25,7 +25,7 @@ def implicit_namespace_packages(
     # Traverse bottom-up because a directory can be a namespace pkg because its child contains module files.
     for dirpath, dirnames, filenames in os.walk(directory, topdown=False):
         if "__init__.py" in filenames:
-            standard_pkg_dirs.add(dirpath)
+            standard_pkg_dirs.add(str(pathlib.Path(dirpath)))
             continue
         elif ignored_dirnames:
             is_ignored_dir = dirpath in ignored_dirnames

--- a/python/pip_install/extract_wheels/lib/namespace_pkgs.py
+++ b/python/pip_install/extract_wheels/lib/namespace_pkgs.py
@@ -1,13 +1,13 @@
 """Utility functions to discover python package types"""
 import os
-import pathlib  # supported in >= 3.4
+from pathlib import Path  # supported in >= 3.4
 import textwrap
 from typing import Set, List, Optional
 
 
 def implicit_namespace_packages(
     directory: str, ignored_dirnames: Optional[List[str]] = None
-) -> Set[str]:
+) -> Set[Path]:
     """Discovers namespace packages implemented using the 'native namespace packages' method.
 
     AKA 'implicit namespace packages', which has been supported since Python 3.3.
@@ -20,37 +20,36 @@ def implicit_namespace_packages(
     Returns:
         The set of directories found under root to be packages using the native namespace method.
     """
-    namespace_pkg_dirs: Set[str] = set()
-    standard_pkg_dirs: Set[str] = set()
+    namespace_pkg_dirs: Set[Path] = set()
+    standard_pkg_dirs: Set[Path] = set()
+    directory_path = Path(directory)
+    ignored_dirname_paths: List[Path] = [Path(p) for p in ignored_dirnames or ()]
     # Traverse bottom-up because a directory can be a namespace pkg because its child contains module files.
-    directory = pathlib.Path(directory)
-    ignored_dirnames = [pathlib.Path(p) for p in ignored_dirnames or ()]
-    for dirpath, dirnames, filenames in os.walk(directory, topdown=False):
-        dirpath = pathlib.Path(dirpath)
+    for dirpath, dirnames, filenames in map(lambda t: (Path(t[0]), *t[1:]), os.walk(directory_path, topdown=False)):
         if "__init__.py" in filenames:
             standard_pkg_dirs.add(dirpath)
             continue
-        elif ignored_dirnames:
-            is_ignored_dir = dirpath in ignored_dirnames
-            child_of_ignored_dir = any(d in dirpath.parents for d in ignored_dirnames)
+        elif ignored_dirname_paths:
+            is_ignored_dir = dirpath in ignored_dirname_paths
+            child_of_ignored_dir = any(d in dirpath.parents for d in ignored_dirname_paths)
             if is_ignored_dir or child_of_ignored_dir:
                 continue
 
         dir_includes_py_modules = _includes_python_modules(filenames)
-        parent_of_namespace_pkg = any(pathlib.Path(dirpath, d) in namespace_pkg_dirs for d in dirnames)
-        parent_of_standard_pkg = any(pathlib.Path(dirpath, d) in standard_pkg_dirs for d in dirnames)
+        parent_of_namespace_pkg = any(Path(dirpath, d) in namespace_pkg_dirs for d in dirnames)
+        parent_of_standard_pkg = any(Path(dirpath, d) in standard_pkg_dirs for d in dirnames)
         parent_of_pkg = parent_of_namespace_pkg or parent_of_standard_pkg
         if (
             (dir_includes_py_modules or parent_of_pkg)
             and
             # The root of the directory should never be an implicit namespace
-            dirpath != directory
+            dirpath != directory_path
         ):
             namespace_pkg_dirs.add(dirpath)
     return namespace_pkg_dirs
 
 
-def add_pkgutil_style_namespace_pkg_init(dir_path: pathlib.Path) -> None:
+def add_pkgutil_style_namespace_pkg_init(dir_path: Path) -> None:
     """Adds 'pkgutil-style namespace packages' init file to the given directory
 
     See: https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
@@ -98,7 +97,7 @@ def _includes_python_modules(files: List[str]) -> bool:
         ".pyd"  # https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll
     }
     return any(
-        pathlib.Path(f).suffix in module_suffixes
+        Path(f).suffix in module_suffixes
         for f
         in files
     )

--- a/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
+++ b/python/pip_install/extract_wheels/lib/whl_filegroup_test.py
@@ -34,8 +34,10 @@ class TestWhlFilegroup(unittest.TestCase):
             enable_implicit_namespace_pkgs=False,
             incremental=incremental,
             incremental_repo_prefix=incremental_repo_prefix
-        )[2:]  # Take off the leading // from the returned label.
+        )
+        # Take off the leading // from the returned label.
         # Assert that the raw wheel ends up in the package.
+        generated_bazel_dir = generated_bazel_dir[2:] if not incremental else self.wheel_dir
         self.assertIn(self.wheel_name, os.listdir(generated_bazel_dir))
         with open("{}/BUILD.bazel".format(generated_bazel_dir)) as build_file:
             build_file_content = build_file.read()

--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -118,6 +118,8 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
             )
         )
 
+def coerce_to_bool(option):
+    return str(option).lower() == 'true'
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -132,8 +134,8 @@ dependencies from a fully resolved requirements lock file."
     )
     parser.add_argument(
         "--quiet",
-        type=bool,
-        action="store",
+        type=coerce_to_bool,
+        default=True,
         required=True,
         help="Whether to print stdout / stderr from child repos.",
     )


### PR DESCRIPTION
fixes #499 
Pathlib.Path normalizes path names, which caused lookups of relative
paths using the special '.' directory path to fail to find parents of
standard packages.

Drive-by change fixes passing quiet argument to child repos.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
pip_parse fails to find implicit namespace packages.

Issue Number: #499 


## What is the new behavior?
pip_parse can find implicit namespace packages.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

