### PR TITLE
Ignore `__pycache__` contents and `*.pyc` files in external dependencies

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -104,7 +104,9 @@ def generate_build_file_contents(
 
     data_exclude = [
         "*.whl",
+        "**/__pycache__/**",
         "**/*.py",
+        "**/*.pyc",
         f"{WHEEL_ENTRY_POINT_PREFIX}*.py",
         "**/* *",
         "BUILD.bazel",
@@ -135,7 +137,7 @@ def generate_build_file_contents(
 
         py_library(
             name = "{name}",
-            srcs = glob(["**/*.py"], exclude=["{entry_point_prefix}*.py"], allow_empty = True),
+            srcs = glob(["**/*.py"], exclude=["{entry_point_prefix}*.py", "**/__pycache__/**"], allow_empty = True),
             data = glob(["**/*"], exclude={data_exclude}),
             # This makes this directory a top-level in the python import
             # search path for anything that depends on this.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I noticed in some of my builds were getting a bunch of unexpected cache misses and found that some pypi dependencies were including some `__pycache__` contents and left-over `*.pyc` files. I don't believe these are needed or should ever be used by the Bazel rules.

Issue Number: N/A


## What is the new behavior?
This PR prevents these files from being included in the `pip_parse` and `pip_install` generated `py_library` targets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

