### PR TITLE
Provide current_py_toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ After registration, your Python targets will use the toolchain's interpreter dur
 is still used to 'bootstrap' Python targets (see https://github.com/bazelbuild/rules_python/issues/691).
 You may also find some quirks while using this toolchain. Please refer to [python-build-standalone documentation's _Quirks_ section](https://python-build-standalone.readthedocs.io/en/latest/quirks.html) for details.
 
+### Toolchain usage in other rules
+
+Python toolchains can be utilised in other bazel rules, such as `genrule()`, by adding the `toolchains=["@rules_python//python:current_py_toolchain"]` attribute. The path to the python interpreter can be obtained by using the `$(PYTHON2)` and `$(PYTHON3)` ["Make" Variables](https://bazel.build/reference/be/make-variables). See the [`test_current_py_toolchain`](tests/load_from_macro/BUILD) target for an example.
+
+
 ### "Hello World"
 
 Once you've imported the rule set into your `WORKSPACE` using any of these

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,5 +1,28 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+<a name="#current_py_toolchain"></a>
+
+## current_py_toolchain
+
+<pre>
+current_py_toolchain(<a href="#current_py_toolchain-name">name</a>)
+</pre>
+
+
+    This rule exists so that the current python toolchain can be used in the `toolchains` attribute of
+    other rules, such as genrule. It allows exposing a python toolchain after toolchain resolution has
+    happened, to a rule which expects a concrete implementation of a toolchain, rather than a
+    toolchain_type which could be resolved to that toolchain.
+    
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+
+
 <a name="#py_import"></a>
 
 ## py_import

--- a/python/BUILD
+++ b/python/BUILD
@@ -24,6 +24,8 @@ In an ideal renaming, we'd move the packaging rules to a different package so
 that @rules_python//python is only concerned with the core rules.
 """
 
+load(":defs.bzl", "current_py_toolchain")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
@@ -138,3 +140,7 @@ exports_files([
     "packaging.bzl",
     "pip.bzl",
 ])
+
+current_py_toolchain(
+    name = "current_py_toolchain",
+)

--- a/tests/load_from_macro/BUILD
+++ b/tests/load_from_macro/BUILD
@@ -24,3 +24,11 @@ py_library(
     # Allow a test to verify an "outside package" doesn't get included
     visibility = ["//examples/wheel:__pkg__"],
 )
+
+genrule(
+    name = "test_current_py_toolchain",
+    srcs = [],
+    outs = ["out.txt"],
+    cmd = "$(PYTHON3) --version > $(location out.txt)",
+    toolchains = ["//python:current_py_toolchain"],
+)


### PR DESCRIPTION
This PR introduces the current_py_toolchain rule, exposing the
PYTHON2 and PYTHON3 "make" variables in bazel rules, analagous to
@bazel_tools//tools/cpp:current_cc_toolchain.

This is useful when building 3rd party libraries which require python via rules_foreign_cc.


See
https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Bazel rules can refer to the python interpreter via "Make" Variables. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

