### PR TITLE
Add Python 3.10.6

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -102,13 +102,24 @@ TOOL_VERSIONS = {
         },
         "strip_prefix": "python",
     },
+    "3.10.6": {
+        "url": "20220802/cpython-{python_version}+20220802-{platform}-{build}.tar.gz",
+        "sha256": {
+            "aarch64-apple-darwin": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7",
+            "aarch64-unknown-linux-gnu": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
+            "x86_64-apple-darwin": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c",
+            "x86_64-pc-windows-msvc": "91889a7dbdceea585ff4d3b7856a6bb8f8a4eca83a0ff52a73542c2e67220eaa",
+            "x86_64-unknown-linux-gnu": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
+        },
+        "strip_prefix": "python",
+    },
 }
 
 # buildifier: disable=unsorted-dict-items
 MINOR_MAPPING = {
     "3.8": "3.8.13",
     "3.9": "3.9.12",
-    "3.10": "3.10.4",
+    "3.10": "3.10.6",
 }
 
 PLATFORMS = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

The following tests were added automatically:

//python/tests/toolchains:python_3_10_6_aarch64-unknown-linux-gnu_test
//python/tests/toolchains:python_3_10_6_x86_64-apple-darwin_test
//python/tests/toolchains:python_3_10_6_x86_64-pc-windows-msvc_test
//python/tests/toolchains:python_3_10_6_x86_64-unknown-linux-gnu_test

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

Adds Python version 3.10.6 and updates 3.10 to reference 3.10.6 (from 3.10.4)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Python 3.10.6 isn't available in rules_python

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If a user references 3.10 this would update that user from 3.10.4 to 3.10.6, but I don't think that should be a breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

