### PR TITLE
Update docstrings for packaging rules/macros

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -17,9 +17,11 @@ load("//python/pip_install:pip_repository.bzl", "pip_repository")
 load("//python/pip_install:repositories.bzl", "pip_install_dependencies")
 
 def pip_install(requirements, name = "pip", **kwargs):
-    """Imports a `requirements.txt` file and generates a new `requirements.bzl` file.
+    """Accepts a `requirements.txt` file and installs the dependencies listed within.
 
-    This is used via the `WORKSPACE` pattern:
+    Those dependencies become available in a generated `requirements.bzl` file.
+
+    This macro runs a repository rule that invokes `pip`. In your WORKSPACE file:
 
     ```python
     pip_install(
@@ -27,7 +29,7 @@ def pip_install(requirements, name = "pip", **kwargs):
     )
     ```
 
-    You can then reference imported dependencies from your `BUILD` file with:
+    You can then reference installed dependencies from a `BUILD` file with:
 
     ```python
     load("@pip//:requirements.bzl", "requirement")
@@ -42,9 +44,9 @@ def pip_install(requirements, name = "pip", **kwargs):
     )
     ```
 
-    In addition to the `requirement` macro, which is used to access the generated `py_library`
-    target generated from a package's wheel, The generated `requirements.bzl` file contains
-    functionality for exposing [entry points][whl_ep] as `py_binary` targets as well.
+    In addition to the `requirement` macro, which is used to access the `py_library`
+    target generated from a package's wheel, the generated `requirements.bzl` file contains
+    functionality for exposing [entry points][whl_ep] as `py_binary` targets.
 
     [whl_ep]: https://packaging.python.org/specifications/entry-points/
 
@@ -60,7 +62,7 @@ def pip_install(requirements, name = "pip", **kwargs):
     )
     ```
 
-    Note that for packages who's name and script are the same, only the name of the package
+    Note that for packages whose name and script are the same, only the name of the package
     is needed when calling the `entry_point` macro.
 
     ```python
@@ -73,9 +75,9 @@ def pip_install(requirements, name = "pip", **kwargs):
     ```
 
     Args:
-        requirements: A 'requirements.txt' pip requirements file.
-        name: A unique name for the created external repository (default 'pip').
-        **kwargs: Keyword arguments passed directly to the `pip_repository` repository rule.
+        requirements (Label): A 'requirements.txt' pip requirements file.
+        name (str, optional): A unique name for the created external repository (default 'pip').
+        **kwargs (dict): Keyword arguments passed directly to the `pip_repository` repository rule.
     """
 
     # Just in case our dependencies weren't already fetched
@@ -88,9 +90,11 @@ def pip_install(requirements, name = "pip", **kwargs):
     )
 
 def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
-    """Imports a locked/compiled requirements file and generates a new `requirements.bzl` file.
+    """Accepts a locked/compiled requirements file and installs the dependencies listed within.
 
-    This is used via the `WORKSPACE` pattern:
+    Those dependencies become available in a generated `requirements.bzl` file.
+
+    This macro runs a repository rule that invokes `pip`. In your WORKSPACE file:
 
     ```python
     load("@rules_python//python:pip.bzl", "pip_parse")
@@ -105,7 +109,7 @@ def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
     install_deps()
     ```
 
-    You can then reference imported dependencies from your `BUILD` file with:
+    You can then reference installed dependencies from a `BUILD` file with:
 
     ```python
     load("@pip_deps//:requirements.bzl", "requirement")
@@ -139,7 +143,7 @@ def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
     )
     ```
 
-    Note that for packages who's name and script are the same, only the name of the package
+    Note that for packages whose name and script are the same, only the name of the package
     is needed when calling the `entry_point` macro.
 
     ```python
@@ -173,10 +177,23 @@ def pip_parse(requirements_lock, name = "pip_parsed_deps", **kwargs):
     )
 
 def pip_repositories():
+    """
+    Obsolete macro to pull in dependencies needed to use the pip_import rule.
+
+    Deprecated:
+        the pip_repositories rule is obsolete. It is not used by pip_install.
+    """
+
     # buildifier: disable=print
     print("DEPRECATED: the pip_repositories rule has been replaced with pip_install, please see rules_python 0.1 release notes")
 
 def pip_import(**kwargs):
+    """
+    Rule for installing packages listed in a requirements file.
+
+    Deprecated:
+        the pip_import rule has been replaced with pip_install.
+    """
     fail("=" * 79 + """\n
     pip_import has been replaced with pip_install, please see the rules_python 0.1 release notes.
     To continue using it, you can load from "@rules_python//python/legacy_pip_import:pip.bzl"

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -11,14 +11,13 @@ def compile_pip_requirements(
         requirements_txt = None,
         tags = None,
         **kwargs):
-    """
-    Macro creating targets for running pip-compile
+    """Generates targets for managing pip dependencies with pip-compile.
 
-    Produce a filegroup by default, named "[name]" which can be included in the data
+    By default this rules generates a filegroup named "[name]" which can be included in the data
     of some other compile_pip_requirements rule that references these requirements
-    (e.g. with `-r ../other/requirements.txt`)
+    (e.g. with `-r ../other/requirements.txt`).
 
-    Produce two targets for checking pip-compile:
+    It also generates two targets for running pip-compile:
 
     - validate with `bazel test <name>_test`
     - update with   `bazel run <name>.update`


### PR DESCRIPTION
Prompted by https://github.com/bazelbuild/rules_python/pull/534 and reading through the docstrings, I'm putting up these edits to clean up things.

* Avoiding use of "import". Going way back to `pip_import`, I thought "import" was a misleading term. The rules need to install packages, and this involves running sometimes arbitrary on the system if a wheel isn't available. "import" also clashes with Python's `import` keyword. Rulesets such as `rules_jvm_external` use "resolve" and "fetch", which is appropriate for JVM dependencies because they are just file bundles you download, but this Python stuff you're installing.
* Adding deprecation notices in docstrings, because #534 showed me that the generated documentation doesn't show anything for our deprecated rules and it's a bit confusing to see no detail.
* Generally trying to bring docstring wording closer to rules_jvm_external. eg. use of "generates", "this macro runs a repository rule". 

---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


