### PR TITLE
release: Fix release snippet

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
-PREFIX="rules_python-${TAG:1}"
+PREFIX="rules_python-${TAG}"
 SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
 
 cat << EOF
@@ -17,7 +17,7 @@ http_archive(
     name = "rules_python",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/bazelbuild/rules_python/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/${TAG}.tar.gz",
 )
 \`\`\`
 EOF


### PR DESCRIPTION
We don't put a 'v' prefix on tags, so we shouldn't trim a character from the tag
Also #650 had an incorrect url for stable SHAs :sweat: