### PR TITLE
Init: pypa/installer

### DIFF
--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -18,7 +18,7 @@ py_library(
         "//python/pip_install/parse_requirements_to_bzl:__subpackages__",
     ],
     deps = [
-        requirement("pkginfo"),
+        requirement("installer"),
         requirement("setuptools"),
     ],
 )

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -407,7 +407,7 @@ def extract_wheel(
 
     directory_path = Path(directory)
     entry_points = []
-    for name, module, attribute in sorted(whl.entry_points().items()):
+    for name, (module, attribute) in sorted(whl.entry_points().items()):
         entry_point_script = f"{WHEEL_ENTRY_POINT_PREFIX}_{name}.py"
         (directory_path / entry_point_script).write_text(
             generate_entry_point_contents(module, attribute)

--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -1,5 +1,4 @@
 """Utility class to inspect an extracted wheel directory"""
-import configparser
 import email
 import glob
 import os
@@ -43,7 +42,7 @@ class Wheel:
 
     @property
     def metadata(self) -> email.message.Message:
-        with WheelFile.open(self.path) as wheel_source:
+        with installer.sources.WheelFile.open(self.path) as wheel_source:
             metadata_file = wheel_source.read_dist_info("METADATA")
             metadata = installer.utils.parse_metadata_file(metadata_file)
         return metadata
@@ -53,7 +52,7 @@ class Wheel:
         # TODO Also available as installer.sources.WheelSource.version
         return str(self.metadata["Version"])
 
-    def entry_points(self) -> Dict[str, Tuple[str, str]]:
+    def entry_points(self) -> Dict[str, tuple[str, str]]:
         """Returns the entrypoints defined in the current wheel
 
         See https://packaging.python.org/specifications/entry-points/ for more info
@@ -61,7 +60,7 @@ class Wheel:
         Returns:
             Dict[str, Tuple[str, str]]: A mapping of the entry point's name to it's module and attribute
         """
-        with WheelFile.open(self.path) as wheel_source:
+        with installer.sources.WheelFile.open(self.path) as wheel_source:
             entry_points_file = wheel_source.read_dist_info("entry_points.txt")
             if entry_points_file is None:
                 return dict()
@@ -75,7 +74,7 @@ class Wheel:
     def dependencies(self, extras_requested: Optional[Set[str]] = None) -> Set[str]:
         dependency_set = set()
 
-        for wheel_req in self.metadata.get_all('Requires-Dist'):
+        for wheel_req in self.metadata.get_all('Requires-Dist', list()):
             req = pkg_resources.Requirement(wheel_req)  # type: ignore
 
             if req.marker is None or any(

--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -67,8 +67,8 @@ class Wheel:
             entry_points_mapping = dict()
             entry_points_contents = wheel_source.read_dist_info("entry_points.txt")
             entry_points = installer.utils.parse_entrypoints(entry_points_contents)
-            for script, module, attribute, kind in entry_points:
-                if kind == "console":
+            for script, module, attribute, script_section in entry_points:
+                if script_section == "console":
                     entry_points_mapping[script] = (module, attribute)
 
             return entry_points_mapping
@@ -76,7 +76,7 @@ class Wheel:
     def dependencies(self, extras_requested: Optional[Set[str]] = None) -> Set[str]:
         dependency_set = set()
 
-        for wheel_req in self.metadata.get_all('Requires-Dist', list()):
+        for wheel_req in self.metadata.get_all('Requires-Dist', []):
             req = pkg_resources.Requirement(wheel_req)  # type: ignore
 
             if req.marker is None or any(

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -18,6 +18,11 @@ _RULE_DEPS = [
         "9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
     ),
     (
+        "pypi__installer",
+        "https://files.pythonhosted.org/packages/1b/21/3e6ebd12d8dccc55bcb7338db462c75ac86dbd0ac7439ac114616b21667b/installer-0.5.1-py3-none-any.whl",
+        "1d6c8d916ed82771945b9c813699e6f57424ded970c9d8bf16bbc23e1e826ed3",
+    ),
+    (
         "pypi__pip",
         "https://files.pythonhosted.org/packages/4d/16/0a14ca596f30316efd412a60bdfac02a7259bf8673d4d917dc60b9a21812/pip-22.0.4-py3-none-any.whl",
         "c6aca0f2f081363f689f041d90dab2a07a9a07fb840284db2218117a52da800b",
@@ -26,11 +31,6 @@ _RULE_DEPS = [
         "pypi__pip_tools",
         "https://files.pythonhosted.org/packages/6d/16/75d65bdccd48bb59a08e2bf167b01d8532f65604270d0a292f0f16b7b022/pip_tools-5.5.0-py2.py3-none-any.whl",
         "10841c1e56c234d610d0466447685b9ea4ee4a2c274f858c0ef3c33d9bd0d985",
-    ),
-    (
-        "pypi__pkginfo",
-        "https://files.pythonhosted.org/packages/cd/00/49f59cdd2c6a52e6665fda4de671dac5614366dc827e050c55428241b929/pkginfo-1.8.2-py2.py3-none-any.whl",
-        "c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc",
     ),
     (
         "pypi__setuptools",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The `Wheel` related parsing / unpacking / installation is using custom written code and the [pkginfo](https://pypi.org/project/pkginfo/) package to parse metadata. This logic is complex and fragile because of the many Python Packaging PEPs it relates to.

Issue Number: https://github.com/bazelbuild/rules_python/issues/671


## What is the new behavior?
This PR introduces a modern, PEP standards-compliant library called [installer](https://pypi.org/project/installer/). This package is maintained in the [Python Packaging Authority](https://www.pypa.io/en/latest/) and is written by a few of the current maintainers of `pip`. It is therefore more likely to be processing Wheel files correctly.

This PR is only using [installer](https://pypi.org/project/installer/) for metadata parsing, but if this PR is accepted, I hope to replace all of the custom Wheel processing code.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There are modern Python packaging libraries and PRs emerging that these Bazel rules should adopt where appropriate.

Modern packaging libraries:

[installer](https://pypi.org/project/installer/) from this PR, is able to correctly "install" (or rather unpack) Wheels into the desired location.
[build](https://github.com/pypa/build) is able to replace the elements of `pip` that produces Wheels. Suitable for converting an `sdist` into a Wheel.
[hatch](https://github.com/pypa/hatch) is a modern, extensible Python project manager that is a good example of how best to use the modern and emerging Python Packaging standards.

<hr />

Promising PRs:

[pip metadata-only resolve with pip download --dry-run --report](https://github.com/pypa/pip/pull/10748) when this PR lands and becomes standardised, the new internal resolver of `pip` can be used to produce an approximation of a lockfile. Note: this is not a formal specification of a lockfile (which will require a PEP), but is a promising step in that direction. This would eventually remove the need for `pip-tools`.

<hr />

All of these things together means that there will eventually be the following options for consuming third-party dependencies with `rules_python`.

Option A - Install pre-built Wheels only in WORKSPACE (similar to rules_jvm_external where Bazel only needs to download and unpack)
1. Produce Wheels either using [build](https://github.com/pypa/build) or `pip wheel`
2. Store the Wheels somewhere (local filesystem, git LFS, private PyPI artifact repository
3. Resolve urls for the dependencies against 2 using ` pip download --dry-run --report` and create `.bzl` file
4. Bazel repository rule to consume the `.bzl` and unpack using [installer](https://pypi.org/project/installer/) 

Option B - Build and install in WORKSPACE (approach in this PR where Bazel does a combined build and unpack of third-party code)
1. Bazel repository rule uses `pip wheel` and the fragile "build on demand" nature of `pip` to resolve and download existing Wheels *OR* convert `sdist` to Wheels
2. Use [installer](https://pypi.org/project/installer/) to parse and unpack Wheels from 1.

Option C - Something like rules_pycross (which attempts to fuse python package builds into Bazel as closely as possible)
See: https://github.com/jvolkman/rules_pycross

Option D - Something like dbx_py_pypi_piplib (where you build cpython and libraries form pypi in Bazel)
See: https://github.com/dropbox/dbx_build_tools