### PR TITLE
Exclude static libraries and tests to reduce zipped Python executables

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -146,8 +146,8 @@ filegroup(
             "lib/*.a",
             "lib/**/*.a",
             # tests for the standard libraries.
-            "lib/**/test/**",
-            "lib/**/tests/**",
+            "lib/python{python_version}/**/test/**",
+            "lib/python{python_version}/**/tests/**",
         ],
     ),
 )

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -142,6 +142,12 @@ filegroup(
         ],
         exclude = [
             "**/* *", # Bazel does not support spaces in file names.
+            # static libraries
+            "lib/*.a",
+            "lib/**/*.a",
+            # tests for the standard libraries.
+            "lib/**/test/**",
+            "lib/**/tests/**",
         ],
     ),
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Build artifacts by `bazel build` with the `--build_python_zip` option are unnecessary big. The size of the artifacts is at least 90MB (e.g., a zipped python binary which just prints "hello, world"). This is not great when build artifacts are included to docker images. The cause of this size issue is that the hermetic Python toolchain include the static libraries of the Python toolchain and tests for the standard libraries even though majority of users of rules_python don't need them. These files occupy 47MB (52% of an artifact of size 90MB).

## Repro steps

`WORKSPACE`:
```starlark
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "rules_python",
    sha256 = "a3a6e99f497be089f81ec082882e40246bfd435f52f4e82f37e89449b04573f6",
    strip_prefix = "rules_python-0.10.2",
    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz",
)

load("@rules_python//python:repositories.bzl", "python_register_toolchains")

python_register_toolchains(
    name = "python3_10",
    python_version = "3.10.4",
)
```

`BUILD`:
```starlark
load("@rules_python//python:defs.bzl", "py_binary")

py_binary(
    name = "hello",
    srcs = ["hello.py"],
)
```

`hello.py`:
```python
print("hello, world!")
```

```shell
$ bazel build --build_python_zip //:hello
$ ls -lh bazel-bin/hello.zip
-r-xr-xr-x 1 t docker 91M Jul 17 11:55 bazel-bin/hello.zip
```

You can see some static libraries are included in the zip file (we have duplicated `libpython3.10.a`. The file size (uncompressed) of the static library is 38MB):

```shell
$ unzip -l bazel-bin/hello.zip | sort -n | grep ".a$"
     2356  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/itcl4.2.2/libitclstub4.2.2.a
   149348  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/thread2.8.7/libthread2.8.7.a
   496010  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/itcl4.2.2/libitcl4.2.2.a
   526406  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/Tix8.4.3/libTix8.4.3.a
 39633662  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/libpython3.10.a
 39633662  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/python3.10/config-3.10-x86_64-linux-gnu/libpython3.10.a
```

## What is the new behavior?

The static libraries and tests for the standard libraries in the Python toolchain are excluded from Python runfiles built by Python rules. Build artifacts by `bazel build` with the `--build_python_zip` get smaller. The size of the artifacts is at least 43MB, saving 47MB.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

