### PR TITLE
Fix remote cache miss

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -142,6 +142,7 @@ filegroup(
         ],
         exclude = [
             "**/* *", # Bazel does not support spaces in file names.
+            "**/__pycache__/**",
         ],
     ),
 )


### PR DESCRIPTION
In some cases, the hermetic python toolchain would generate .pyc files
when being used, resulting in a remote cache miss. This commit excludes
generated files from the "files" filegroup to resolve this issue

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

