### PR TITLE
fix(gazelle): include file path in manifest parsing error message

### DIFF
--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -158,7 +158,7 @@ func (py *Configurer) loadGazelleManifest(gazelleManifestPath string) (*manifest
 	}
 	manifestFile := new(manifest.File)
 	if err := manifestFile.Decode(gazelleManifestPath); err != nil {
-		return nil, fmt.Errorf("failed to load Gazelle manifest at %s: %w", gazelleManifestPath, err)
+		return nil, fmt.Errorf("failed to load Gazelle manifest at %q: %w", gazelleManifestPath, err)
 	}
 	return manifestFile.Manifest, nil
 }

--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -154,11 +154,11 @@ func (py *Configurer) loadGazelleManifest(gazelleManifestPath string) (*manifest
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to load Gazelle manifest: %w", err)
+		return nil, fmt.Errorf("failed to load Gazelle manifest at %s: %w", gazelleManifestPath, err)
 	}
 	manifestFile := new(manifest.File)
 	if err := manifestFile.Decode(gazelleManifestPath); err != nil {
-		return nil, fmt.Errorf("failed to load Gazelle manifest: %w", err)
+		return nil, fmt.Errorf("failed to load Gazelle manifest at %s: %w", gazelleManifestPath, err)
 	}
 	return manifestFile.Manifest, nil
 }

--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -154,7 +154,7 @@ func (py *Configurer) loadGazelleManifest(gazelleManifestPath string) (*manifest
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to load Gazelle manifest at %s: %w", gazelleManifestPath, err)
+		return nil, fmt.Errorf("failed to load Gazelle manifest at %q: %w", gazelleManifestPath, err)
 	}
 	manifestFile := new(manifest.File)
 	if err := manifestFile.Decode(gazelleManifestPath); err != nil {


### PR DESCRIPTION
SUMMARY
Include the file path so it's easier to find the manifest that's causing issues

TEST PLAN
Break a manifest file locally, run gazelle, enjoy the improved message:

```
$ bazel run //:update_build_files
INFO: Invocation ID: e38c7bfb-1566-4f58-9485-efe66594e0d5
INFO: Analyzed target //:update_build_files (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:update_build_files up-to-date:
  .bazel/bin/update_build_files-runner.bash
  .bazel/bin/update_build_files
INFO: Elapsed time: 0.323s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
gazelle: failed to load Gazelle manifest at /my-project/gazelle_python.yaml: failed to decode manifest file: EOF
```