### PR TITLE
chore: remove distribution filegroups

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,27 +22,6 @@ exports_files([
     "version.bzl",
 ])
 
-filegroup(
-    name = "distribution",
-    srcs = [
-        "BUILD",
-        "MODULE.bazel",
-        "WORKSPACE",
-        "internal_deps.bzl",
-        "internal_setup.bzl",
-        "//python:distribution",
-        "//python/pip_install:distribution",
-        "//third_party/github.com/bazelbuild/bazel-skylib/lib:distribution",
-        "//third_party/github.com/bazelbuild/bazel-skylib/rules:distribution",
-        "//third_party/github.com/bazelbuild/bazel-skylib/rules/private:distribution",
-        "//tools:distribution",
-    ],
-    visibility = [
-        "//examples:__pkg__",
-        "//tests:__pkg__",
-    ],
-)
-
 # Reexport of all bzl files used to allow downstream rules to generate docs
 # without shipping with a dependency on Skylib
 filegroup(

--- a/python/BUILD
+++ b/python/BUILD
@@ -30,16 +30,6 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]) + [
-        "//python/constraints:distribution",
-        "//python/runfiles:distribution",
-        "//python/private:distribution",
-    ],
-    visibility = ["//:__pkg__"],
-)
-
 # Filegroup of bzl files that can be used by downstream rules for documentation generation
 # Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
 filegroup(

--- a/python/constraints/BUILD
+++ b/python/constraints/BUILD
@@ -16,12 +16,6 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]),
-    visibility = ["//python:__pkg__"],
-)
-
 # A constraint_setting to use for constraints related to the location of the
 # system Python 2 interpreter on a platform.
 alias(

--- a/python/pip_install/BUILD
+++ b/python/pip_install/BUILD
@@ -1,17 +1,6 @@
 exports_files(["pip_compile.py"])
 
 filegroup(
-    name = "distribution",
-    srcs = glob(["*.bzl"]) + [
-        "BUILD",
-        "pip_compile.py",
-        "//python/pip_install/extract_wheels:distribution",
-        "//python/pip_install/private:distribution",
-    ],
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
     name = "bzl",
     srcs = glob(["*.bzl"]) + [
         "//python/pip_install/private:bzl_srcs",

--- a/python/pip_install/extract_wheels/BUILD
+++ b/python/pip_install/extract_wheels/BUILD
@@ -169,15 +169,6 @@ py_test(
 )
 
 filegroup(
-    name = "distribution",
-    srcs = glob(
-        ["*"],
-        exclude = ["*_test.py"],
-    ),
-    visibility = ["//python/pip_install:__subpackages__"],
-)
-
-filegroup(
     name = "py_srcs",
     srcs = glob(
         include = ["**/*.py"],

--- a/python/pip_install/private/BUILD
+++ b/python/pip_install/private/BUILD
@@ -7,12 +7,6 @@ exports_files([
 ])
 
 filegroup(
-    name = "distribution",
-    srcs = glob(["*"]),
-    visibility = ["//python/pip_install:__subpackages__"],
-)
-
-filegroup(
     name = "bzl_srcs",
     srcs = glob(["*.bzl"]),
 )

--- a/python/private/BUILD
+++ b/python/private/BUILD
@@ -17,12 +17,6 @@ load(":stamp.bzl", "stamp_build_setting")
 
 licenses(["notice"])  # Apache 2.0
 
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]),
-    visibility = ["//python:__pkg__"],
-)
-
 # Filegroup of bzl files that can be used by downstream rules for documentation generation
 # Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
 filegroup(

--- a/python/runfiles/BUILD
+++ b/python/runfiles/BUILD
@@ -31,12 +31,6 @@
 
 load("//python:defs.bzl", "py_library")
 
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]),
-    visibility = ["//python:__pkg__"],
-)
-
 py_library(
     name = "runfiles",
     srcs = ["runfiles.py"],

--- a/third_party/github.com/bazelbuild/bazel-skylib/lib/BUILD
+++ b/third_party/github.com/bazelbuild/bazel-skylib/lib/BUILD
@@ -10,12 +10,6 @@ exports_files(
     visibility = ["//:__subpackages__"],
 )
 
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]),
-    visibility = ["//:__pkg__"],
-)
-
 bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],

--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/BUILD
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/BUILD
@@ -18,17 +18,6 @@ filegroup(
     ] + glob(["*.bzl"]),
 )
 
-# The files needed for distribution
-filegroup(
-    name = "distribution",
-    srcs = [
-        "BUILD",
-    ] + glob(["*.bzl"]),
-    visibility = [
-        "//:__pkg__",
-    ],
-)
-
 # export bzl files for the documentation
 exports_files(
     glob(["*.bzl"]),

--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/BUILD
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/BUILD
@@ -7,12 +7,3 @@ bzl_library(
     srcs = ["copy_file_private.bzl"],
     visibility = ["//third_party/github.com/bazelbuild/bazel-skylib/rules:__pkg__"],
 )
-
-# The files needed for distribution
-filegroup(
-    name = "distribution",
-    srcs = glob(["*"]),
-    visibility = [
-        "//:__subpackages__",
-    ],
-)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -22,12 +22,3 @@ py_binary(
     name = "wheelmaker",
     srcs = ["wheelmaker.py"],
 )
-
-filegroup(
-    name = "distribution",
-    srcs = [
-        "BUILD",
-        "wheelmaker.py",
-    ],
-    visibility = ["//:__pkg__"],
-)


### PR DESCRIPTION
Since https://github.com/bazelbuild/rules_python/pull/587 we just distribute the whole source archive from GitHub