### PR TITLE
Remove return code type check.

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -35,8 +35,7 @@ def generate_entry_point_contents(entry_point: str, shebang: str = "#!/usr/bin/e
         from {module} import {method}
         if __name__ == "__main__":
             rc = {method}()
-            if rc.is_integer():
-                sys.exit(rc)
+            sys.exit({method}())
         """.format(
         shebang=shebang,
         module=module,

--- a/python/pip_install/extract_wheels/lib/bazel_test.py
+++ b/python/pip_install/extract_wheels/lib/bazel_test.py
@@ -10,9 +10,7 @@ class BazelTestCase(unittest.TestCase):
 import sys
 from sphinx.cmd.build import main
 if __name__ == "__main__":
-    rc = main()
-    if rc.is_integer():
-        sys.exit(rc)
+    sys.exit(main())
 """
         self.assertEqual(got, want)
 
@@ -22,8 +20,6 @@ if __name__ == "__main__":
         want = """#!/usr/bin/python
 import sys
 from sphinx.cmd.build import main
-rc = main()
-if rc.is_integer():
-    sys.exit(rc)
+sys.exit(main())
 """
         self.assertEqual(got, want)


### PR DESCRIPTION
Only floating-point objects have an is_integer
method (cf. https://docs.python.org/3.10/library/stdtypes.html#typesnumeric),
so this will actually raise an AttributeError whenever the main function
returns an integer or None.  sys.exit works just fine with any argument type,
so there’s no need to check anything.  The example at
https://packaging.python.org/specifications/entry-points/#use-for-scripts also
doesn’t contain a type check.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

