### PR TITLE
Added importlib + reqs to pip-compile for python < 3.8

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -67,6 +67,21 @@ _RULE_DEPS = [
         "https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl",
         "4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a",
     ),
+    (
+        "pypi__importlib_metadata",
+        "https://files.pythonhosted.org/packages/d7/31/74dcb59a601b95fce3b0334e8fc9db758f78e43075f22aeb3677dfb19f4c/importlib_metadata-1.4.0-py2.py3-none-any.whl",
+        "bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
+    ),
+    (
+        "pypi__zipp",
+        "https://files.pythonhosted.org/packages/f4/50/cc72c5bcd48f6e98219fc4a88a5227e9e28b81637a99c49feba1d51f4d50/zipp-1.0.0-py2.py3-none-any.whl",
+        "8dda78f06bd1674bd8720df8a50bb47b6e1233c503a4eed8e7810686bde37656",
+    ),
+    (
+        "pypi__more_itertools",
+        "https://files.pythonhosted.org/packages/bd/3f/c4b3dbd315e248f84c388bd4a72b131a29f123ecacc37ffb2b3834546e42/more_itertools-8.13.0-py3-none-any.whl",
+        "c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb",
+    ),
 ]
 
 _GENERIC_WHEEL = """\

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -76,6 +76,9 @@ def compile_pip_requirements(
         requirement("pip_tools"),
         requirement("setuptools"),
         requirement("tomli"),
+        requirement("importlib_metadata"),
+        requirement("zipp"),
+        requirement("more_itertools"),
     ]
 
     attrs = {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
You cannot run the `compile_pip_requirements.update` target with a Python interpreter at a version < 3.8 - it will fail on importing `importlib_metadata` in the `build` package

## What is the new behavior?
You can run the `compile_pip_requirements.update` target with a Python interpreter at a version < 3.8 


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

I could see a scenario where part of the setup instructions involve telling the user to produce a lockfile for `pip-compile` from their local env, but it's probably just easier to package up all the reqs for any version.