### PR TITLE
bump: ubuntu version on CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,7 +19,7 @@ all_targets: &all_targets
     # Disabled due to https://github.com/bazelbuild/rules_python/issues/827
     - "-//python/tests/toolchains:python_3_8_10_x86_64-apple-darwin_test"
 platforms:
-  ubuntu1804:
+  ubuntu2004:
     <<: *all_targets
   macos:
     <<: *all_targets


### PR DESCRIPTION
I noticed that Ubuntu 18.04 on CI is running Python 3.6 in the host, which is EOL already. Since Ubuntu 22.04 is the current LTS, I judged that using the previous LTS (20.04 - still under support) is the best option.