### PR TITLE
changes to pip_repository source files now re-trigger the repo rule

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -61,9 +61,7 @@ bzl_library(
 bzl_library(
     name = "pip_install_bzl",
     srcs = [
-        "//python/pip_install:pip_repository.bzl",
-        "//python/pip_install:repositories.bzl",
-        "//python/pip_install:requirements.bzl",
+        "//python/pip_install:bzl",
     ],
     deps = [
         ":defs",

--- a/python/BUILD
+++ b/python/BUILD
@@ -46,6 +46,7 @@ filegroup(
         "defs.bzl",
         "packaging.bzl",
         "pip.bzl",
+        "//python/pip_install:bzl",
         "//python/private:bzl",
     ],
     visibility = ["//:__pkg__"],

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -7,14 +7,26 @@ filegroup(
         "pip_compile.py",
         "//python/pip_install/extract_wheels:distribution",
         "//python/pip_install/parse_requirements_to_bzl:distribution",
+        "//python/pip_install/private:distribution",
     ],
     visibility = ["//:__pkg__"],
 )
 
 filegroup(
     name = "bzl",
-    srcs = glob(["*.bzl"]),
-    visibility = ["//:__pkg__"],
+    srcs = glob(["*.bzl"]) + [
+        "//python/pip_install/private:bzl_srcs",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "py_srcs",
+    srcs = [
+        "//python/pip_install/extract_wheels:py_srcs",
+        "//python/pip_install/parse_requirements_to_bzl:py_srcs",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 exports_files(

--- a/python/pip_install/extract_wheels/BUILD
+++ b/python/pip_install/extract_wheels/BUILD
@@ -17,3 +17,14 @@ filegroup(
     ],
     visibility = ["//python/pip_install:__subpackages__"],
 )
+
+filegroup(
+    name = "py_srcs",
+    srcs = glob(
+        include = ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ) + [
+        "//python/pip_install/extract_wheels/lib:py_srcs",
+    ],
+    visibility = ["//python/pip_install:__subpackages__"],
+)

--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -110,3 +110,12 @@ filegroup(
     ),
     visibility = ["//python/pip_install:__subpackages__"],
 )
+
+filegroup(
+    name = "py_srcs",
+    srcs = glob(
+        include = ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ),
+    visibility = ["//python/pip_install:__subpackages__"],
+)

--- a/python/pip_install/parse_requirements_to_bzl/BUILD
+++ b/python/pip_install/parse_requirements_to_bzl/BUILD
@@ -41,3 +41,14 @@ filegroup(
     ],
     visibility = ["//python/pip_install:__subpackages__"],
 )
+
+filegroup(
+    name = "py_srcs",
+    srcs = glob(
+        include = ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ) + [
+        "//python/pip_install/parse_requirements_to_bzl/extract_single_wheel:py_srcs",
+    ],
+    visibility = ["//python/pip_install:__subpackages__"],
+)

--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/BUILD
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/BUILD
@@ -6,3 +6,12 @@ filegroup(
     ),
     visibility = ["//python/pip_install:__subpackages__"],
 )
+
+filegroup(
+    name = "py_srcs",
+    srcs = glob(
+        include = ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ),
+    visibility = ["//python/pip_install:__subpackages__"],
+)

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -1,6 +1,7 @@
 ""
 
 load("//python/pip_install:repositories.bzl", "all_requirements")
+load("//python/pip_install/private:srcs.bzl", "PIP_INSTALL_PY_SRCS")
 
 def _construct_pypath(rctx):
     """Helper function to construct a PYTHONPATH.
@@ -111,6 +112,18 @@ def _parse_optional_attrs(rctx, args):
 
     return args
 
+def _detect_changes(rctx):
+    """Ensure sources used by the `pip_repository` rule are tracked as inputs.
+
+    This function ensures that if any source file used by the rule changes,
+    that the repository rule is re-triggered.
+
+    Args:
+        rctx (repository_ctx): The repository rule's context object
+    """
+    for src in rctx.attr._py_srcs:
+        rctx.path(src)
+
 _BUILD_FILE_CONTENTS = """\
 package(default_visibility = ["//visibility:public"])
 
@@ -126,6 +139,8 @@ def _pip_repository_impl(rctx):
 
     # We need a BUILD file to load the generated requirements.bzl
     rctx.file("BUILD.bazel", _BUILD_FILE_CONTENTS)
+
+    _detect_changes(rctx)
 
     pypath = _construct_pypath(rctx)
 
@@ -249,6 +264,11 @@ For incremental mode the packages will be of the form
     "timeout": attr.int(
         default = 600,
         doc = "Timeout (in seconds) on the rule's execution duration.",
+    ),
+    "_py_srcs": attr.label_list(
+        doc = "Python sources used in the repository rule",
+        allow_files = True,
+        default = PIP_INSTALL_PY_SRCS,
     ),
 }
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -112,18 +112,6 @@ def _parse_optional_attrs(rctx, args):
 
     return args
 
-def _detect_changes(rctx):
-    """Ensure sources used by the `pip_repository` rule are tracked as inputs.
-
-    This function ensures that if any source file used by the rule changes,
-    that the repository rule is re-triggered.
-
-    Args:
-        rctx (repository_ctx): The repository rule's context object
-    """
-    for src in rctx.attr._py_srcs:
-        rctx.path(src)
-
 _BUILD_FILE_CONTENTS = """\
 package(default_visibility = ["//visibility:public"])
 
@@ -139,8 +127,6 @@ def _pip_repository_impl(rctx):
 
     # We need a BUILD file to load the generated requirements.bzl
     rctx.file("BUILD.bazel", _BUILD_FILE_CONTENTS)
-
-    _detect_changes(rctx)
 
     pypath = _construct_pypath(rctx)
 

--- a/python/pip_install/private/BUILD
+++ b/python/pip_install/private/BUILD
@@ -1,0 +1,24 @@
+load(":pip_install_utils.bzl", "srcs_module")
+
+package(default_visibility = ["//:__subpackages__"])
+
+exports_files([
+    "srcs.bzl",
+])
+
+filegroup(
+    name = "distribution",
+    srcs = glob(["*"]),
+    visibility = ["//python/pip_install:__subpackages__"],
+)
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]),
+)
+
+srcs_module(
+    name = "srcs_module",
+    srcs = "//python/pip_install:py_srcs",
+    dest = ":srcs.bzl",
+)

--- a/python/pip_install/private/pip_install_utils.bzl
+++ b/python/pip_install/private/pip_install_utils.bzl
@@ -77,12 +77,12 @@ def _srcs_installer_impl(ctx):
     )
 
 _srcs_installer = rule(
-    doc = "A rule for writing a file back to the repository",
+    doc = "A rule for writing a `srcs.bzl` file back to the repository",
     implementation = _srcs_installer_impl,
     attrs = {
         "dest": attr.label(
-            doc = "the file name to use for installation",
-            allow_single_file = True,
+            doc = "The target to use installation",
+            allow_single_file = ["srcs.bzl"],
             mandatory = True,
         ),
         "input": attr.label(

--- a/python/pip_install/private/pip_install_utils.bzl
+++ b/python/pip_install/private/pip_install_utils.bzl
@@ -56,7 +56,7 @@ set -euo pipefail
 cp -f "{path}" "${{BUILD_WORKSPACE_DIRECTORY}}/{dest}"
 """
 
-def _srcs_installer_impl(ctx):
+def _srcs_updater_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name + ".sh")
     target_file = ctx.file.input
     dest = ctx.file.dest.short_path
