### PR TITLE
Fixed incorrect custom compile commands from `compile_pip_requirements`

### DIFF
--- a/python/pip_install/pip_compile.py
+++ b/python/pip_install/pip_compile.py
@@ -15,7 +15,7 @@ if len(sys.argv) < 4:
 
 requirements_in = os.path.relpath(sys.argv.pop(1))
 requirements_txt = sys.argv.pop(1)
-update_target_name = sys.argv.pop(1)
+update_target_label = sys.argv.pop(1)
 
 # Before loading click, set the locale for its parser.
 # If it leaks through to the system setting, it may fail:
@@ -65,9 +65,8 @@ update_target_pkg = "/".join(requirements_in.split("/")[:-1])
 # $(rootpath) in the workspace root gives ./requirements.in
 if update_target_pkg == ".":
     update_target_pkg = ""
-update_command = os.getenv("CUSTOM_COMPILE_COMMAND") or "bazel run //%s:%s" % (
-    update_target_pkg,
-    update_target_name,
+update_command = os.getenv("CUSTOM_COMPILE_COMMAND") or "bazel run %s" % (
+    update_target_label,
 )
 
 os.environ["CUSTOM_COMPILE_COMMAND"] = update_command

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -54,7 +54,7 @@ def compile_pip_requirements(
     args = [
         loc % requirements_in,
         loc % requirements_txt,
-        name + ".update",
+        "//%s:%s.update" % (native.package_name(), name),
     ] + extra_args
 
     deps = [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a `compile_pip_requirements` target is setup in a separate package than where the `requirements_in` file is located, then an incorrect custom compile command is written into the `requirements_txt` file.

Issue Number: N/A


## What is the new behavior?
This change fixes that so no matter where the `compile_pip_requirements` target is defined, it will always correctly be reflected in the generated files when running the `*.update` target.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

