### PR TITLE
Allow for custom python versions in `python_register_toolchains`

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -183,7 +183,6 @@ python_repository = repository_rule(
         "python_version": attr.string(
             doc = "The Python version.",
             mandatory = True,
-            values = TOOL_VERSIONS.keys() + MINOR_MAPPING.keys(),
         ),
         "release_filename": attr.string(
             doc = "The filename of the interpreter to be downloaded",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you define your own `python_register_toolchains.tool_versions` for a version that is not a built in version, then the repository rule rejects it.

Issue Number: N/A


## What is the new behavior?
This change allows users to define custom python versions that are not already registered in `@rules_python//python:versions.bzl`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

