### PR TITLE
restrict visibility on filegroup target only consumed in 1 place

### DIFF
--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -26,7 +26,7 @@ filegroup(
         "//python/pip_install/extract_wheels:py_srcs",
         "//python/pip_install/parse_requirements_to_bzl:py_srcs",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 exports_files(

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -26,7 +26,7 @@ filegroup(
         "//python/pip_install/extract_wheels:py_srcs",
         "//python/pip_install/parse_requirements_to_bzl:py_srcs",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//python/pip_install/private:__pkg__"],
 )
 
 exports_files(


### PR DESCRIPTION
Reviewd #601 after it merged. Thanks for fixing this long outstanding annoyance 🙂  @UebelAndre 

If I understand this code correctly the filegroup is only consumed by `//python/pip_install/private:srcs_module` and so you don't need public visibility on the target.