### PR TITLE
Exposed docs for `compile_pip_requirements`

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,6 +59,10 @@ bzl_library(
     srcs = [
         "//python/pip_install:pip_repository.bzl",
         "//python/pip_install:repositories.bzl",
+        "//python/pip_install:requirements.bzl",
+    ],
+    deps = [
+        ":defs",
     ],
 )
 

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -1,5 +1,40 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+<a name="#compile_pip_requirements"></a>
+
+## compile_pip_requirements
+
+<pre>
+compile_pip_requirements(<a href="#compile_pip_requirements-name">name</a>, <a href="#compile_pip_requirements-extra_args">extra_args</a>, <a href="#compile_pip_requirements-visibility">visibility</a>, <a href="#compile_pip_requirements-requirements_in">requirements_in</a>, <a href="#compile_pip_requirements-requirements_txt">requirements_txt</a>, <a href="#compile_pip_requirements-tags">tags</a>,
+                         <a href="#compile_pip_requirements-kwargs">kwargs</a>)
+</pre>
+
+    Macro creating targets for running pip-compile
+
+Produce a filegroup by default, named "[name]" which can be included in the data
+of some other compile_pip_requirements rule that references these requirements
+(e.g. with `-r ../other/requirements.txt`)
+
+Produce two targets for checking pip-compile:
+
+- validate with `bazel test <name>_test`
+- update with   `bazel run <name>.update`
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| name |  base name for generated targets, typically "requirements"   |  none |
+| extra_args |  passed to pip-compile   |  <code>[]</code> |
+| visibility |  passed to both the _test and .update rules   |  <code>["//visibility:private"]</code> |
+| requirements_in |  file expressing desired dependencies   |  <code>None</code> |
+| requirements_txt |  result of "compiling" the requirements.in file   |  <code>None</code> |
+| tags |  tagging attribute common to all build rules, passed to both the _test and .update rules   |  <code>None</code> |
+| kwargs |  other bazel attributes passed to the "_test" rule   |  none |
+
+
 <a name="#pip_import"></a>
 
 ## pip_import

--- a/examples/pip_install/BUILD
+++ b/examples/pip_install/BUILD
@@ -4,7 +4,7 @@ load(
     "requirement",
 )
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 # Toolchain setup, this is optional.
 # Demonstrate that we can use the same python interpreter for the toolchain and executing pip in pip install (see WORKSPACE).

--- a/examples/pip_parse/BUILD
+++ b/examples/pip_parse/BUILD
@@ -1,6 +1,6 @@
 load("@pip_parsed_deps//:requirements.bzl", "entry_point", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 # Toolchain setup, this is optional.
 # Demonstrate that we can use the same python interpreter for the toolchain and executing pip in pip install (see WORKSPACE).

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -15,6 +15,9 @@
 
 load("//python/pip_install:pip_repository.bzl", "pip_repository")
 load("//python/pip_install:repositories.bzl", "pip_install_dependencies")
+load("//python/pip_install:requirements.bzl", _compile_pip_requirements = "compile_pip_requirements")
+
+compile_pip_requirements = _compile_pip_requirements
 
 def pip_install(requirements, name = "pip", **kwargs):
     """Imports a `requirements.txt` file and generates a new `requirements.bzl` file.

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -13,17 +13,11 @@ filegroup(
 
 filegroup(
     name = "bzl",
-    srcs = [
-        "pip_repository.bzl",
-        "repositories.bzl",
-    ],
+    srcs = glob(["*.bzl"]),
     visibility = ["//:__pkg__"],
 )
 
 exports_files(
-    [
-        "pip_repository.bzl",
-        "repositories.bzl",
-    ],
+    glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
 )

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -1,4 +1,4 @@
-"Rules to verify and update pip-compile locked requirements.txt"
+"""Rules to verify and update pip-compile locked requirements.txt"""
 
 load("//python:defs.bzl", "py_binary", "py_test")
 load("//python/pip_install:repositories.bzl", "requirement")


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`compile_pip_requirements` is not currently in the docs and seems to otherwise be hidden as a result. This PR fixes that.

Issue Number: N/A


## What is the new behavior?
`compile_pip_requirements` can now be loaded via `@rules_python//python:pip.bzl` which is also used to populate `docs/pip.md` with the appropriate docs for the rule.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

