### PR TITLE
Allow `*.dist-info/WHEEL` files into `pip_repository` generated targets

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -146,7 +146,6 @@ def generate_build_file_contents(
     dist_info_ignores = [
         "**/*.dist-info/METADATA",
         "**/*.dist-info/RECORD",
-        "**/*.dist-info/WHEEL",
     ]
 
     data_exclude = list(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This is another followup to https://github.com/bazelbuild/rules_python/pull/632

Issue Number: N/A


## What is the new behavior?
`WHEEL` files should be deterministic and could be used by certain packages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

