### PR TITLE
conditionally log unused annotations

### DIFF
--- a/python/pip_install/extract_wheels/lib/annotation.py
+++ b/python/pip_install/extract_wheels/lib/annotation.py
@@ -81,7 +81,10 @@ class AnnotationsMap:
             if pkg in unused:
                 collection.update({pkg: unused.pop(pkg)})
 
-        logging.warning("Unused annotations: {}".format(sorted(list(unused.keys()))))
+        if unused:
+            logging.warning(
+                "Unused annotations: {}".format(sorted(list(unused.keys())))
+            )
 
         return collection
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For every use of `pip_repository`, a warning log will be printed about unused `package_annotations` when there aren't any (prints an empty list). There's no reason to print an empty list

Issue Number: N/A


## What is the new behavior?
A warning will only be printed about unsued annotations if there are actually some that are unused.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

