### PR TITLE
ignore .pyc files in py_library() targets created in pip_install_dependencies()

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -92,7 +92,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "lib",
     srcs = glob(["**/*.py"]),
-    data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
+    data = glob(["**/*"], exclude=["**/*.py", "**/*.pyc", "**/* *", "BUILD", "WORKSPACE"]),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
     imports = ["."],


### PR DESCRIPTION
.pyc files are not hermetic and ruin hashes for remote-caching. Observed with pypi__pip and pypi__setuptools

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ X ] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `py_library()`ies created by `pip_install_requirements()` have checksums for `.pyc` files included. These files don't match from one install to the next, and because they are build inputs they guarantee a `remote-cache` miss.

I noticed this because the `requirements_test` target that's set up by `compile_pip_requirements()` is never a cache hit in my CI pipeline.

Running bazel with `--execution_log_json_file=` allowed me to debug. When run twice on the same machine with a remote-cache, even with a `bazel clean` in between still yields a cache hit.

But when running bazel on 2 different executors (docker containers), then diffing the runs yields only file hash changes:
```diff
--- exec1.json  2022-09-12 15:29:38.000000000 +0900
+++ exec1-1.json        2022-09-12 15:34:03.000000000 +0900
@@ -2343,21 +2343,21 @@
   }, {
     "path": "external/pypi__pip/pip/_internal/utils/__pycache__/compat.cpython-310.pyc",
     "digest": {
-      "hash": "72f8ee456dd18c7b6b370e7705c1f4a254b56e9291182cf40445e2be6fbd0ef5",
+      "hash": "6691abe643cd9e5aae626749720fa8c49d2b3bb3ed3e653e3a90378336b096ad",
       "sizeBytes": "1534",
       "hashFunctionName": "SHA-256"
     }
   }, {
     "path": "external/pypi__pip/pip/_internal/utils/__pycache__/compat.cpython-39.pyc",
     "digest": {
-      "hash": "d1933621a8710b6b017e6b8c6516e81bf5c99a5f22e2aaac45161f13e5b9a501",
+      "hash": "0078e3ce171c2162f656db8fe2b40bcfc27ae6d076f6194366ae85b027fd1603",
       "sizeBytes": "1535",
       "hashFunctionName": "SHA-256"
     }
   }, {
     "path": "external/pypi__pip/pip/_internal/utils/__pycache__/compatibility_tags.cpython-310.pyc",
     "digest": {
-      "hash": "6b7d2b0c22492c289a93fbc34e11fea1f4c8941916b314074e515af2f0063ace",
+      "hash": "7854acaf76bb430d0e57dcc878824114b5fcf1f44735c129bdcfc85298d82b0a",
       "sizeBytes": "4103",
       "hashFunctionName": "SHA-256"
     }
...
```

It seems to only include hashes from `pypi__pip` and `pypi__setuptools`.

## What is the new behavior?

With my patch applied, the remote-cache is a hit on differing CI executors when previously it was not.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

