### PR TITLE
Allow METADATA files in pip_repository generated targets

### DIFF
--- a/examples/pip_repository_annotations/WORKSPACE
+++ b/examples/pip_repository_annotations/WORKSPACE
@@ -34,6 +34,7 @@ write_file(
         copy_executables = {"@pip_repository_annotations_example//:data/copy_executable.py": "copied_content/executable.py"},
         copy_files = {"@pip_repository_annotations_example//:data/copy_file.txt": "copied_content/file.txt"},
         data = [":generated_file"],
+        data_exclude_glob = ["*.dist-info/WHEEL"],
     ),
 }
 

--- a/examples/pip_repository_annotations/pip_repository_annotations_test.py
+++ b/examples/pip_repository_annotations/pip_repository_annotations_test.py
@@ -64,6 +64,34 @@ class PipRepositoryAnnotationsTest(unittest.TestCase):
         stdout = proc.stdout.decode("utf-8").strip()
         self.assertEqual(stdout, "Hello world from copied executable")
 
+    def test_data_exclude_glob(self):
+        current_wheel_version = "0.37.1"
+
+        r = runfiles.Create()
+        dist_info_dir = (
+            "pip_repository_annotations_example/external/{}/wheel-{}.dist-info".format(
+                self.wheel_pkg_dir(),
+                current_wheel_version,
+            )
+        )
+
+        # Note: `METADATA` is important as it's consumed by https://docs.python.org/3/library/importlib.metadata.html
+        # `METADATA` is expected to be there to show dist-info files are included in the runfiles.
+        metadata_path = r.Rlocation("{}/METADATA".format(dist_info_dir))
+
+        # However, `WHEEL` was explicitly excluded, so it should be missing
+        wheel_path = r.Rlocation("{}/WHEEL".format(dist_info_dir))
+
+        # Because windows does not have `--enable_runfiles` on by default, the
+        # `runfiles.Rlocation` results will be different on this platform vs
+        # unix platforms. See `@rules_python//python/runfiles` for more details.
+        if platform.system() == "Windows":
+            self.assertIsNotNone(metadata_path)
+            self.assertIsNone(wheel_path)
+        else:
+            self.assertTrue(Path(metadata_path).exists())
+            self.assertFalse(Path(wheel_path).exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -139,12 +139,10 @@ def generate_build_file_contents(
     there may be no Python sources whatsoever (e.g. packages written in Cython: like `pymssql`).
     """
 
-    # `dist-info` contains non-determinisitc files which can change any time
-    # the repository rules run. Below is a list of known patterns to these
-    # files. However, not all files should be ignored as certain packages
-    # require things like `top_level.txt`.
     dist_info_ignores = [
-        "**/*.dist-info/METADATA",
+        # RECORD is known to contain sha256 checksums of files which might include the checksums
+        # of generated files produced when wheels are installed. The file is ignored to avoid
+        # Bazel caching issues.
         "**/*.dist-info/RECORD",
     ]
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `*.dist-info/METADATA` files are excluded in `pip_repository` generated targets. This is incorrect as it's consumed by https://docs.python.org/3/library/importlib.metadata.html

Issue Number: N/A


## What is the new behavior?
This change allows `METADATA` files to be included in `pip_repository` generated targets, enabling the use of https://docs.python.org/3/library/importlib.metadata.html.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

