### PR TITLE
Exclude unused libpython{python_version}.so to reduce the size of zipped Python executables

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -170,6 +170,9 @@ filegroup(
         allow_empty = True,
         exclude = [
             "**/* *", # Bazel does not support spaces in file names.
+            # Unused shared libraries. `python` executable and the `:libpython` target
+            # depend on `libpython{python_version}.so.1.0`.
+            "lib/libpython{python_version}.so",
             # static libraries
             "lib/**/*.a",
             # tests for the standard libraries.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

#758 reduced the size of artifacts built by the `bazel build` command with the `--build_python_zip` option, but there is still room for improvement. The size of the artifacts is at least 43MB (e.g., a zipped python binary which just prints "hello, world"). This is still not great when build artifacts are included to docker images. It turned out that the --build_python_zip option includes the two identical shared libraries (not symlinks), `libpython{python_version}.so` and `libpython{python_version}.so.1.0` into the zip files, but rules_python doesn't use `libpython{python_version}.so`.
`libpython{python_version}.so` occupies 16MB (37% of the total size of the artifact of size 43MB). By removing the unused shared library, users of rules_python can deploy smaller Python binaries.

## Repro steps

`WORKSPACE`:
```starlark
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

commit = "9cdb4f3f6aded1ccc62a10d004f9927ccc72702f"

http_archive(
    name = "rules_python",
    sha256 = "7d048c530ca907013565fee907d358314c4cb329622284e07c50be76f2d961ee",
    strip_prefix = "rules_python-" + commit,
    url = "https://github.com/tetsuok/rules_python/archive/" + commit + ".tar.gz",
)

load("@rules_python//python:repositories.bzl", "python_register_toolchains")

python_register_toolchains(
    name = "python3_10",
    python_version = "3.10.4",
)
```

`BUILD`:
```starlark
load("@rules_python//python:defs.bzl", "py_binary")

py_binary(
    name = "hello",
    srcs = ["hello.py"],
)
```

`hello.py`:
```python
print("hello, world!")
```

```shell
$ bazel build --build_python_zip //:hello
$ ls -lh bazel-bin/hello.zip
-r-xr-xr-x 1 t docker 43M Jul 29 00:15 bazel-bin/hello.zip
```

You can see two identical shared libraries, `libpython{python_version}.so` and `libpython{python_version}.so.1.0` into zip files, and the shared libraries dominate the total size of zip files:

```shell
$ unzip -l bazel-bin/hello.zip | sort -n | tail -n 6
   745004  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/python3.10/pydoc_data/topics.py
   816725  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/python3.10/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl
  2123599  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/python3.10/ensurepip/_bundled/pip-22.0.4-py3-none-any.whl
 38861696  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/libpython3.10.so
 38861696  2010-01-01 00:00   runfiles/python3_10_x86_64-unknown-linux-gnu/lib/libpython3.10.so.1.0
110513272                     2381 files
```

## What is the new behavior?

The unused shared library, `libpython{python_version}.so` included in the hermetic Python toolchain is excluded from Python runfiles built by Python rules. Artifacts built by the `bazel build` command with the `--build_python_zip` get smaller. The size of the resulting zipped Python executables reduces by 16 MB (43 MB → 27 MB in the above example).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

