### PR TITLE
Add support for multi-platform `pip download` to pip_parse

### DIFF
--- a/python/pip_install/extract_wheels/lib/arguments.py
+++ b/python/pip_install/extract_wheels/lib/arguments.py
@@ -35,11 +35,10 @@ def deserialize_structured_args(args):
     Args:
         args: dict of parsed command line arguments
     """
-    structured_args = ("extra_pip_args", "pip_data_exclude", "environment")
+    structured_args = ("extra_pip_args", "pip_data_exclude", "environment", "pip_platform_definitions")
     for arg_name in structured_args:
         if args.get(arg_name) is not None:
             args[arg_name] = json.loads(args[arg_name])["arg"]
         else:
             args[arg_name] = []
     return args
-

--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -3,7 +3,7 @@ import json
 import textwrap
 import sys
 import shlex
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from python.pip_install.extract_wheels.lib import bazel, arguments
 from pip._internal.req import parse_requirements, constructors
@@ -36,14 +36,31 @@ def parse_install_requirements(requirements_lock: str, extra_pip_args: List[str]
     return install_req_and_lines
 
 
-def repo_names_and_requirements(install_reqs: List[Tuple[InstallRequirement, str]], repo_prefix: str) -> List[Tuple[str, str]]:
-    return [
-        (
-            bazel.sanitise_name(ir.name, prefix=repo_prefix),
-            line,
-        )
-        for ir, line in install_reqs
-    ]
+class NamesAndRequirements:
+    def __init__(self, whls: List[Tuple[str, str, Optional[str]]], aliases: List[Tuple[str, Dict[str, str]]]):
+        self.whls = whls
+        self.aliases = aliases
+
+
+def repo_names_and_requirements(
+        install_reqs: List[Tuple[InstallRequirement, str]],
+        repo_prefix: str,
+        platforms: Dict[str, str]) -> NamesAndRequirements:
+    whls = []
+    aliases = []
+    for ir, line in install_reqs:
+        generic_name = bazel.sanitise_name(ir.name, prefix=repo_prefix)
+        if not platforms:
+            whls.append((generic_name, line, None))
+        else:
+            select_items = {}
+            for key, platform in platforms.items():
+                prefix = bazel.sanitise_name(platform, prefix=repo_prefix) + "__"
+                name = bazel.sanitise_name(ir.name, prefix=prefix)
+                whls.append((name, line, platform))
+                select_items[key] = "@{name}//:pkg".format(name=name)
+            aliases.append((generic_name, select_items))
+    return NamesAndRequirements(whls, aliases)
 
 
 def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
@@ -58,12 +75,13 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
     args = dict(vars(all_args))
     args = arguments.deserialize_structured_args(args)
     args.setdefault("python_interpreter", sys.executable)
-    # Pop this off because it wont be used as a config argument to the whl_library rule.
+    # Pop these off because they won't be used as a config argument to the whl_library rule.
     requirements_lock = args.pop("requirements_lock")
+    pip_platform_definitions = args.pop("pip_platform_definitions")
     repo_prefix = bazel.whl_library_repo_prefix(args["repo"])
 
     install_req_and_lines = parse_install_requirements(requirements_lock, args["extra_pip_args"])
-    repo_names_and_reqs = repo_names_and_requirements(install_req_and_lines, repo_prefix)
+    repo_names_and_reqs = repo_names_and_requirements(install_req_and_lines, repo_prefix, pip_platform_definitions)
     all_requirements = ", ".join(
         [bazel.sanitised_repo_library_label(ir.name, repo_prefix=repo_prefix) for ir, _ in install_req_and_lines]
     )
@@ -71,13 +89,14 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
         [bazel.sanitised_repo_file_label(ir.name, repo_prefix=repo_prefix) for ir, _ in install_req_and_lines]
     )
     return textwrap.dedent("""\
