### PR TITLE
Update CODEOWNERS. remove andy scott as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # NB: Last matching rule takes precedence in CODEOWNERS.
 
 # Fall-through to community maintainers.
-* @thundergolfer @andyscott
+* @thundergolfer
 
 # Core Python rules belong to the Bazel team.
 /python/ @brandjon @lberki
 # But not everything under python/ is the core Python rules.
-/python/pip.bzl @thundergolfer @andyscott
-/python/requirements.txt @thundergolfer @andyscott
+/python/pip.bzl @thundergolfer
+/python/requirements.txt @thundergolfer
 
 # Directory containing the Gazelle extension and Go code.
 /gazelle/ @f0rmiga


### PR DESCRIPTION
Finally getting around to taking @andyscott off auto-enrolment in reviews. 

Others should probably replace him, but that can be managed in a follow-up. For now, this saves me manually removing him from reviewers lists on new PRs.