### PR TITLE
Allow toolchain registration to be optional

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -235,6 +235,7 @@ def python_register_toolchains(
         python_version,
         distutils = None,
         distutils_content = None,
+        register_toolchains = True,
         tool_versions = TOOL_VERSIONS,
         **kwargs):
     """Convenience macro for users which does typical setup.
@@ -251,6 +252,7 @@ def python_register_toolchains(
         python_version: the Python version.
         distutils: see the distutils attribute in the python_repository repository rule.
         distutils_content: see the distutils_content attribute in the python_repository repository rule.
+        register_toolchains: Whether or not to register the downloaded toolchains.
         tool_versions: a dict containing a mapping of version with SHASUM and platform info. If not supplied, the defaults
         in python/versions.bzl will be used
         **kwargs: passed to each python_repositories call.
@@ -282,10 +284,11 @@ def python_register_toolchains(
             strip_prefix = strip_prefix,
             **kwargs
         )
-        native.register_toolchains("@{name}_toolchains//:{platform}_toolchain".format(
-            name = name,
-            platform = platform,
-        ))
+        if register_toolchains:
+            native.register_toolchains("@{name}_toolchains//:{platform}_toolchain".format(
+                name = name,
+                platform = platform,
+            ))
 
     resolved_interpreter_os_alias(
         name = name,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I have workspace A which uses uses these toolchains and want to load things from workspace A in workspace B. Workspace B does not use the new toolchains. Unfortunately, I'm not able to continue loading workspace A since I need the toolchain repositories defined or I'll fail to be able to load some `*.bzl` files. This change allows me to define the toolchain repositories without registering them so.

Issue Number: N/A


## What is the new behavior?
Users can now set `register_toolchains = False` on `python_register_toolchains` to define the toolchain repositories but not register them.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

