### PR TITLE
feat(gazelle_python_manifest): provide a target with the given name

### DIFF
--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -89,3 +89,10 @@ def gazelle_python_manifest(
         },
         visibility = ["//visibility:private"],
     )
+
+    native.filegroup(
+        name = name,
+        srcs = [manifest],
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
Provides a somewhat useful target as the "default" target for the macro, that is, the target that is the actual name of the macro. 

Having this is incredibly useful when attempting to do static analysis of BUILD files to determine targets, but where those targets are macros and don't expand to a target with the given name it causes issues with any further bazel processing of that target (as it doesn't exist!). 

While there are workarounds, it seems sane and good practice to simply provide a target with that name.