### PR TITLE
python_repository: Exclude pycache files

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -196,8 +196,20 @@ def _python_repository_impl(rctx):
 
     python_bin = "python.exe" if ("windows" in platform) else "bin/python3"
 
+    glob_include = []
+
+    if rctx.attr.ignore_root_user_error:
+        glob_include += [
+            "# These pycache files are created on first use of the associated python files.",
+            "# Exclude them from the glob because otherwise between the first time and second time a python toolchain is used,",
+            "# the definition of this filegroup will change, and depending rules will get invalidated.",
+            "# See https://github.com/bazelbuild/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them.",
+            "**/__pycache__/*.pyc",
+            "**/__pycache__/*.pyo",
+        ]
+
     if "windows" in platform:
-        glob_include = [
+        glob_include += [
             "*.exe",
             "*.dll",
             "bin/**",
@@ -210,7 +222,7 @@ def _python_repository_impl(rctx):
             "share/**",
         ]
     else:
-        glob_include = [
+        glob_include += [
             "bin/**",
             "extensions/**",
             "include/**",


### PR DESCRIPTION
After the first time the python_repository is used, files are created in
`__pycache__` directories. These invalidate the configured target for
the python_repository target, and cause spurious rebuilds.

Here's an example of the set of pycache files I've seen in one
repository.

```
lib/python3.8/distutils/__pycache__/__init__.cpython-38.pyc
lib/python3.8/distutils/__pycache__/archive_util.cpython-38.pyc
lib/python3.8/distutils/__pycache__/cmd.cpython-38.pyc
lib/python3.8/distutils/__pycache__/config.cpython-38.pyc
lib/python3.8/distutils/__pycache__/core.cpython-38.pyc
lib/python3.8/distutils/__pycache__/debug.cpython-38.pyc
lib/python3.8/distutils/__pycache__/dep_util.cpython-38.pyc
lib/python3.8/distutils/__pycache__/dir_util.cpython-38.pyc
lib/python3.8/distutils/__pycache__/dist.cpython-38.pyc
lib/python3.8/distutils/__pycache__/errors.cpython-38.pyc
lib/python3.8/distutils/__pycache__/extension.cpython-38.pyc
lib/python3.8/distutils/__pycache__/fancy_getopt.cpython-38.pyc
lib/python3.8/distutils/__pycache__/file_util.cpython-38.pyc
lib/python3.8/distutils/__pycache__/log.cpython-38.pyc
lib/python3.8/distutils/__pycache__/spawn.cpython-38.pyc
lib/python3.8/distutils/__pycache__/sysconfig.cpython-38.pyc
lib/python3.8/distutils/__pycache__/util.cpython-38.pyc
lib/python3.8/distutils/command/__pycache__/__init__.cpython-38.pyc
lib/python3.8/distutils/command/__pycache__/build.cpython-38.pyc
lib/python3.8/distutils/command/__pycache__/install.cpython-38.pyc
lib/python3.8/email/__pycache__/_header_value_parser.cpython-38.pyc
lib/python3.8/email/__pycache__/contentmanager.cpython-38.pyc
lib/python3.8/email/__pycache__/headerregistry.cpython-38.pyc
lib/python3.8/email/__pycache__/policy.cpython-38.pyc
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
If you cquery twice in a row, you get different output, because extra files were created in the repository by the first cquery invocation.

Issue Number: N/A


## What is the new behavior?
The consecutive cqueries now produce identical results.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No