### PR TITLE
refactor: ci with multiple tasks

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,60 +3,148 @@ buildifier:
   version: latest
   # keep this argument in sync with .pre-commit-config.yaml
   warnings: "all"
-all_targets: &all_targets
+.reusable_config: &reusable_config
   build_targets:
+    - "--"
     - "..."
     # As a regression test for #225, check that wheel targets still build when
     # their package path is qualified with the repo name.
     - "@rules_python//examples/wheel/..."
+     # Gazelle is not fully Windows compatible: https://github.com/bazelbuild/bazel-gazelle/issues/1122
+    - "-//gazelle/..."
   build_flags:
-      - "--keep_going"
-  # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
-  skip_use_bazel_version_for_test: true
+    - "--keep_going"
   test_targets:
     - "--"
     - "..."
-platforms:
-  ubuntu2004:
-    <<: *all_targets
+    # Gazelle is not fully Windows compatible: https://github.com/bazelbuild/bazel-gazelle/issues/1122
+    - "-//gazelle/..."
+  test_flags:
+    - "--test_tag_filters=-integration-test"
+.reusable_build_test_all: &reusable_build_test_all
+  build_targets: ["..."]
+  test_targets: ["..."]
+tasks:
+  gazelle_extension:
+    name: Test the Gazelle extension
+    platform: ubuntu2004
+    build_targets: ["//gazelle/..."]
+    test_targets: ["//gazelle/..."]
+  linux:
+    <<: *reusable_config
+    name: Default test on Linux
+    platform: ubuntu2004
   macos:
-    <<: *all_targets
+    <<: *reusable_config
+    name: Default test on macOS
+    platform: macos
   windows:
-    build_targets:
-      - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
-      - "..."
-      # Gazelle is not fully Windows compatible: https://github.com/bazelbuild/bazel-gazelle/issues/1122
-      - "-//gazelle/..."
-      # As a regression test for #225, check that wheel targets still build when
-      # their package path is qualified with the repo name.
-      - "@rules_python//examples/wheel/..."
-      # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
-    skip_use_bazel_version_for_test: true
-    test_targets:
-      - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
-      - "..."
-      # Gazelle is not fully Windows compatible: https://github.com/bazelbuild/bazel-gazelle/issues/1122
-      - "-//gazelle/..."
-      # The dependencies needed for this test are not cross-platform: https://github.com/bazelbuild/rules_python/issues/260
-      - "-//tests:pip_repository_entry_points_example"
+    <<: *reusable_config
+    name: Default test on Windows
+    platform: windows
     test_flags:
-      - "--test_tag_filters=-fix-windows"
-  rbe_ubuntu1604:
-    build_targets:
-      - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
-      - "..."
-    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
-    skip_use_bazel_version_for_test: true
-    test_targets:
-      - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
-      - "..."
-      # TODO: The toolchain tests do not currently work in RBE
-      - "-//python/tests/toolchains/..."
-      # TODO: The integration tests do not currently work on RBE
-      # This list is the result of `bazel query 'filter(".*_example$", attr(generator_function, bazel_integration_test, //...))'`
-      - "-//examples:bzlmod_example"
-      - "-//examples:pip_install_example"
-      - "-//examples:pip_parse_example"
-      - "-//examples:pip_parse_vendored_example"
-      - "-//examples:pip_repository_annotations_example"
-      - "-//tests:pip_repository_entry_points_example"
+      - "--test_tag_filters=-integration-test,-fix-windows"
+  rbe:
+    <<: *reusable_config
+    name: Test on RBE
+    platform: rbe_ubuntu1604
+    test_flags:
+      - "--test_tag_filters=-integration-test,-acceptance-test"
+
+  integration_test_build_file_generation_linux:
+    <<: *reusable_build_test_all
+    name: build_file_generation integration tests on Linux
+    working_directory: examples/build_file_generation
+    platform: ubuntu2004
+  integration_test_build_file_generation_macos:
+    <<: *reusable_build_test_all
+    name: build_file_generation integration tests on macOS
+    working_directory: examples/build_file_generation
+    platform: macos
+  integration_test_build_file_generation_windows:
+    <<: *reusable_build_test_all
+    name: build_file_generation integration tests on Windows
+    working_directory: examples/build_file_generation
+    platform: windows
+
+  integration_test_bzlmod_linux:
+    <<: *reusable_build_test_all
+    name: bzlmod integration tests on Linux
+    working_directory: examples/bzlmod
+    platform: ubuntu2004
+  integration_test_bzlmod_macos:
+    <<: *reusable_build_test_all
+    name: bzlmod integration tests on macOS
+    working_directory: examples/bzlmod
+    platform: macos
+  integration_test_bzlmod_windows:
+    <<: *reusable_build_test_all
+    name: bzlmod integration tests on Windows
+    working_directory: examples/bzlmod
+    platform: windows
+
+  integration_test_pip_install_linux:
+    <<: *reusable_build_test_all
+    name: pip_install integration tests on Linux
+    working_directory: examples/pip_install
+    platform: ubuntu2004
+  integration_test_pip_install_macos:
+    <<: *reusable_build_test_all
+    name: pip_install integration tests on macOS
+    working_directory: examples/pip_install
+    platform: macos
+  integration_test_pip_install_windows:
+    <<: *reusable_build_test_all
+    name: pip_install integration tests on Windows
+    working_directory: examples/pip_install
+    platform: windows
+
+  integration_test_pip_parse_linux:
+    <<: *reusable_build_test_all
+    name: pip_parse integration tests on Linux
+    working_directory: examples/pip_parse
+    platform: ubuntu2004
+  integration_test_pip_parse_macos:
+    <<: *reusable_build_test_all
+    name: pip_parse integration tests on macOS
+    working_directory: examples/pip_parse
+    platform: macos
+  integration_test_pip_parse_windows:
+    <<: *reusable_build_test_all
+    name: pip_parse integration tests on Windows
+    working_directory: examples/pip_parse
+    platform: windows
+
+  integration_test_pip_parse_vendored_linux:
+    <<: *reusable_build_test_all
+    name: pip_parse_vendored integration tests on Linux
+    working_directory: examples/pip_parse_vendored
+    platform: ubuntu2004
+  integration_test_pip_parse_vendored_macos:
+    <<: *reusable_build_test_all
+    name: pip_parse_vendored integration tests on macOS
+    working_directory: examples/pip_parse_vendored
+    platform: macos
+  # TODO(f0rmiga): fix this test under Windows. It needs to be consistent on
+  # characters across all platforms.
+  # integration_test_pip_parse_vendored_windows:
+  #   <<: *reusable_build_test_all
+  #   name: pip_parse_vendored integration tests on Windows
+  #   working_directory: examples/pip_parse_vendored
+  #   platform: windows
+
+  integration_test_pip_repository_annotations_linux:
+    <<: *reusable_build_test_all
+    name: pip_repository_annotations integration tests on Linux
+    working_directory: examples/pip_repository_annotations
+    platform: ubuntu2004
+  integration_test_pip_repository_annotations_macos:
+    <<: *reusable_build_test_all
+    name: pip_repository_annotations integration tests on macOS
+    working_directory: examples/pip_repository_annotations
+    platform: macos
+  integration_test_pip_repository_annotations_windows:
+    <<: *reusable_build_test_all
+    name: pip_repository_annotations integration tests on Windows
+    working_directory: examples/pip_repository_annotations
+    platform: windows

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -20,24 +20,31 @@ licenses(["notice"])  # Apache 2.0
 bazel_integration_test(
     name = "pip_install_example",
     timeout = "long",
+    tags = ["integration-test"],
 )
 
 bazel_integration_test(
     name = "pip_parse_example",
     timeout = "long",
+    tags = ["integration-test"],
 )
 
 bazel_integration_test(
     name = "pip_parse_vendored_example",
     timeout = "long",
-    tags = ["fix-windows"],
+    tags = [
+        "fix-windows",
+        "integration-test",
+    ],
 )
 
 bazel_integration_test(
     name = "pip_repository_annotations_example",
     timeout = "long",
+    tags = ["integration-test"],
 )
 
 bazel_integration_test(
     name = "bzlmod_example",
+    tags = ["integration-test"],
 )

