### PR TITLE
Fix entry point discovery on Windows.

### DIFF
--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -58,6 +58,7 @@ class Wheel:
             # Note that the zipfile module always uses the forward slash as
             # directory separator, even on Windows, so don't use os.path.join
             # here.
+            # Ref, for Python 3.10: https://github.com/python/cpython/blob/3.10/Lib/zipfile.py#L355
             entry_points_path = "{}.dist-info/entry_points.txt".format(name)
 
             # If this file does not exist in the wheel, there are no entry points

--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -57,8 +57,9 @@ class Wheel:
             name = "{}-{}".format(metadata.name.replace("-", "_"), metadata.version)
             # Note that the zipfile module always uses the forward slash as
             # directory separator, even on Windows, so don't use os.path.join
-            # here.
-            # Ref, for Python 3.10: https://github.com/python/cpython/blob/3.10/Lib/zipfile.py#L355
+            # here.  Reference for Python 3.10:
+            # https://github.com/python/cpython/blob/3.10/Lib/zipfile.py#L355.
+            # TODO: use zipfile.Path once 3.8 is our minimum supported version
             entry_points_path = "{}.dist-info/entry_points.txt".format(name)
 
             # If this file does not exist in the wheel, there are no entry points

--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -55,9 +55,10 @@ class Wheel:
             # Calculate the location of the entry_points.txt file
             metadata = self.metadata
             name = "{}-{}".format(metadata.name.replace("-", "_"), metadata.version)
-            entry_points_path = os.path.join(
-                "{}.dist-info".format(name), "entry_points.txt"
-            )
+            # Note that the zipfile module always uses the forward slash as
+            # directory separator, even on Windows, so don't use os.path.join
+            # here.
+            entry_points_path = "{}.dist-info/entry_points.txt".format(name)
 
             # If this file does not exist in the wheel, there are no entry points
             if entry_points_path not in whl.namelist():


### PR DESCRIPTION
The zipfile module always uses forward slashes, so we shouldn't use
os.path.join here.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Entry points aren't found on Windows
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Entry points should be found on Windows (haven't fully tested it though)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

