### PR TITLE
Fix annotations_test on windows systems that don't support symlinks

### DIFF
--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -34,13 +34,15 @@ package_annotations_file(
             ],
         ),
         "pkg_c": package_annotation(
-            additive_build_content = """\
+            # The `join` and `strip` here accounts for potential differences
+            # in new lines between unix and windows hosts.
+            additive_build_content = "\n".join([line.strip() for line in """\
 cc_library(
     name = "my_target",
     hdrs = glob(["**/*.h"]),
     srcs = glob(["**/*.cc"]),
 )
-""",
+""".splitlines()]),
             data = [":my_target"],
         ),
         "pkg_d": package_annotation(
@@ -57,7 +59,10 @@ py_test(
     data = [":mock_annotations"],
     env = {"MOCK_ANNOTATIONS": "$(rootpath :mock_annotations)"},
     tags = ["unit"],
-    deps = [":lib"],
+    deps = [
+        ":lib",
+        "//python/runfiles",
+    ],
 )
 
 py_test(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently this test fails on windows systems that don't support symlinks and use `\r\n` as the newline character for checkouts.

Issue Number: N/A


## What is the new behavior?
This change updates `//python/pip_install/extract_wheels/lib:annotations_test` to work on these windows platforms by sanitizing some of the test inputs and using the `@rules_python//python/runfiles` library to locate test data.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