@@ -76,12 +76,12 @@ def _srcs_installer_impl(ctx):
         executable = output,
     )
 
-_srcs_installer = rule(
+_srcs_updater = rule(
     doc = "A rule for writing a `srcs.bzl` file back to the repository",
-    implementation = _srcs_installer_impl,
+    implementation = _srcs_updater_impl,
     attrs = {
         "dest": attr.label(
-            doc = "The target to use installation",
+            doc = "The target file to write the new `input` to.",
             allow_single_file = ["srcs.bzl"],
             mandatory = True,
         ),
@@ -110,8 +110,8 @@ def srcs_module(name, dest, **kwargs):
         **kwargs
     )
 
-    _srcs_installer(
-        name = name + ".install",
+    _srcs_updater(
+        name = name + ".update",
         input = name,
         dest = dest,
         tags = tags,

--- a/python/pip_install/private/pip_install_utils.bzl
+++ b/python/pip_install/private/pip_install_utils.bzl
@@ -1,7 +1,11 @@
 """Utilities for `rules_python` pip rules"""
 
 _SRCS_TEMPLATE = """\
-\"\"\"A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules\"\"\"
+\"\"\"A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules
+
+This file is auto-generated from the `@rules_python//python/pip_install/private:srcs_module.install` target. Please
+`bazel run` this target to apply any updates. Note that doing so will discard any local modifications.
+"\"\"
 
 # Each source file is tracked as a target so `pip_repository` rules will know to automatically rebuild if any of the
 # sources changed.

--- a/python/pip_install/private/pip_install_utils.bzl
+++ b/python/pip_install/private/pip_install_utils.bzl
@@ -1,0 +1,114 @@
+"""Utilities for `rules_python` pip rules"""
+
+_SRCS_TEMPLATE = """\
+\"\"\"A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules\"\"\"
+
+# Each source file is tracked as a target so `pip_repository` rules will know to automatically rebuild if any of the
+# sources changed.
+PIP_INSTALL_PY_SRCS = [
+    {srcs}
+]
+"""
+
+def _src_label(file):
+    dir_path, file_name = file.short_path.rsplit("/", 1)
+
+    return "@rules_python//{}:{}".format(
+        dir_path,
+        file_name,
+    )
+
+def _srcs_module_impl(ctx):
+    srcs = [_src_label(src) for src in ctx.files.srcs]
+    if not srcs:
+        fail("`srcs` cannot be empty")
+    output = ctx.actions.declare_file(ctx.label.name)
+
+    ctx.actions.write(
+        output = output,
+        content = _SRCS_TEMPLATE.format(
+            srcs = "\n    ".join(["\"{}\",".format(src) for src in srcs]),
+        ),
+    )
+
+    return DefaultInfo(
+        files = depset([output]),
+    )
+
+_srcs_module = rule(
+    doc = "A rule for writing a list of sources to a templated file",
+    implementation = _srcs_module_impl,
+    attrs = {
+        "srcs": attr.label(
+            doc = "A filegroup of source files",
+            allow_files = True,
+        ),
+    },
+)
+
+_INSTALLER_TEMPLATE = """\
+#!/bin/bash
+set -euo pipefail
+cp -f "{path}" "${{BUILD_WORKSPACE_DIRECTORY}}/{dest}"
+"""
+
+def _srcs_installer_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name + ".sh")
+    target_file = ctx.file.input
+    dest = ctx.file.dest.short_path
+
+    ctx.actions.write(
+        output = output,
+        content = _INSTALLER_TEMPLATE.format(
+            path = target_file.short_path,
+            dest = dest,
+        ),
+        is_executable = True,
+    )
+
+    return DefaultInfo(
+        files = depset([output]),
+        runfiles = ctx.runfiles(files = [target_file]),
+        executable = output,
+    )
+
+_srcs_installer = rule(
+    doc = "A rule for writing a file back to the repository",
+    implementation = _srcs_installer_impl,
+    attrs = {
+        "dest": attr.label(
+            doc = "the file name to use for installation",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "input": attr.label(
+            doc = "The file to write back to the repository",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+    executable = True,
+)
+
+def srcs_module(name, dest, **kwargs):
+    """A helper rule to ensure `pip_repository` rules are always up to date
+
+    Args:
+        name (str): The name of the sources module
+        dest (str): The filename the module should be written as in the current package.
+        **kwargs (dict): Additional keyword arguments
+    """
+    tags = kwargs.pop("tags", [])
+
+    _srcs_module(
+        name = name,
+        tags = tags,
+        **kwargs
+    )
+
+    _srcs_installer(
+        name = name + ".install",
+        input = name,
+        dest = dest,
+        tags = tags,
+    )

--- a/python/pip_install/private/srcs.bzl
+++ b/python/pip_install/private/srcs.bzl
@@ -1,4 +1,8 @@
-"""A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules"""
+"""A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules
+
+This file is auto-generated from the `@rules_python//python/pip_install/private:srcs_module.install` target. Please
+`bazel run` this target to apply any updates. Note that doing so will discard any local modifications.
+"""
 
 # Each source file is tracked as a target so `pip_repository` rules will know to automatically rebuild if any of the
 # sources changed.

--- a/python/pip_install/private/srcs.bzl
+++ b/python/pip_install/private/srcs.bzl
@@ -1,0 +1,19 @@
+"""A generate file containing all source files used for `@rules_python//python/pip_install:pip_repository.bzl` rules"""
+
+# Each source file is tracked as a target so `pip_repository` rules will know to automatically rebuild if any of the
+# sources changed.
+PIP_INSTALL_PY_SRCS = [
+    "@rules_python//python/pip_install/extract_wheels:__init__.py",
+    "@rules_python//python/pip_install/extract_wheels:__main__.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:__init__.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:arguments.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:bazel.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:namespace_pkgs.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:purelib.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:requirements.py",
+    "@rules_python//python/pip_install/extract_wheels/lib:wheel.py",
+    "@rules_python//python/pip_install/parse_requirements_to_bzl:__init__.py",
+    "@rules_python//python/pip_install/parse_requirements_to_bzl:__main__.py",
+    "@rules_python//python/pip_install/parse_requirements_to_bzl/extract_single_wheel:__init__.py",
+    "@rules_python//python/pip_install/parse_requirements_to_bzl/extract_single_wheel:__main__.py",
+]

--- a/python/pip_install/private/test/BUILD
+++ b/python/pip_install/private/test/BUILD
@@ -3,7 +3,7 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 diff_test(
     name = "srcs_diff_test",
     failure_message = (
-        "Please run `bazel run //python/pip_install/private:srcs_module.install` " +
+        "Please run `bazel run //python/pip_install/private:srcs_module.update` " +
         "to update the `srcs.bzl` module found in the same package."
     ),
     file1 = "//python/pip_install/private:srcs_module",

--- a/python/pip_install/private/test/BUILD
+++ b/python/pip_install/private/test/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+diff_test(
+    name = "srcs_diff_test",
+    failure_message = "Please run `bazel run @rules_rust//python/pip_install/private:srcs_module.install`",
+    file1 = "//python/pip_install/private:srcs_module",
+    file2 = "//python/pip_install/private:srcs.bzl",
+    # TODO: The diff_test here fails on Windows. As does the
+    # install script. This should be fixed.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)

--- a/python/pip_install/private/test/BUILD
+++ b/python/pip_install/private/test/BUILD
@@ -2,7 +2,10 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 diff_test(
     name = "srcs_diff_test",
-    failure_message = "Please run `bazel run @rules_rust//python/pip_install/private:srcs_module.install`",
+    failure_message = (
+        "Please run `bazel run //python/pip_install/private:srcs_module.install` " +
+        "to update the `srcs.bzl` module found in the same package."
+    ),
     file1 = "//python/pip_install/private:srcs_module",
     file2 = "//python/pip_install/private:srcs.bzl",
     # TODO: The diff_test here fails on Windows. As does the


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`pip_repository` rules currently only track the root of `rules_python` in order to determine the location of the necessary python files for rendering BUILD files for python packages. Because only the BUILD file is tracked, the repository rule is never made aware of the python sources. This results in situations where the `@rules_python//python/pip_install` source code may be changed but existing `pip_repository` rules will not be updated. 

Issue Number: N/A


## What is the new behavior?
This change generates a list of source files and passes them to the `pip_repository` rules so it can react to changes made. Now if a change is made to the python code, the repository rule will correctly be re-triggerd.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

