### PR TITLE
Fixed unsound issue in wheel examples

### DIFF
--- a/examples/wheel/BUILD
+++ b/examples/wheel/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//examples/wheel/private:wheel_utils.bzl", "directory_writer")
 load("//python:defs.bzl", "py_library", "py_test")
 load("//python:packaging.bzl", "py_package", "py_wheel")
 load("//python:versions.bzl", "gen_python_config_settings")
@@ -40,10 +41,10 @@ py_library(
     ],
 )
 
-genrule(
+directory_writer(
     name = "gen_dir",
-    outs = ["someDir"],
-    cmd = "mkdir -p $@ && touch $@/foo.py",
+    out = "someDir",
+    files = {"foo.py": ""},
 )
 
 # Package just a specific py_libraries, without their dependencies
@@ -188,8 +189,8 @@ py_wheel(
 )
 
 py_wheel(
-    name = "use_genrule_with_dir_in_outs",
-    distribution = "use_genrule_with_dir_in_outs",
+    name = "use_rule_with_dir_in_outs",
+    distribution = "use_rule_with_dir_in_outs",
     python_tag = "py3",
     version = "0.0.1",
     deps = [
@@ -240,6 +241,6 @@ py_test(
         ":minimal_with_py_package",
         ":python_abi3_binary_wheel",
         ":python_requires_in_a_package",
-        ":use_genrule_with_dir_in_outs",
+        ":use_rule_with_dir_in_outs",
     ],
 )

--- a/examples/wheel/private/BUILD
+++ b/examples/wheel/private/BUILD
@@ -1,0 +1,7 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "directory_writer",
+    srcs = ["directory_writer.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/wheel/private/directory_writer.py
+++ b/examples/wheel/private/directory_writer.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""The action executable of the `@rules_python//examples/wheel/private:wheel_utils.bzl%directory_writer` rule."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Tuple
+
+
+def _file_input(value) -> Tuple[Path, str]:
+    path, content = value.split("=", maxsplit=1)
+    return (Path(path), json.loads(content))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--output", type=Path, required=True, help="The output directory to create."
+    )
+    parser.add_argument(
+        "--file",
+        dest="files",
+        type=_file_input,
+        action="append",
+        help="Files to create within the `output` directory.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    for (path, content) in args.files:
+        new_file = args.output / path
+        new_file.parent.mkdir(parents=True, exist_ok=True)
+        new_file.write_text(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wheel/private/wheel_utils.bzl
+++ b/examples/wheel/private/wheel_utils.bzl
@@ -1,0 +1,42 @@
+"""Helper rules for demonstrating `py_wheel` examples"""
+
+def _directory_writer_impl(ctx):
+    output = ctx.actions.declare_directory(ctx.attr.out)
+
+    args = ctx.actions.args()
+    args.add("--output", output.path)
+
+    for path, content in ctx.attr.files.items():
+        args.add("--file={}={}".format(
+            path,
+            json.encode(content),
+        ))
+
+    ctx.actions.run(
+        outputs = [output],
+        arguments = [args],
+        executable = ctx.executable._writer,
+    )
+
+    return [DefaultInfo(
+        files = depset([output]),
+        runfiles = ctx.runfiles(files = [output]),
+    )]
+
+directory_writer = rule(
+    implementation = _directory_writer_impl,
+    doc = "A rule for generating a directory with the requested content.",
+    attrs = {
+        "files": attr.string_dict(
+            doc = "A mapping of file name to content to create relative to the generated `out` directory.",
+        ),
+        "out": attr.string(
+            doc = "The name of the directory to create",
+        ),
+        "_writer": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//examples/wheel/private:directory_writer"),
+        ),
+    },
+)

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -29,7 +29,7 @@ class WheelTest(unittest.TestCase):
             "example_minimal_library-0.0.1-py3-none-any.whl",
         )
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/lib/module_with_data.py",
@@ -49,7 +49,7 @@ class WheelTest(unittest.TestCase):
             "example_minimal_package-0.0.1-py3-none-any.whl",
         )
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/lib/data.txt",
@@ -71,7 +71,7 @@ class WheelTest(unittest.TestCase):
             "example_customized-0.0.1-py3-none-any.whl",
         )
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/lib/data.txt",
@@ -92,7 +92,7 @@ class WheelTest(unittest.TestCase):
             )
             # The entries are guaranteed to be sorted.
             if platform.system() == "Windows":
