### PR TITLE
fix: missing RunEnvironmentInfo

### DIFF
--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -58,10 +58,10 @@ def _transition_py_impl(ctx):
             dependency_attributes = ["target"],
         ),
         target[OutputGroupInfo],
-        # testing.TestEnvironment is deprecated in favour of RunEnvironmentInfo but
+        # TODO(f0rmiga): testing.TestEnvironment is deprecated in favour of RunEnvironmentInfo but
         # RunEnvironmentInfo is not exposed in Bazel < 5.3.
         # https://github.com/bazelbuild/bazel/commit/dbdfa07e92f99497be9c14265611ad2920161483
-        (RunEnvironmentInfo if hasattr(native, "RunEnvironmentInfo") else testing.TestEnvironment)(environment = env),
+        testing.TestEnvironment(environment = env),
     ]
     return providers
 

--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -60,6 +60,7 @@ def _transition_py_impl(ctx):
         target[OutputGroupInfo],
         # TODO(f0rmiga): testing.TestEnvironment is deprecated in favour of RunEnvironmentInfo but
         # RunEnvironmentInfo is not exposed in Bazel < 5.3.
+        # https://github.com/bazelbuild/rules_python/issues/901
         # https://github.com/bazelbuild/bazel/commit/dbdfa07e92f99497be9c14265611ad2920161483
         testing.TestEnvironment(environment = env),
     ]


### PR DESCRIPTION
After we introduced multi-toolchain support, the release failed because `RunEnvironmentInfo` is only available on Bazel 5.3.0+ and there was a bug in how we checked for the existence of this provider. Apparently, there's no way to check for this provider, so I reverted to the deprecated `testing.TestEnvironment`. Once we are okay with not supporting Bazel < 5.3.0, we can move to `RunEnvironmentInfo`.