### PR TITLE
pip_parse: Fix when using a python wrapper script

### DIFF
--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -141,7 +141,9 @@ dependencies from a fully resolved requirements lock file."
     )
     parser.add_argument(
         "--python_interpreter_target",
-        help="Bazel target of the python interpreter. It will take precedence over python_interpreter.",
+        help="Bazel target of a python interpreter.\
+It will be used in repository rules so it must be an already built interpreter.\
+If set, it will take precedence over python_interpreter.",
     )
     parser.add_argument(
         "--quiet",

--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -136,6 +136,14 @@ dependencies from a fully resolved requirements lock file."
         help="Path to fully resolved requirements.txt to use as the source of repos.",
     )
     parser.add_argument(
+        "--python_interpreter",
+        help="The python interpreter that will be used to download and unpack the wheels.",
+    )
+    parser.add_argument(
+        "--python_interpreter_target",
+        help="Bazel target of the python interpreter. It will take precedence over python_interpreter.",
+    )
+    parser.add_argument(
         "--quiet",
         type=coerce_to_bool,
         default=True,

--- a/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
+++ b/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
@@ -26,6 +26,8 @@ class TestParseRequirementsToBzl(unittest.TestCase):
             pip_data_exclude = ["**.foo"]
             args.extra_pip_args = json.dumps({"arg": extra_pip_args})
             args.pip_data_exclude= json.dumps({"arg": pip_data_exclude})
+            args.python_interpreter = "/custom/python3"
+            args.python_interpreter_target = "@custom_python//:exec"
             args.environment= json.dumps({"arg": {}})
             contents = generate_parsed_requirements_contents(args)
             library_target = "@pip_parsed_deps_pypi__foo//:pkg"
@@ -38,6 +40,8 @@ class TestParseRequirementsToBzl(unittest.TestCase):
             all_flags = extra_pip_args + ["--require-hashes", "True"]
             self.assertIn("'extra_pip_args': {}".format(repr(all_flags)), contents, contents)
             self.assertIn("'pip_data_exclude': {}".format(repr(pip_data_exclude)), contents, contents)
+            self.assertIn("'python_interpreter': '/custom/python3'", contents, contents)
+            self.assertIn("'python_interpreter_target': '@custom_python//:exec'", contents, contents)
             # Assert it gets set to an empty dict by default.
             self.assertIn("'environment': {}", contents, contents)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When using `pip_parse` with a python wrapper script in `python_interpreter` or `python_interpreter_target`, the declared `whl_library` do not use the wrapper script but directly the underlying python interpreter given by `sys.executable`.

We use a portable python distribution that needs some environment adaptation in the `PATH` and `LD_LIBRARY_PRELOAD` variables to run properly. Calling directly the python interpreter binary fails, so `pip_parse` itself is successful but the wheels cannot be retrieved.


## What is the new behavior?

 - `pip_parse` now transmits `python_interpreter` and `python_interpreter_target` attributes to the `whl_library` targets
 - `whl_library` now takes `python_interpreter_target` in account


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
