### PR TITLE
Fixed stable stamping of wheels

### DIFF
--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -155,7 +155,7 @@ def _py_wheel_impl(ctx):
     # Pass workspace status files if stamping is enabled
     if is_stamping_enabled(ctx.attr):
         args.add("--volatile_status_file", ctx.version_file)
-        args.add("--stable_status_file", ctx.version_file)
+        args.add("--stable_status_file", ctx.info_file)
         other_inputs.extend([ctx.version_file, ctx.info_file])
 
     args.add("--input_file_list", packageinputfile)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently stable stamps do not make their way into wheels, this is the result of a copy/paste error in https://github.com/bazelbuild/rules_python/pull/554

Issue Number: N/A


## What is the new behavior?
This change correctly wires up stable status stamp files for stamping `py_wheel` targets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

