### PR TITLE
fix(determinism): copy two missing entries from data_excludes

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -92,7 +92,17 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "lib",
     srcs = glob(["**/*.py"]),
-    data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
+    data = glob(["**/*"], exclude=[
+        # These entries include those put into user-installed dependencies by
+        # data_exclude in /python/pip_install/extract_wheels/bazel.py
+        # to avoid non-determinism following pip install's behavior.
+        "**/*.py",
+        "**/*.pyc",
+        "**/* *",
+        "**/*.dist-info/RECORD",
+        "BUILD",
+        "WORKSPACE",
+    ]),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
     imports = ["."],


### PR DESCRIPTION
We install some pip packages to bootstrap the pip_install/pip_parse rules, and these were allowing .pyc files as data deps. In some clients I observe that pip install is creating these with non-determinism and busting the python action caches. We already had a correct solution for user-installed packages, so we just need to include those entries for the built-ins.
