### PR TITLE
fix bazel_integration_test runner to allow non-release URLs

### DIFF
--- a/tools/bazel_integration_test/test_runner.py
+++ b/tools/bazel_integration_test/test_runner.py
@@ -24,10 +24,12 @@ def modify_WORKSPACE(wksp, distro_path):
         content = wksp_file.read()
     # Replace the url for rules_python with our locally built one
     content = re.sub(
-        r'url = "https://github.com/bazelbuild/rules_python/releases/download/[^"]+"',
+        r'url = "https://github.com/bazelbuild/rules_python/[^"]+"',
         'url = "file://%s"' % r.Rlocation(distro_path),
         content)
+    # comment out sha256 and strip_prefix if present
     content = re.sub(r'sha256 = "', '#\1', content)
+    content = re.sub(r'strip_prefix = "', '#\1', content)
     with open(wksp, 'w') as wksp_file:
         wksp_file.write(content)
 


### PR DESCRIPTION
was broken by cd5416e3b2702e7ff7d7564c2a9395344e9e724a in such a way that it was testing the prior release and not the local code from HEAD
