### PR TITLE
Fixed `stamp.bzl` missing form `@rules_python//:bzl` target.

### DIFF
--- a/python/private/BUILD
+++ b/python/private/BUILD
@@ -26,9 +26,7 @@ filegroup(
 # Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
 filegroup(
     name = "bzl",
-    srcs = [
-        "reexports.bzl",
-    ],
+    srcs = glob(["**/*.bzl"]),
     visibility = ["//python:__pkg__"],
 )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following https://github.com/bazelbuild/rules_python/pull/554, a regression was introduced that broke the ability to generate docs via stardoc. This PR fixes that.

Issue Number: https://github.com/bazelbuild/rules_python/issues/561


## What is the new behavior?
This allows users to continue to generate docs after release `0.5.0`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

