### PR TITLE
chore: remove pkginfo from bzlmod file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,6 @@ use_repo(
     "pypi__click",
     "pypi__pip",
     "pypi__pip_tools",
-    "pypi__pkginfo",
     "pypi__setuptools",
     "pypi__wheel",
 )


### PR DESCRIPTION
Under bazel 5 this unused entry is okay, but with Bazel 6 you get an error

ERROR: Analysis of target '//:bzlmod' failed; build aborted: module extension "pip_install" from "@@rules_python~override//python:extensions.bzl" does not generate repository "pypi__pkginfo", yet it is imported as "pypi__pkginfo" in the usage at rules_python@_/MODULE.bazel:7:28

This was detected on BCR which runs against latest bazel, so I had to
make this change there already:
https://github.com/bazelbuild/bazel-central-registry/commit/6e1bf0e63008fff663da70ae96cf1425c568fa31#diff-d133485c86e1650c9910643274be2051f2c714042c59de22b4c3fd6e546bd93c
