### PR TITLE
Made version failure message better reflect the issue

### DIFF
--- a/third_party/github.com/bazelbuild/bazel-skylib/lib/versions.bzl
+++ b/third_party/github.com/bazelbuild/bazel-skylib/lib/versions.bzl
@@ -89,7 +89,7 @@ def _check_bazel_version(minimum_bazel_version, maximum_bazel_version = None, ba
     """
     if not bazel_version:
         if "bazel_version" not in dir(native):
-            fail("Current Bazel version is lower than 0.2.1; expected at least {}".format(
+            fail("Bazel version cannot be determined; expected at least {}".format(
                 minimum_bazel_version,
             ))
         elif not native.bazel_version:


### PR DESCRIPTION
I ran into a sitation that triggered this failure. I have version 5.0.0 installed, so it was confusing to see a message telling me my version was lower than 0.2.1.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:
Error message clarification.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I received the following output from a build:

```
File "/private/var/tmp/_bazel_jdob/300f9ff46946083ee2e5c32c9a7995b7/external/rules_python/third_party/github.com/bazelbuild/bazel-skyli
b/lib/versions.bzl", line 92, column 17, in _check_bazel_version
                fail("Current Bazel version is lower than 0.2.1; expected at least {}".format(
Error in fail: Current Bazel version is lower than 0.2.1; expected at least 4.0.0
```

Running Bazel shows I have a higher version than 0.2.1:

```
$ bazel version
Build label: 5.0.0
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Wed Jan 19 14:15:55 2022 (1642601755)
Build timestamp: 1642601755
Build timestamp as int: 1642601755
```

## What is the new behavior?

The error message indicates that the version cannot be determined, rather than the message reflecting an old version.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

