### PR TITLE
Fix python3.8 type compatibility

### DIFF
--- a/python/pip_install/extract_wheels/lib/wheel.py
+++ b/python/pip_install/extract_wheels/lib/wheel.py
@@ -4,7 +4,7 @@ import glob
 import os
 import stat
 import zipfile
-from typing import Dict, Optional, Set
+from typing import Dict, Optional, Set, Tuple
 
 import installer
 import pkg_resources
@@ -52,7 +52,7 @@ class Wheel:
         # TODO Also available as installer.sources.WheelSource.version
         return str(self.metadata["Version"])
 
-    def entry_points(self) -> Dict[str, tuple[str, str]]:
+    def entry_points(self) -> Dict[str, Tuple[str, str]]:
         """Returns the entrypoints defined in the current wheel
 
         See https://packaging.python.org/specifications/entry-points/ for more info


### PR DESCRIPTION
The tuple type helper isn't supported in python3.8, which is currently
the version macOS has in /usr/bin/python3.