### PR TITLE
Update `pip_install` to `pip_parse` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ target in the appropriate wheel repo.
 
 ### Installing third_party packages
 
-To add pip dependencies to your `WORKSPACE`, load the `pip_install` function, and call it to create the
+To add pip dependencies to your `WORKSPACE`, load the `pip_parse` function, and call it to create the
 central external repo and individual wheel external repos.
 
 


### PR DESCRIPTION
`pip_install` is deprecated and will be removed in a future release. The example has already been updated to `pip_parse`, but the caption has not been updated yet.