### PR TITLE
Fix issue #682

### DIFF
--- a/examples/wheel/BUILD
+++ b/examples/wheel/BUILD
@@ -130,12 +130,15 @@ py_wheel(
 # An example of how to change the wheel package root directory using 'strip_path_prefixes'.
 py_wheel(
     name = "custom_package_root",
-    # Package data. We're building "custom_package_root-0.0.1-py3-none-any.whl"
-    distribution = "example_custom_package_root",
+    # Package data. We're building "examples_custom_package_root-0.0.1-py3-none-any.whl"
+    distribution = "examples_custom_package_root",
     python_tag = "py3",
     strip_path_prefixes = [
         "examples",
     ],
+    entry_points = {
+        "console_scripts": ["main = foo.bar:baz"],
+    },
     version = "0.0.1",
     deps = [
         ":example_pkg",

--- a/examples/wheel/BUILD
+++ b/examples/wheel/BUILD
@@ -132,13 +132,13 @@ py_wheel(
     name = "custom_package_root",
     # Package data. We're building "examples_custom_package_root-0.0.1-py3-none-any.whl"
     distribution = "examples_custom_package_root",
+    entry_points = {
+        "console_scripts": ["main = foo.bar:baz"],
+    },
     python_tag = "py3",
     strip_path_prefixes = [
         "examples",
     ],
-    entry_points = {
-        "console_scripts": ["main = foo.bar:baz"],
-    },
     version = "0.0.1",
     deps = [
         ":example_pkg",

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -219,7 +219,7 @@ UNKNOWN
             "rules_python",
             "examples",
             "wheel",
-            "example_custom_package_root-0.0.1-py3-none-any.whl",
+            "examples_custom_package_root-0.0.1-py3-none-any.whl",
         )
 
         with zipfile.ZipFile(filename) as zf:
@@ -230,9 +230,10 @@ UNKNOWN
                     "wheel/lib/module_with_data.py",
                     "wheel/lib/simple_module.py",
                     "wheel/main.py",
-                    "example_custom_package_root-0.0.1.dist-info/WHEEL",
-                    "example_custom_package_root-0.0.1.dist-info/METADATA",
-                    "example_custom_package_root-0.0.1.dist-info/RECORD",
+                    "examples_custom_package_root-0.0.1.dist-info/WHEEL",
+                    "examples_custom_package_root-0.0.1.dist-info/METADATA",
+                    "examples_custom_package_root-0.0.1.dist-info/entry_points.txt",
+                    "examples_custom_package_root-0.0.1.dist-info/RECORD",
                 ],
             )
 

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -67,6 +67,7 @@ class WheelMaker(object):
             + ".dist-info/"
         )
         self._zipfile = None
+        # Entries for the RECORD file as (filename, hash, size) tuples.
         self._record = []
 
     def __enter__(self):
@@ -119,6 +120,9 @@ class WheelMaker(object):
         def arcname_from(name):
             # Always use unix path separators.
             normalized_arcname = name.replace(os.path.sep, "/")
+            # Don't manipulate names filenames in the .distinfo directory.
+            if normalized_arcname.startswith(self._distinfo_dir):
+                return normalized_arcname
             for prefix in self._strip_path_prefixes:
                 if normalized_arcname.startswith(prefix):
                     return normalized_arcname[len(prefix) :]


### PR DESCRIPTION
Fix a bug where path prefix could be stripped from the distinfo directory name.

Fixes bug #682

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix

## What is the current behavior?
strip_prefixes was wrongly applied to files in .distinfo directory

Issue Number: 682

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
