### PR TITLE
Make python only `bzl_library` target publicly visible

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -49,7 +49,7 @@ filegroup(
         "//python/pip_install:bzl",
         "//python/private:bzl",
     ],
-    visibility = ["//:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 # ========= Core rules =========


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With the introduction of the `gazelle` stuff, I can no longer generate docs in my projects. All I really want is the python `bzl_library` target and think it'd make sense to allow it to be public.

Issue Number: N/A


## What is the new behavior?
This change fixes the use of `stardoc` for generating documentation in external repositories that uses `rules_python` and *does not* use `bazel_gazelle`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

