### PR TITLE
Handle python/Python dir/file in repository archive

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -226,6 +226,11 @@ py_runtime_pair(
         python_path = python_bin,
         python_version = python_short_version,
     )
+    # On older macos versions there is a Python directory containing
+    # object files, which conflicts with a python symlink (macos is case
+    # insensitive). Therefore remove any file/directory from the archive
+    # before adding a python symlink.
+    rctx.delete("python")
     rctx.symlink(python_bin, "python")
     rctx.file(STANDALONE_INTERPRETER_FILENAME, "# File intentionally left blank. Indicates that this is an interpreter repo created by rules_python.")
     rctx.file("BUILD.bazel", build_content)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
For python 3.8.10 on macos there is a Python directory in the python static archive. This conflicts with the symlink added in #782. Note that bazel "incorrectly" caches the repository tests so they may not run if the test code itself didn't change even if the repository rules do.

Issue Number: N/A


## What is the new behavior?
Delete python directory/file before creating a symlink and tests pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

We should look to ensure that repository integration tests aren't incorrectly cached for the toolchain in CI.
