### PR TITLE
Replace host cfg with exec

### DIFF
--- a/gazelle/modules_mapping/def.bzl
+++ b/gazelle/modules_mapping/def.bzl
@@ -37,7 +37,7 @@ modules_mapping = rule(
             mandatory = True,
         ),
         "_generator": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = "//gazelle/modules_mapping:generator",
             executable = True,
         ),

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -432,7 +432,7 @@ tries to locate `.runfiles` directory which is not packaged in the wheel.
             ),
             "_wheelmaker": attr.label(
                 executable = True,
-                cfg = "host",
+                cfg = "exec",
                 default = "//tools:wheelmaker",
             ),
         },


### PR DESCRIPTION
Something changed on Bazel CI (probably the version of buildifier) such that this suddenly broke on the latest nightly master despite us not changing anything.

See https://buildkite.com/bazel/rules-python-python/builds/2694#d430bd0c-f1cb-496c-81ae-6a9eae413f21