### PR TITLE
fix: make conftest.py special with gazelle

### DIFF
--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -81,7 +81,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			hasPyBinary = true
 		} else if !hasPyTestFile && f == pyTestEntrypointFilename {
 			hasPyTestFile = true
-		} else if strings.HasSuffix(f, "_test.py") || (strings.HasPrefix(f, "test_") && ext == ".py") {
+		} else if f == "conftest.py" || strings.HasSuffix(f, "_test.py") || (strings.HasPrefix(f, "test_") && ext == ".py") {
 			pyTestFilenames.Add(f)
 		} else if ext == ".py" {
 			pyLibraryFilenames.Add(f)

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -26,6 +26,8 @@ const (
 	pyBinaryEntrypointFilename  = "__main__.py"
 	pyTestEntrypointFilename    = "__test__.py"
 	pyTestEntrypointTargetname  = "__test__"
+	conftestFilename            = "conftest.py"
+	conftestTargetname          = "conftest"
 )
 
 var (
@@ -71,6 +73,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	// be generated for this package or not.
 	hasPyTestFile := false
 	hasPyTestTarget := false
+	hasConftestFile := false
 
 	for _, f := range args.RegularFiles {
 		if cfg.IgnoresFile(filepath.Base(f)) {
@@ -81,7 +84,9 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			hasPyBinary = true
 		} else if !hasPyTestFile && f == pyTestEntrypointFilename {
 			hasPyTestFile = true
-		} else if f == "conftest.py" || strings.HasSuffix(f, "_test.py") || (strings.HasPrefix(f, "test_") && ext == ".py") {
+		} else if f == conftestFilename {
+			hasConftestFile = true
+		} else if strings.HasSuffix(f, "_test.py") || (strings.HasPrefix(f, "test_") && ext == ".py") {
 			pyTestFilenames.Add(f)
 		} else if ext == ".py" {
 			pyLibraryFilenames.Add(f)
@@ -196,10 +201,10 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 		pyLibraryTargetName := cfg.RenderLibraryName(packageName)
 
-		// Check if a target with the same name we are generating alredy exists,
-		// and if it is of a different kind from the one we are generating. If
-		// so, we have to throw an error since Gazelle won't generate it
-		// correctly.
+		// Check if a target with the same name we are generating already
+		// exists, and if it is of a different kind from the one we are
+		// generating. If so, we have to throw an error since Gazelle won't
+		// generate it correctly.
 		if args.File != nil {
 			for _, t := range args.File.Rules {
 				if t.Name() == pyLibraryTargetName && t.Kind() != pyLibraryKind {
@@ -233,10 +238,10 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 		pyBinaryTargetName := cfg.RenderBinaryName(packageName)
 
-		// Check if a target with the same name we are generating alredy exists,
-		// and if it is of a different kind from the one we are generating. If
-		// so, we have to throw an error since Gazelle won't generate it
-		// correctly.
+		// Check if a target with the same name we are generating already
+		// exists, and if it is of a different kind from the one we are
+		// generating. If so, we have to throw an error since Gazelle won't
+		// generate it correctly.
 		if args.File != nil {
 			for _, t := range args.File.Rules {
 				if t.Name() == pyBinaryTargetName && t.Kind() != pyBinaryKind {
@@ -267,6 +272,42 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		result.Imports = append(result.Imports, pyBinary.PrivateAttr(config.GazelleImportsKey))
 	}
 
+	var conftest *rule.Rule
+	if hasConftestFile {
+		deps, err := parser.parseSingle(conftestFilename)
+		if err != nil {
+			log.Fatalf("ERROR: %v\n", err)
+		}
+
+		// Check if a target with the same name we are generating already
+		// exists, and if it is of a different kind from the one we are
+		// generating. If so, we have to throw an error since Gazelle won't
+		// generate it correctly.
+		if args.File != nil {
+			for _, t := range args.File.Rules {
+				if t.Name() == conftestTargetname && t.Kind() != pyLibraryKind {
+					fqTarget := label.New("", args.Rel, conftestTargetname)
+					err := fmt.Errorf("failed to generate target %q of kind %q: "+
+						"a target of kind %q with the same name already exists.",
+						fqTarget.String(), pyLibraryKind, t.Kind())
+					collisionErrors.Add(err)
+				}
+			}
+		}
+
+		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel).
+			setUUID(uuid.Must(uuid.NewUUID()).String()).
+			addSrc(conftestFilename).
+			addModuleDependencies(deps).
+			addVisibility(visibility).
+			generateImportsAttribute()
+
+		conftest = conftestTarget.build()
+
+		result.Gen = append(result.Gen, conftest)
+		result.Imports = append(result.Imports, conftest.PrivateAttr(config.GazelleImportsKey))
+	}
+
 	if hasPyTestFile || hasPyTestTarget {
 		if hasPyTestFile {
 			// Only add the pyTestEntrypointFilename to the pyTestFilenames if
@@ -280,10 +321,10 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 		pyTestTargetName := cfg.RenderTestName(packageName)
 
-		// Check if a target with the same name we are generating alredy exists,
-		// and if it is of a different kind from the one we are generating. If
-		// so, we have to throw an error since Gazelle won't generate it
-		// correctly.
+		// Check if a target with the same name we are generating already
+		// exists, and if it is of a different kind from the one we are
+		// generating. If so, we have to throw an error since Gazelle won't
+		// generate it correctly.
 		if args.File != nil {
 			for _, t := range args.File.Rules {
 				if t.Name() == pyTestTargetName && t.Kind() != pyTestKind {
@@ -315,6 +356,10 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 		if pyLibrary != nil {
 			pyTestTarget.addModuleDependency(module{Name: pyLibrary.PrivateAttr(uuidKey).(string)})
+		}
+
+		if conftest != nil {
+			pyTestTarget.addModuleDependency(module{Name: conftest.PrivateAttr(uuidKey).(string)})
 		}
 
 		pyTest := pyTestTarget.build()

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -300,6 +300,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			addSrc(conftestFilename).
 			addModuleDependencies(deps).
 			addVisibility(visibility).
+			setTestonly().
 			generateImportsAttribute()
 
 		conftest = conftestTarget.build()

--- a/gazelle/target.go
+++ b/gazelle/target.go
@@ -22,6 +22,7 @@ type targetBuilder struct {
 	visibility        *treeset.Set
 	main              *string
 	imports           []string
+	testonly          bool
 }
 
 // newTargetBuilder constructs a new targetBuilder.
@@ -96,6 +97,12 @@ func (t *targetBuilder) setMain(main string) *targetBuilder {
 	return t
 }
 
+// setTestonly sets the testonly attribute to true.
+func (t *targetBuilder) setTestonly() *targetBuilder {
+	t.testonly = true
+	return t
+}
+
 // generateImportsAttribute generates the imports attribute.
 // These are a list of import directories to be added to the PYTHONPATH. In our
 // case, the value we add is on Bazel sub-packages to be able to perform imports
@@ -130,6 +137,9 @@ func (t *targetBuilder) build() *rule.Rule {
 	}
 	if !t.deps.Empty() {
 		r.SetPrivateAttr(config.GazelleImportsKey, t.deps)
+	}
+	if t.testonly {
+		r.SetAttr("testonly", "True")
 	}
 	r.SetPrivateAttr(resolvedDepsKey, t.resolvedDeps)
 	return r

--- a/gazelle/target.go
+++ b/gazelle/target.go
@@ -139,7 +139,7 @@ func (t *targetBuilder) build() *rule.Rule {
 		r.SetPrivateAttr(config.GazelleImportsKey, t.deps)
 	}
 	if t.testonly {
-		r.SetAttr("testonly", "True")
+		r.SetAttr("testonly", true)
 	}
 	r.SetPrivateAttr(resolvedDepsKey, t.resolvedDeps)
 	return r

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.in
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.in
@@ -1,6 +1,1 @@
 load("@rules_python//python:defs.bzl", "py_library")
-
-py_library(
-    name = "simple_test_with_conftest",
-    srcs = ["__init__.py"],
-)

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.in
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.in
@@ -1,0 +1,6 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "simple_test_with_conftest",
+    srcs = ["__init__.py"],
+)

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.out
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.out
@@ -11,6 +11,7 @@ py_library(
 
 py_library(
     name = "conftest",
+    testonly = "True",
     srcs = ["conftest.py"],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.out
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.out
@@ -11,7 +11,7 @@ py_library(
 
 py_library(
     name = "conftest",
-    testonly = "True",
+    testonly = True,
     srcs = ["conftest.py"],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.out
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.out
@@ -1,0 +1,20 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "simple_test_with_conftest",
+    srcs = [
+        "__init__.py",
+        "foo.py",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+py_test(
+    name = "simple_test_with_conftest_test",
+    srcs = [
+        "__test__.py",
+        "conftest.py",
+    ],
+    main = "__test__.py",
+    deps = [":simple_test_with_conftest"],
+)

--- a/gazelle/testdata/simple_test_with_conftest/BUILD.out
+++ b/gazelle/testdata/simple_test_with_conftest/BUILD.out
@@ -9,12 +9,18 @@ py_library(
     visibility = ["//:__subpackages__"],
 )
 
+py_library(
+    name = "conftest",
+    srcs = ["conftest.py"],
+    visibility = ["//:__subpackages__"],
+)
+
 py_test(
     name = "simple_test_with_conftest_test",
-    srcs = [
-        "__test__.py",
-        "conftest.py",
-    ],
+    srcs = ["__test__.py"],
     main = "__test__.py",
-    deps = [":simple_test_with_conftest"],
+    deps = [
+        ":conftest",
+        ":simple_test_with_conftest",
+    ],
 )

--- a/gazelle/testdata/simple_test_with_conftest/README.md
+++ b/gazelle/testdata/simple_test_with_conftest/README.md
@@ -1,0 +1,4 @@
+# Simple test with conftest.py
+
+This test case asserts that a simple `py_test` is generated as expected when a
+`conftest.py` is present.

--- a/gazelle/testdata/simple_test_with_conftest/WORKSPACE
+++ b/gazelle/testdata/simple_test_with_conftest/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/testdata/simple_test_with_conftest/__init__.py
+++ b/gazelle/testdata/simple_test_with_conftest/__init__.py
@@ -1,0 +1,3 @@
+from foo import foo
+
+_ = foo

--- a/gazelle/testdata/simple_test_with_conftest/__test__.py
+++ b/gazelle/testdata/simple_test_with_conftest/__test__.py
@@ -1,0 +1,12 @@
+import unittest
+
+from __init__ import foo
+
+
+class FooTest(unittest.TestCase):
+    def test_foo(self):
+        self.assertEqual("foo", foo())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gazelle/testdata/simple_test_with_conftest/foo.py
+++ b/gazelle/testdata/simple_test_with_conftest/foo.py
@@ -1,0 +1,2 @@
+def foo():
+    return "foo"

--- a/gazelle/testdata/simple_test_with_conftest/test.yaml
+++ b/gazelle/testdata/simple_test_with_conftest/test.yaml
@@ -1,0 +1,3 @@
+---
+expect:
+  exit_code: 0


### PR DESCRIPTION
`conftest.py` is a special file that should be used only with tests, so we create a `py_library` for it and add it as a dependency to `py_test`. By special-casing it, we take advantage of all the dependency resolution Gazelle offers. In contrast, when adding it to a `py_test` with `# keep` and excluding it from Gazelle, we also have to manage its dependencies manually.