### PR TITLE
fix: versioned shared object for libpython on Linux

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -154,7 +154,7 @@ cc_import(
     shared_library = select({{
         "@platforms//os:windows": "python3.dll",
         "@platforms//os:macos": "lib/libpython{python_version}.dylib",
-        "@platforms//os:linux": "lib/libpython{python_version}.so",
+        "@platforms//os:linux": "lib/libpython{python_version}.so.1.0",
     }}),
 )
 


### PR DESCRIPTION
We need the versioned shared object on Linux rather than the symlink that points to the versioned one.