### PR TITLE
specify timeout for gazelle manifest test

### DIFF
--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -88,6 +88,7 @@ def gazelle_python_manifest(
             "_TEST_REQUIREMENTS": "$(rootpath {})".format(requirements),
         },
         visibility = ["//visibility:private"],
+        timeout = "short",
     )
 
     native.filegroup(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_python/issues/802

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

I think this doesn't apply here, but LMK if there's something you want me to do.

- [ ] Docs have been added / updated (for bug fixes / features)

Ditto

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Manifest test timeout is not set. Whatever it defaults to is too long, at least for my manifests, and bazel complains.

Issue Number: https://github.com/bazelbuild/rules_python/issues/802

## What is the new behavior?

manifest test timeout is set to "short"

## Does this PR introduce a breaking change?

In theory if someone's manifest test takes too long to run, this could break them.
In practice this seems very unlikely.
LMK if you want me to make this an option instead.

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

