### PR TITLE
Remove duplicate method invocation in entry_point generation

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -41,7 +41,6 @@ def generate_entry_point_contents(
         import sys
         from {module} import {method}
         if __name__ == "__main__":
-            rc = {method}()
             sys.exit({method}())
         """.format(
             shebang=shebang, module=module, method=method


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Duplicate method invocation. 

https://github.com/bazelbuild/rules_python/issues/675 introduced the return code handling. 

https://github.com/bazelbuild/rules_python/pull/573/files#diff-cd80d344159f5c70b91dfc2caee848739096387abeda9152d53f601c812b41eaR38 removed the unnecessary type-check but intro'd the 🐛.

Issue Number: https://github.com/bazelbuild/rules_python/issues/675

## What is the new behavior?

Only execute the method once.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

