### PR TITLE
Fix logical error in pip_repository.bzl

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -73,14 +73,17 @@ def _maybe_set_xcode_location_cflags(rctx, environment):
     Pip won't be able to compile c extensions from sdists with the pre built python distributions from indygreg
     otherwise. See https://github.com/indygreg/python-build-standalone/issues/103
     """
-    python_interpreter_workspace = rctx.path(Label("@{}//:WORKSPACE".format(rctx.attr.python_interpreter_target.workspace_name))).dirname
-    if (
+    if not (
         rctx.os.name.lower().startswith("mac os") and
         rctx.attr.python_interpreter_target != None and
-        # This is a rules_python provided toolchain.
-        rctx.execute(["ls", "{}/{}".format(python_interpreter_workspace, STANDALONE_INTERPRETER_FILENAME)]).return_code == 0 and
         not environment.get(CPPFLAGS)
     ):
+        return
+
+    # This is a rules_python provided toolchain.
+    python_interpreter_workspace = rctx.path(Label("@{}//:WORKSPACE".format(rctx.attr.python_interpreter_target.workspace_name))).dirname
+    ls_result = rctx.execute(["ls", "{}/{}".format(python_interpreter_workspace, STANDALONE_INTERPRETER_FILENAME)])
+    if ls_result.return_code == 0:
         xcode_sdk_location = rctx.execute(["xcode-select", "--print-path"])
         if xcode_sdk_location.return_code == 0:
             xcode_root = xcode_sdk_location.stdout.strip()


### PR DESCRIPTION
`rctx.attr.python_interpreter_target.workspace_name` was being accessed even if `rctx.attr.python_interpreter_target` was unset. This change returns from the `_maybe_set_xcode_location_cflags` function early if the preconditions aren't met.

Looks like this was very-recently merged in #750