### PR TITLE
[gazelle] Use filepath.WalkDir instead of filepath.Walk

### DIFF
--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -4,6 +4,8 @@ This directory contains a plugin for
 [Gazelle](https://github.com/bazelbuild/bazel-gazelle)
 that generates BUILD file content for Python code.
 
+It requires Go 1.16+ to compile.
+
 ## Installation
 
 First, you'll need to add Gazelle to your `WORKSPACE` file.


### PR DESCRIPTION
filepath.WalkDir lets us avoid calling stat on each file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
N/A

## What is the new behavior?
Avoid a stat call for each file and slightly cleaner error handling

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

