### PR TITLE
Fix #507 - Always run from WORKSPACE root in compile_pip_requirements update exe

### DIFF
--- a/python/pip_install/pip_compile.py
+++ b/python/pip_install/pip_compile.py
@@ -42,7 +42,7 @@ if "TEST_TMPDIR" in os.environ:
     copyfile(requirements_txt, requirements_out)
 
 elif "BUILD_WORKSPACE_DIRECTORY" in os.environ:
-    # This value, populated when running under `bazel run` is a path to the
+    # This value, populated when running under `bazel run`, is a path to the
     # "root of the workspace where the build was run."
     # This matches up with the values passed in via the macro using the 'rootpath' Make variable,
     # which for source files provides a path "relative to your workspace root."

--- a/python/pip_install/pip_compile.py
+++ b/python/pip_install/pip_compile.py
@@ -41,11 +41,22 @@ if "TEST_TMPDIR" in os.environ:
     )
     copyfile(requirements_txt, requirements_out)
 
-elif "BUILD_WORKING_DIRECTORY" in os.environ:
-    os.chdir(os.environ['BUILD_WORKING_DIRECTORY'])
+elif "BUILD_WORKSPACE_DIRECTORY" in os.environ:
+    # This value, populated when running under `bazel run` is a path to the
+    # "root of the workspace where the build was run."
+    # This matches up with the values passed in via the macro using the 'rootpath' Make variable,
+    # which for source files provides a path "relative to your workspace root."
+    #
+    # Changing to the WORKSPACE root avoids 'file not found' errors when the `.update` target is run
+    # from different directories within the WORKSPACE.
+    os.chdir(os.environ['BUILD_WORKSPACE_DIRECTORY'])
 else:
+    err_msg = (
+        "Expected to find BUILD_WORKSPACE_DIRECTORY (running under `bazel run`) or "
+        "TEST_TMPDIR (running under `bazel test`) in environment."
+    )
     print(
-        "Expected to find BUILD_WORKING_DIRECTORY in environment",
+        err_msg,
         file=sys.stderr,
     )
     sys.exit(1)


### PR DESCRIPTION
Addresses #507

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #507


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