-        load("@rules_python//python/pip_install:pip_repository.bzl", "whl_library")
+        load("@rules_python//python/pip_install:pip_repository.bzl", "whl_library", "platform_alias")
 
         all_requirements = [{all_requirements}]
 
         all_whl_requirements = [{all_whl_requirements}]
 
-        _packages = {repo_names_and_reqs}
+        _packages = {whl_definitions}
+        _aliases = {alias_definitions}
         _config = {args}
 
         def _clean_name(name):
@@ -90,18 +109,26 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
            return "@{repo_prefix}" + _clean_name(name) + "//:whl"
 
         def install_deps():
-            for name, requirement in _packages:
+            for name, requirement, platform in _packages:
                 whl_library(
                     name = name,
                     requirement = requirement,
+                    pip_platform_definition = platform,
                     **_config,
+                )
+            for name, select_items in _aliases:
+                platform_alias(
+                    name = name,
+                    select_items = select_items,
                 )
         """.format(
             all_requirements=all_requirements,
             all_whl_requirements=all_whl_requirements,
-            repo_names_and_reqs=repo_names_and_reqs,
+            whl_definitions=repo_names_and_reqs.whls,
+            alias_definitions=repo_names_and_reqs.aliases,
             args=args,
             repo_prefix=repo_prefix,
+            pip_platform_definitions=pip_platform_definitions,
             )
         )
 
@@ -132,6 +159,11 @@ dependencies from a fully resolved requirements lock file."
         action="store",
         required=True,
         help="timeout to use for pip operation.",
+    )
+    parser.add_argument(
+        "--pip_platform_definitions",
+        help="A map of select keys to platform definitions in the form "
+             + "<platform>-<python_version>-<implementation>-<abi>",
     )
     arguments.parse_common_args(parser)
     args = parser.parse_args()

--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
@@ -21,6 +21,10 @@ def main() -> None:
         required=True,
         help="A single PEP508 requirement specifier string.",
     )
+    parser.add_argument(
+        "--pip_platform_definition",
+        help="A pip platform definition in the form <platform>-<python_version>-<implementation>-<abi>",
+    )
     arguments.parse_common_args(parser)
     args = parser.parse_args()
     deserialized_args = dict(vars(args))
@@ -28,10 +32,20 @@ def main() -> None:
 
     configure_reproducible_wheels()
 
-    pip_args = (
-        [sys.executable, "-m", "pip", "--isolated", "wheel", "--no-deps"] +
-        deserialized_args["extra_pip_args"]
-    )
+    pip_args = [sys.executable, "-m", "pip", "--isolated"]
+    if args.pip_platform_definition:
+        platform, python_version, implementation, abi = args.pip_platform_definition.split("-")
+        pip_args.extend([
+            "download",
+            "--only-binary", ":all:",
+            "--platform", platform,
+            "--python-version", python_version,
+            "--implementation", implementation,
+            "--abi", abi
+        ])
+    else:
+        pip_args.append("wheel")
+    pip_args.extend(["--no-deps"] + deserialized_args["extra_pip_args"])
 
     requirement_file = NamedTemporaryFile(mode='wb', delete=False)
     try:

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -183,6 +183,11 @@ pip_repository_attrs = {
         default = False,
         doc = "Create the repository in incremental mode.",
     ),
+    "pip_platform_definitions": attr.label_keyed_string_dict(
+        doc = """
+A map of select keys to platform definitions in the form <platform>-<python_version>-<implementation>-<abi>"
+        """,
+    ),
     "requirements": attr.label(
         allow_single_file = True,
         doc = "A 'requirements.txt' pip requirements file.",
@@ -195,11 +200,6 @@ of 'requirements' no resolve will take place and pip_repository will create indi
 wheels are fetched/built only for the targets specified by 'build/run/test'.
 """,
     ),
-    "pip_platform_definitions": attr.label_keyed_string_dict(
-        doc = """
-A map of select keys to platform definitions in the form <platform>-<python_version>-<implementation>-<abi>"
-        """
-    )
 }
 
 pip_repository_attrs.update(**common_attrs)