-                self.assertEquals(
+                self.assertEqual(
                     record_contents,
                     b"""\
 example_customized-0.0.1.dist-info/METADATA,sha256=pzE96o3Sp63TDzxAZgl0F42EFevm8x15vpDLqDVp_EQ,378
@@ -106,7 +106,7 @@ examples/wheel/main.py,sha256=sgg5iWN_9inYBjm6_Zw27hYdmo-l24fA-2rfphT-IlY,909
 """,
                 )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     record_contents,
                     b"""\
 example_customized-0.0.1.dist-info/METADATA,sha256=TeeEmokHE2NWjkaMcVJuSAq4_AXUoIad2-SLuquRmbg,372
@@ -119,7 +119,7 @@ examples/wheel/lib/simple_module.py,sha256=z2hwciab_XPNIBNH8B1Q5fYgnJvQTeYf0ZQJp
 examples/wheel/main.py,sha256=sgg5iWN_9inYBjm6_Zw27hYdmo-l24fA-2rfphT-IlY,909
 """,
                 )
-            self.assertEquals(
+            self.assertEqual(
                 wheel_contents,
                 b"""\
 Wheel-Version: 1.0
@@ -129,7 +129,7 @@ Tag: py3-none-any
 """,
             )
             if platform.system() == "Windows":
-                self.assertEquals(
+                self.assertEqual(
                     metadata_contents,
                     b"""\
 Metadata-Version: 2.1
@@ -147,7 +147,7 @@ This is a sample description of a wheel.
 """,
                 )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     metadata_contents,
                     b"""\
 Metadata-Version: 2.1
@@ -164,7 +164,7 @@ Requires-Dist: pytest
 This is a sample description of a wheel.
 """,
                 )
-            self.assertEquals(
+            self.assertEqual(
                 entry_point_contents,
                 b"""\
 [console_scripts]
@@ -185,7 +185,7 @@ second = second.main:s""",
             "file_name_escaping-0.0.1_r7-py3-none-any.whl",
         )
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/lib/data.txt",
@@ -203,7 +203,7 @@ second = second.main:s""",
             metadata_contents = zf.read(
                 "file_name_escaping-0.0.1_r7.dist-info/METADATA"
             )
-            self.assertEquals(
+            self.assertEqual(
                 metadata_contents,
                 b"""\
 Metadata-Version: 2.1
@@ -224,7 +224,7 @@ UNKNOWN
         )
 
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "wheel/lib/data.txt",
@@ -256,7 +256,7 @@ UNKNOWN
         )
 
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "data.txt",
@@ -287,7 +287,7 @@ UNKNOWN
         )
 
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "lib/data.txt",
@@ -321,7 +321,7 @@ UNKNOWN
                 "example_python_requires_in_a_package-0.0.1.dist-info/METADATA"
             )
             # The entries are guaranteed to be sorted.
-            self.assertEquals(
+            self.assertEqual(
                 metadata_contents,
                 b"""\
 Metadata-Version: 2.1
@@ -380,24 +380,24 @@ Tag: cp38-abi3-{os_string}_{arch}
 """,
             )
 
-    def test_genrule_creates_directory_and_is_included_in_wheel(self):
+    def test_rule_creates_directory_and_is_included_in_wheel(self):
         filename = os.path.join(
             os.environ["TEST_SRCDIR"],
             "rules_python",
             "examples",
             "wheel",
-            "use_genrule_with_dir_in_outs-0.0.1-py3-none-any.whl",
+            "use_rule_with_dir_in_outs-0.0.1-py3-none-any.whl",
         )
 
         with zipfile.ZipFile(filename) as zf:
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/main.py",
                     "examples/wheel/someDir/foo.py",
-                    "use_genrule_with_dir_in_outs-0.0.1.dist-info/WHEEL",
-                    "use_genrule_with_dir_in_outs-0.0.1.dist-info/METADATA",
-                    "use_genrule_with_dir_in_outs-0.0.1.dist-info/RECORD",
+                    "use_rule_with_dir_in_outs-0.0.1.dist-info/WHEEL",
+                    "use_rule_with_dir_in_outs-0.0.1.dist-info/METADATA",
+                    "use_rule_with_dir_in_outs-0.0.1.dist-info/RECORD",
                 ],
             )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There's currently a warning in the `//examples/wheel` package:
```
WARNING: /Users/user/Code/rules_python/examples/wheel/BUILD:43:8: output 'examples/wheel/someDir' of //examples/wheel:gen_dir is a directory; dependency checking of directories is unsound
```

Issue Number: N/A


## What is the new behavior?

The changes here fix the warning by implementing a rule to properly create the desired inputs to the examples.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

