### PR TITLE
Add hrfuller as code owner for pip_parse

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 
 # Directory containing the Gazelle extension and Go code.
 /gazelle/ @f0rmiga
+
+# pip_parse related code
+/python/pip_install/ @hrfuller


### PR DESCRIPTION
In chat, @hrfuller said he was willing to be set as a code owner of it.