@@ -282,6 +282,9 @@ def _impl_whl_library(rctx):
     return
 
 whl_library_attrs = {
+    "pip_platform_definition": attr.string(
+        doc = "A pip platform definition in the form <platform>-<python_version>-<implementation>-<abi>",
+    ),
     "repo": attr.string(
         mandatory = True,
         doc = "Pointer to parent repo name. Used to make these rules rerun if the parent repo changes.",
@@ -290,9 +293,6 @@ whl_library_attrs = {
         mandatory = True,
         doc = "Python requirement string describing the package to make available",
     ),
-    "pip_platform_definition": attr.string(
-        doc = "A pip platform definition in the form <platform>-<python_version>-<implementation>-<abi>",
-    )
 }
 
 whl_library_attrs.update(**common_attrs)
@@ -317,16 +317,16 @@ def _impl_platform_alias(rctx):
     rctx.file(
         "BUILD",
         content = _PLATFORM_ALIAS_TMPL.format(
-            select_items = rctx.attr.select_items
+            select_items = rctx.attr.select_items,
         ),
         executable = False,
     )
 
 platform_alias = repository_rule(
     attrs = {
-        "select_items": attr.string_dict()
+        "select_items": attr.string_dict(),
     },
     implementation = _impl_platform_alias,
     doc = """
-An internal rule used to create an alias for a pip package for the appropriate platform."""
+An internal rule used to create an alias for a pip package for the appropriate platform.""",
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

There is no multi-platform support: https://github.com/bazelbuild/rules_python/issues/260

## What is the new behavior?

Adds a new argument, `pip_platform_definitions`, to `pip_parse`. The value of the argument looks like this:
```
    pip_platform_definitions = {
        "//platforms:linux_x86_64_build": "manylinux2014_x86_64-37-cp-cp37m",
        "//platforms:macos_x86_64_build": "macosx_10_14_x86_64-37-cp-cp37m",
    },
```
Each key is a `config_setting`, and each value is a string of the fom `<platform>-<python_version>-<implementation>-<abi>`.

When `pip_platform_definitions` is specified, instead of running `pip wheel`, the rules run `pip download` with constraints extracted from the values in the map values. This makes it possible to do cross-platform Python builds, e.g. on MacOS run bazel with `--platforms=//platforms:macos_x86_64` and have linux dependencies fetched properly. In the above example, we would end with 3 targets for a pip package called `foo`:
* `@pip_pypi__macosx_10_14_x86_64_37_cp_cp37m__foo//:pkg` is the `py_library` for the MacOS version of the package.
* `@pip_pypi__manylinux2014_x86_64_37_cp_cp37m__foo//:pkg` is the `py_library` for the Linux version of the package.
* `@pip_pypi__foo` is an `alias` with its `actual` determined by a `select` over the provided `config_settings` pointing at the above two targets. This is the target that the `requirement` macro points at.

Of course this only works if all of the required packages have wheels available which match the configured platform constraints, either in PyPI or another configured repository.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

In its current state, this PR is more of a proof of concept that is intended to start a conversation rather than something that is ready to merge. If I get feedback from the maintainers that this general approach is something that could be merged, then I would be happy to do the work to get it into a better state.

We've been successfully been using this at my company to build Docker images with native Python dependencies (e.g. pandas, gRPC) on MacOS. We have a reasonably large collection of Python deps (124), and in practice it has not been a large problem to obtain wheels for all of them. All except 3 are already in PyPI, and for the 3 that are missing it's possible to build universal wheels, which we just do manually outside of Bazel.

Things that I think likely need improvement before this is ready to merge are:
* The interface to this new functionality is clunky. It's basically the fastest thing I could get working to see if the approach would work at all. I think the right way may be to create a `toolchain_type` for this purpose, and put the pip download constraints in a toolchain provider, but have not investigated this thoroughly.
* Documentation
* Examples/Tests
* Some general code cleanup. The new interface for `repo_names_and_requirements` is pretty confusing.
Feedback on any of these items would be great!