### PR TITLE
Added support for custom `strip_prefix` args in toolchains

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -195,6 +195,7 @@ python_repository = repository_rule(
         ),
         "strip_prefix": attr.string(
             doc = "A directory prefix to strip from the extracted files.",
+            mandatory = True,
         ),
         "url": attr.string(
             doc = "The URL of the interpreter to download",

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -81,7 +81,7 @@ def _python_repository_impl(rctx):
         rctx.download_and_extract(
             url = url,
             sha256 = rctx.attr.sha256,
-            stripPrefix = "python",
+            stripPrefix = rctx.attr.strip_prefix,
         )
 
     # Write distutils.cfg to the Python installation.
@@ -157,6 +157,7 @@ py_runtime_pair(
         "python_version": python_version,
         "release_filename": release_filename,
         "sha256": rctx.attr.sha256,
+        "strip_prefix": rctx.attr.strip_prefix,
         "url": url,
     }
 
@@ -191,6 +192,9 @@ python_repository = repository_rule(
         "sha256": attr.string(
             doc = "The SHA256 integrity hash for the Python interpreter tarball.",
             mandatory = True,
+        ),
+        "strip_prefix": attr.string(
+            doc = "A directory prefix to strip from the extracted files.",
         ),
         "url": attr.string(
             doc = "The URL of the interpreter to download",
@@ -244,7 +248,7 @@ def python_register_toolchains(
         if not sha256:
             continue
 
-        (release_filename, url) = get_release_url(platform, python_version, base_url, tool_versions)
+        (release_filename, url, strip_prefix) = get_release_url(platform, python_version, base_url, tool_versions)
 
         python_repository(
             name = "{name}_{platform}".format(
@@ -258,6 +262,7 @@ def python_register_toolchains(
             url = url,
             distutils = distutils,
             distutils_content = distutils_content,
+            strip_prefix = strip_prefix,
             **kwargs
         )
         native.register_toolchains("@{name}_toolchains//:{platform}_toolchain".format(

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -34,6 +34,7 @@ TOOL_VERSIONS = {
             "x86_64-apple-darwin": "8d06bec08db8cdd0f64f4f05ee892cf2fcbc58cfb1dd69da2caab78fac420238",
             "x86_64-unknown-linux-gnu": "aec8c4c53373b90be7e2131093caa26063be6d9d826f599c935c0e1042af3355",
         },
+        "strip_prefix": "python",
     },
     "3.8.12": {
         "url": "20220227/cpython-{python_version}+20220227-{platform}-{build}.tar.gz",
@@ -43,6 +44,7 @@ TOOL_VERSIONS = {
             "x86_64-pc-windows-msvc": "924f9fd51ff6ccc533ed8e96c5461768da5781eb3dfc11d846f9e300fab44eda",
             "x86_64-unknown-linux-gnu": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
         },
+        "strip_prefix": "python",
     },
     "3.9.10": {
         "url": "20220227/cpython-{python_version}+20220227-{platform}-{build}.tar.gz",
@@ -52,6 +54,7 @@ TOOL_VERSIONS = {
             "x86_64-pc-windows-msvc": "5bc65ce023614bf496a6748e41dca934b70fc5fac6dfacc46aa8dbcad772afc2",
             "x86_64-unknown-linux-gnu": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
         },
+        "strip_prefix": "python",
     },
     "3.10.2": {
         "url": "20220227/cpython-{python_version}+20220227-{platform}-{build}.tar.gz",
@@ -61,6 +64,7 @@ TOOL_VERSIONS = {
             "x86_64-pc-windows-msvc": "a293c5838dd9c8438a84372fb95dda9752df63928a8a2ae516438f187f89567d",
             "x86_64-unknown-linux-gnu": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
         },
+        "strip_prefix": "python",
     },
 }
 
@@ -118,7 +122,7 @@ def get_release_url(platform, python_version, base_url = DEFAULT_RELEASE_BASE_UR
         tool_versions: A dict listing the interpreter versions, their SHAs and URL
 
     Returns:
-        filename and url pair
+        A tuple of (filename, url, and archive strip prefix)
     """
 
     url = tool_versions[python_version]["url"]
@@ -126,13 +130,17 @@ def get_release_url(platform, python_version, base_url = DEFAULT_RELEASE_BASE_UR
     if type(url) == type({}):
         url = url[platform]
 
+    strip_prefix = tool_versions[python_version].get("strip_prefix", None)
+    if type(strip_prefix) == type({}):
+        strip_prefix = strip_prefix[platform]
+
     release_filename = url.format(
         platform = platform,
         python_version = python_version,
         build = "static-install_only" if (WINDOWS_NAME in platform) else "install_only",
     )
     url = "/".join([base_url, release_filename])
-    return (release_filename, url)
+    return (release_filename, url, strip_prefix)
 
 def print_toolchains_checksums(name):
     native.genrule(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Not all toolchains are packaged the same. Even older releases of https://github.com/indygreg/python-build-standalone have different archive structures which are incompatible with how toolchains are currently setup.

Issue Number: N/A


## What is the new behavior?
This change allows for a `strip_prefix` key to be added to `python_register_toolchains.tool_versions` so that users can use reasonably different archive layouts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

