### PR TITLE
Don't include pyc files as part of the hermetic toolchain

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -128,7 +128,8 @@ filegroup(
             "share/**",
         ],
         exclude = [
-            "**/* *", # Bazel does not support spaces in file names.
+            "**/* *",   # Bazel does not support spaces in file names.
+            "**/*.pyc", # These are not deterministically generated, breaking remote caching
         ],
     ),
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'm not sure how to test this.

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Using rules_python with the hermetic toolchain via `python_register_toolchains` results in cache misses when using bazel with a remote cache. This appears to be because pyc files that are generated on the build host are included as part of one of the globs, but since pyc files don't appear to be generated deterministically. For example, from one run we saw one action that used the hermetic toolchain had the following file as an input:
```
        {
          "path": "external/python3_9_x86_64-pc-windows-msvc/lib/__pycache__/_markupbase.cpython-39.pyc",
          "digest": "acc87949c12c0a73eace38bed1a4d9e311ff283fe29a7e28bdfb339ff267ed27"
        },
```
but from another run we saw:
```
        {
          "path": "external/python3_9_x86_64-pc-windows-msvc/lib/__pycache__/_markupbase.cpython-39.pyc",
          "digest": "afb43608c750e3f7d4dcb0c968aec6d84f678cebc506666325b43c24ce964e5a"
        },
```
The hashes above are taken from the bazel execution log as per https://bazel.build/docs/remote-execution-caching-debug.
Note that although the above are with the windows toolchain, we saw the same behaviour on all MacOS, Linux, and Windows.

## What is the new behavior?

pyc files are excluded from the glob. We're no longer seeing cache misses when using a cache.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
