### PR TITLE
Fix regression in parsing requirements due to invalid entry points config.

### DIFF
--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -63,9 +63,18 @@ class Wheel:
 
             # Parse the avaialble entry points
             config = configparser.ConfigParser()
-            config.read_string(whl.read(entry_points_path).decode("utf-8"))
-            if "console_scripts" in config.sections():
-                return dict(config["console_scripts"])
+            try:
+                config.read_string(whl.read(entry_points_path).decode("utf-8"))
+                if "console_scripts" in config.sections():
+                    return dict(config["console_scripts"])
+
+            # TODO: It's unclear what to do in a situation with duplicate sections or options.
+            # For now, we treat the config file as though it contains no scripts. For more
+            # details on the config parser, see:
+            # https://docs.python.org/3.7/library/configparser.html#configparser.ConfigParser
+            # https://docs.python.org/3.7/library/configparser.html#configparser.Error
+            except configparser.Error:
+                pass
 
         return dict()
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dependencies which have a potentially invalid `entry_points.txt` file will currently cause parsing dependencies to fail, rendering your code unbuildable.

Issue Number: N/A


## What is the new behavior?
The `entry_points` functionality should at this point never result in a fatal error when parsing dependencies. This allows dependencies to continue to be generated as they did before in the event that `entry_points.txt` is malformed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

