### PR TITLE
Handle entry_points that end with .py

### DIFF
--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -48,7 +48,7 @@ def generate_entry_point_contents(
     )
 
 
-def generate_entry_point_rule(script: str, pkg: str) -> str:
+def generate_entry_point_rule(name: str, script: str, pkg: str) -> str:
     """Generate a Bazel `py_binary` rule for an entry point script.
 
     Note that the script is used to determine the name of the target. The name of
@@ -56,6 +56,7 @@ def generate_entry_point_rule(script: str, pkg: str) -> str:
     directories within a wheel.
 
     Args:
+        name (str): The name of the generated py_binary.
         script (str): The path to the entry point's python file.
         pkg (str): The package owning the entry point. This is expected to
             match up with the `py_library` defined for each repository.
@@ -64,7 +65,6 @@ def generate_entry_point_rule(script: str, pkg: str) -> str:
     Returns:
         str: A `py_binary` instantiation.
     """
-    name = os.path.splitext(script)[0]
     return textwrap.dedent(
         """\
         py_binary(
@@ -409,13 +409,18 @@ def extract_wheel(
     directory_path = Path(directory)
     entry_points = []
     for name, entry_point in sorted(whl.entry_points().items()):
-        entry_point_script = f"{WHEEL_ENTRY_POINT_PREFIX}_{name}.py"
-        (directory_path / entry_point_script).write_text(
+        # There is an extreme edge-case with entry_points that end with `.py`
+        # See: https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/test/java/com/google/devtools/build/lib/rules/python/PyBinaryConfiguredTargetTest.java#L174
+        entry_point_without_py = name[:-3] if name.endswith(".py") else name
+        entry_point_target_name = f"{WHEEL_ENTRY_POINT_PREFIX}_{entry_point_without_py}"
+        entry_point_script_name = f"{entry_point_target_name}.py"
+        (directory_path / entry_point_script_name).write_text(
             generate_entry_point_contents(entry_point)
         )
         entry_points.append(
             generate_entry_point_rule(
-                entry_point_script,
+                entry_point_target_name,
+                entry_point_script_name,
                 library_name,
             )
         )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
There are some entry_points in the wild that end with a `.py` suffix. This is an extreme edge-case, but this clashes with the native Python rules in Bazel that forbids `py_binary` to end with `.py`.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
An example entry_point in the wild that ends with `.py` https://github.com/jupyterhub/jupyterhub-idle-culler/blob/9dba16033485f3c70352edd3255bb0c5905f16ce/setup.py#L15
