### PR TITLE
Make spread_purelib_into_root behave like the wheel was installed by pip

### DIFF
--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -94,6 +94,17 @@ py_test(
     ],
 )
 
+py_test(
+    name = "purelib_test",
+    size = "small",
+    srcs = [
+        "purelib_test.py",
+    ],
+    deps = [
+        ":lib",
+    ],
+)
+
 filegroup(
     name = "distribution",
     srcs = glob(

--- a/python/pip_install/extract_wheels/lib/purelib_test.py
+++ b/python/pip_install/extract_wheels/lib/purelib_test.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from python.pip_install.extract_wheels.lib import purelib
+
+
+class TestPurelibTestCase(unittest.TestCase):
+    @contextmanager
+    def setup_faux_unzipped_wheel(self):
+        files = [
+            ("faux_wheel.data/purelib/toplevel/foo.py", "# foo"),
+            ("faux_wheel.data/purelib/toplevel/dont_overwrite.py", "overwritten"),
+            ("faux_wheel.data/purelib/toplevel/subdir/baz.py", "overwritten"),
+            ("toplevel/bar.py", "# bar"),
+            ("toplevel/dont_overwrite.py", "original"),
+        ]
+        with TemporaryDirectory() as td:
+            self.td_path = Path(td)
+            self.purelib_path = self.td_path / Path("faux_wheel.data/purelib")
+            for file_, content in files:
+                path = self.td_path / Path(file_)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with open(str(path), "w") as f:
+                    f.write(content)
+            yield
+
+    def test_spread_purelib_(self):
+        with self.setup_faux_unzipped_wheel():
+            purelib._spread_purelib(self.purelib_path, self.td_path)
+            self.assertTrue(Path(self.td_path, "toplevel/foo.py").exists())
+            self.assertTrue(Path(self.td_path, "toplevel/subdir/baz.py").exists())
+            with open(Path(self.td_path, "toplevel/dont_overwrite.py")) as original:
+                self.assertEqual(original.read().strip(), "original")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Merge purelib dir into toplevel even if purelib and toplevel have
subdirs with the same name. See tensorflow-io for an example of
a package which was not installed correctly by rules_python before this
change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
In pip_install and pip_parse rule if you try to install a wheel which has Root-Is-Purelib: false (tensorflow-io is an example), python sources in the .data/purelib dir will not be merged into the root because we skip children of the purelib which have the same basename as a directory in the top level of the wheel.

What rules_python does currently: https://gist.github.com/hrfuller/ccc0420cd5b72b38f6151fa1b5c811e0

After running the example open up the created repo in the bazel output base, and notice that purelib directory is not merged.

This leads to issues where tensorflow_io python sources cannot be imported.


Issue Number: N/A


## What is the new behavior?

Descendants of the purelib directory will be merged with existing directories in the top level, but will not overwrite any files in the toplevel. This is the same thing that pip does when you install a wheel.

To verify this run

`pip install --no-deps --only-binary :all: --target tfio tensorflow-io==0.19.0`

Compare the shape of the tfio directory with the external repo bazel generated using the gist above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

