### PR TITLE
chore: update GitHub archive url to produce stable SHA

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -17,7 +17,7 @@ http_archive(
     name = "rules_python",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/bazelbuild/rules_python/archive/${TAG}.tar.gz",
+    url = "https://github.com/bazelbuild/rules_python/refs/tags/${TAG}.tar.gz",
 )
 \`\`\`
 EOF


### PR DESCRIPTION
Required per https://github.com/bazel-contrib/SIG-rules-authors/issues/11