--- a/examples/build_file_generation/.bazelrc
+++ b/examples/build_file_generation/.bazelrc
@@ -1,0 +1,5 @@
+test --test_output=errors
+
+# Windows requires these for multi-python support:
+build --enable_runfiles
+startup --windows_enable_symlinks

--- a/examples/build_file_generation/WORKSPACE
+++ b/examples/build_file_generation/WORKSPACE
@@ -48,10 +48,19 @@ local_repository(
     path = "../..",
 )
 
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+python_register_toolchains(
+    name = "python39",
+    python_version = "3.9",
+)
+
+load("@python39//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
     name = "pip",
+    python_interpreter_target = interpreter,
     requirements_lock = "//:requirements_lock.txt",
 )
 

--- a/examples/build_file_generation/gazelle_python.yaml
+++ b/examples/build_file_generation/gazelle_python.yaml
@@ -129,4 +129,4 @@ manifest:
   pip_repository:
     name: pip
     incremental: true
-integrity: c47bf2ca0a185cf6b8815d4a61e26e7457564e931de76c70653277e4eccfadc8
+integrity: 4b3eed2cb51741419e11bd12a4533f285d059fda8029deaf6fedfe0fcda1b782

--- a/examples/pip_parse_vendored/.bazelrc
+++ b/examples/pip_parse_vendored/.bazelrc
@@ -1,0 +1,5 @@
+test --test_output=errors
+
+# Windows requires these for multi-python support:
+build --enable_runfiles
+startup --windows_enable_symlinks

--- a/python/tests/toolchains/defs.bzl
+++ b/python/tests/toolchains/defs.bzl
@@ -172,4 +172,5 @@ def acceptance_tests():
                 ),
                 python_version = python_version,
                 target_compatible_with = meta.compatible_with,
+                tags = ["acceptance-test"],
             )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,4 +7,5 @@ licenses(["notice"])  # Apache 2.0
 bazel_integration_test(
     name = "pip_repository_entry_points_example",
     timeout = "long",
+    tags = ["integration-test"],
 )

--- a/tests/pip_repository_entry_points/BUILD
+++ b/tests/pip_repository_entry_points/BUILD
@@ -28,6 +28,8 @@ py_test(
         "YAMLLINT_ENTRY_POINT": "$(rootpath {})".format(pip_parsed_yamllint),
     },
     main = "pip_repository_entry_points_test.py",
+    # The dependencies needed for this test are not cross-platform: https://github.com/bazelbuild/rules_python/issues/260
+    tags = ["fix-windows"],
     deps = ["@rules_python//python/runfiles"],
 )
 


### PR DESCRIPTION
Refactor CI to run examples as integration tests as separate tasks. This makes CI faster and improves the iteration experience when developing features multi-platform.