### PR TITLE
Fixed extra_pip_arg parsing error in pip_repository rules.

### DIFF
--- a/examples/pip_repository_annotations/WORKSPACE
+++ b/examples/pip_repository_annotations/WORKSPACE
@@ -2,10 +2,9 @@ workspace(name = "pip_repository_annotations_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
+local_repository(
     name = "rules_python",
-    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
+    path = "../..",
 )
 
 http_archive(

--- a/examples/pip_repository_annotations/requirements.in
+++ b/examples/pip_repository_annotations/requirements.in
@@ -1,1 +1,5 @@
+# This flag allows for regression testing requirements arguments in 
+# `pip_repository` rules.
+--extra-index-url https://pypi.python.org/simple/
+
 wheel

--- a/examples/pip_repository_annotations/requirements.txt
+++ b/examples/pip_repository_annotations/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    bazel run //:requirements.update
 #
+--extra-index-url https://pypi.python.org/simple/
+
 wheel==0.37.1 \
     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4

--- a/python/pip_install/parse_requirements_to_bzl/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/__init__.py
@@ -209,9 +209,11 @@ If set, it will take precedence over python_interpreter.",
     arguments.parse_common_args(parser)
     args = parser.parse_args()
 
+    whl_library_args = parse_whl_library_args(args)
+
     # Check for any annotations which match packages in the locked requirements file
     install_requirements = parse_install_requirements(
-        args.requirements_lock, args.extra_pip_args
+        args.requirements_lock, whl_library_args["extra_pip_args"]
     )
     req_names = sorted([req.name for req, _ in install_requirements])
     annotations = args.annotations.collect(req_names)
@@ -230,8 +232,6 @@ If set, it will take precedence over python_interpreter.",
         )
 
     with open("requirements.bzl", "w") as requirement_file:
-        whl_library_args = parse_whl_library_args(args)
-
         requirement_file.write(
             generate_parsed_requirements_contents(
                 requirements_lock=args.requirements_lock,

--- a/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
+++ b/python/pip_install/parse_requirements_to_bzl/parse_requirements_to_bzl_test.py
@@ -3,14 +3,20 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from textwrap import dedent
+
+from pip._internal.req.req_install import InstallRequirement
 
 from python.pip_install.parse_requirements_to_bzl import (
     generate_parsed_requirements_contents,
+    parse_install_requirements,
     parse_whl_library_args,
 )
 
 
 class TestParseRequirementsToBzl(unittest.TestCase):
+    maxDiff = None
+
     def test_generated_requirements_bzl(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             requirements_lock = Path(temp_dir) / "requirements.txt"
@@ -63,6 +69,55 @@ class TestParseRequirementsToBzl(unittest.TestCase):
             )
             # Assert it gets set to an empty dict by default.
             self.assertIn("'environment': {}", contents, contents)
+
+    def test_parse_install_requirements_with_args(self):
+        # Test requirements files with varying arguments
+        for requirement_args in ("", "--index-url https://index.python.com"):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                requirements_lock = Path(temp_dir) / "requirements.txt"
+                requirements_lock.write_text(
+                    dedent(
+                        """\
+                    {}
+
+                    wheel==0.37.1 \\
+                        --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \\
+                        --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
+                        # via -r requirements.in
+                    setuptools==58.2.0 \\
+                        --hash=sha256:2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11 \
+                        --hash=sha256:2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145
+                        # via -r requirements.in
+                    """.format(
+                            requirement_args
+                        )
+                    )
+                )
+
+                install_req_and_lines = parse_install_requirements(
+                    str(requirements_lock), ["-v"]
+                )
+
+                # There should only be two entries for the two requirements
+                self.assertEqual(len(install_req_and_lines), 2)
+
+                # The first index in each tuple is expected to be an `InstallRequirement` object
+                self.assertIsInstance(install_req_and_lines[0][0], InstallRequirement)
+                self.assertIsInstance(install_req_and_lines[1][0], InstallRequirement)
+
+                # Ensure the requirements text is correctly parsed with the trailing arguments
+                self.assertTupleEqual(
+                    install_req_and_lines[0][1:],
+                    (
+                        "wheel==0.37.1     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4",
+                    ),
+                )
+                self.assertTupleEqual(
+                    install_req_and_lines[1][1:],
+                    (
+                        "setuptools==58.2.0     --hash=sha256:2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11                         --hash=sha256:2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145",
+                    ),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I ran into an issue where `pip_repository` rules would fail whenever flags were added to `requirements.txt` (or `requirements_lock`). With the diff below, the following exception occurs when running `bazel test //...` in any workspace (here I just happen to have chosen an example at random).
```diff
diff --git a/examples/pip_repository_annotations/requirements.txt b/examples/pip_repository_annotations/requirements.txt
index 51d1dfc..db762cb 100644
--- a/examples/pip_repository_annotations/requirements.txt
+++ b/examples/pip_repository_annotations/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    bazel run //:requirements.update
 #
+--extra-index-url https://pypi.python.org/simple/
+
 wheel==0.37.1 \
     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
```
```
ERROR: no such package '@pypi//': rules_python failed:  (Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/private/var/tmp/_bazel_user/1364d13d3d56e9f951a1c2e7037fc439/external/rules_python/python/pip_install/parse_requirements_to_bzl/__main__.py", line 5, in <module>
    main()
  File "/private/var/tmp/_bazel_user/1364d13d3d56e9f951a1c2e7037fc439/external/rules_python/python/pip_install/parse_requirements_to_bzl/__init__.py", line 213, in main
    install_requirements = parse_install_requirements(
  File "/private/var/tmp/_bazel_user/1364d13d3d56e9f951a1c2e7037fc439/external/rules_python/python/pip_install/parse_requirements_to_bzl/__init__.py", line 43, in parse_install_requirements
    extra_pip_args.extend(shlex.split(line))
AttributeError: 'str' object has no attribute 'extend'
)
```

Issue Number: N/A


## What is the new behavior?
This fixes this exception by correcting the regression introduced in https://github.com/bazelbuild/rules_python/pull/589 and adds regression tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

