### PR TITLE
Escape characters in the wheel filename.

### DIFF
--- a/examples/wheel/BUILD
+++ b/examples/wheel/BUILD
@@ -189,6 +189,17 @@ py_wheel(
     version = "0.0.1",
 )
 
+py_wheel(
+    name = "filename_escaping",
+    # Per https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
+    # runs of non-alphanumeric, non-digit symbols should be replaced with a single underscore.
+    # Unicode non-ascii letters should *not* be replaced with underscore.
+    distribution = "file~~name-escaping",
+    python_tag = "py3",
+    version = "0.0.1-r7",
+    deps = [":example_pkg"],
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],
@@ -197,6 +208,7 @@ py_test(
         ":custom_package_root_multi_prefix",
         ":custom_package_root_multi_prefix_reverse_order",
         ":customized",
+        ":filename_escaping",
         ":minimal_with_py_library",
         ":minimal_with_py_package",
         ":python_abi3_binary_wheel",

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -112,6 +112,34 @@ customized_wheel = examples.wheel.main:main
 first = first.main:f
 second = second.main:s""")
 
+    def test_filename_escaping(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'rules_python',
+                                'examples', 'wheel',
+                                'file_name_escaping-0.0.1_r7-py3-none-any.whl')
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['examples/wheel/lib/data.txt',
+                 'examples/wheel/lib/module_with_data.py',
+                 'examples/wheel/lib/simple_module.py',
+                 'examples/wheel/main.py',
+                 # PEP calls for replacing only in the archive filename.
+                 # Alas setuptools also escapes in the dist-info directory
+                 # name, so let's be compatible.
+                 'file_name_escaping-0.0.1_r7.dist-info/WHEEL',
+                 'file_name_escaping-0.0.1_r7.dist-info/METADATA',
+                 'file_name_escaping-0.0.1_r7.dist-info/RECORD'])
+            metadata_contents = zf.read(
+                'file_name_escaping-0.0.1_r7.dist-info/METADATA')
+            self.assertEquals(metadata_contents, b"""\
+Metadata-Version: 2.1
+Name: file~~name-escaping
+Version: 0.0.1-r7
+
+UNKNOWN
+""")
+
     def test_custom_package_root_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
                                 'rules_python',

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -83,13 +83,30 @@ Sub-packages are automatically included.
     },
 )
 
+def _escape_filename_segment(segment):
+    """Escape a segment of the wheel filename.
+
+    See https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
+    """
+    # TODO: this is wrong, isalnum replaces non-ascii letters, while we should
+    # not replace them.
+    # TODO: replace this with a regexp once starlark supports them.
+    escaped = ""
+    for character in segment.elems():
+        # isalnum doesn't handle unicode characters properly.
+        if character.isalnum() or character == '.':
+            escaped += character
+        elif not escaped.endswith('_'):
+            escaped += '_'
+    return escaped
+
 def _py_wheel_impl(ctx):
     outfile = ctx.actions.declare_file("-".join([
-        ctx.attr.distribution,
-        ctx.attr.version,
-        ctx.attr.python_tag,
-        ctx.attr.abi,
-        ctx.attr.platform,
+        _escape_filename_segment(ctx.attr.distribution),
+        _escape_filename_segment(ctx.attr.version),
+        _escape_filename_segment(ctx.attr.python_tag),
+        _escape_filename_segment(ctx.attr.abi),
+        _escape_filename_segment(ctx.attr.platform),
     ]) + ".whl")
 
     inputs_to_package = depset(

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -88,16 +88,17 @@ def _escape_filename_segment(segment):
 
     See https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
     """
+
     # TODO: this is wrong, isalnum replaces non-ascii letters, while we should
     # not replace them.
     # TODO: replace this with a regexp once starlark supports them.
     escaped = ""
     for character in segment.elems():
         # isalnum doesn't handle unicode characters properly.
-        if character.isalnum() or character == '.':
+        if character.isalnum() or character == ".":
             escaped += character
-        elif not escaped.endswith('_'):
-            escaped += '_'
+        elif not escaped.endswith("_"):
+            escaped += "_"
     return escaped
 
 def _py_wheel_impl(ctx):


### PR DESCRIPTION
Escape characters in the wheel filename.

Note the implementation is buggy, it replaces non-ascii (unicode) letters in the filename. Unfortunately, starlark isalnum function returns wrong result here, and regexp support is not available yet.

Fixes #517.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #517


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

