### PR TITLE
Added targets for data and dist-info to pip generated targets

### DIFF
--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -84,10 +84,16 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
             return name.replace("-", "_").replace(".", "_").lower()
 
         def requirement(name):
-           return "@{repo_prefix}" + _clean_name(name) + "//:pkg"
+           return "@{repo_prefix}" + _clean_name(name) + "//:{py_library_label}"
 
         def whl_requirement(name):
-           return "@{repo_prefix}" + _clean_name(name) + "//:whl"
+           return "@{repo_prefix}" + _clean_name(name) + "//:{wheel_file_label}"
+
+        def data_requirement(name):
+            return requirement(name) + ":{data_label}"
+
+        def dist_info_requirement(name):
+            return requirement(name) + ":{dist_info_label}"
 
         def install_deps():
             for name, requirement in _packages:
@@ -102,6 +108,10 @@ def generate_parsed_requirements_contents(all_args: argparse.Namespace) -> str:
             repo_names_and_reqs=repo_names_and_reqs,
             args=args,
             repo_prefix=repo_prefix,
+            py_library_label=bazel.PY_LIBRARY_LABEL,
+            wheel_file_label=bazel.WHEEL_FILE_LABEL,
+            data_label=bazel.DATA_LABEL,
+            dist_info_label=bazel.DIST_INFO_LABEL,
             )
         )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A wheel is [documented](https://www.python.org/dev/peps/pep-0491/#file-contents) to contain both `.dist-info` and `.data` directories which contain additional metadata for a particular package. However, even though the pip repository rules extract wheel contents into the repository directory, data in these directories are not exposed. In order to access this, the `:whl` target must be consumed and unzipped again, even though this information already lives in the pip repository generated by Bazel. Something should be done to expose this data so users don't have to write additional parsers.

Issue Number: N/A


## What is the new behavior?

This pull request exposes files in `.data` and `.dist-info` in individual filegroups, allowing users to consume them without having to re-extract this data from the wheel.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

