### PR TITLE
fix: gazelle panics when "# gazelle:ignore" doesn't have a value

### DIFF
--- a/gazelle/parser.go
+++ b/gazelle/parser.go
@@ -206,7 +206,7 @@ func (c *comment) asAnnotation() (*annotation, error) {
 	withoutPrefix := strings.TrimPrefix(uncomment, annotationPrefix)
 	annotationParts := strings.SplitN(withoutPrefix, " ", 2)
 	if len(annotationParts) < 2 {
-		return nil, fmt.Errorf("`%s` is not valid annotation", *c)
+		return nil, fmt.Errorf("`%s` requires a value", *c)
 	}
 	return &annotation{
 		kind:  annotationKind(annotationParts[0]),

--- a/gazelle/parser.go
+++ b/gazelle/parser.go
@@ -128,7 +128,10 @@ func (p *python3Parser) parse(pyFilenames *treeset.Set) (*treeset.Set, error) {
 	}
 
 	for _, res := range allRes {
-		annotations := annotationsFromComments(res.Comments)
+		annotations, err := annotationsFromComments(res.Comments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse annotations: %w", err)
+		}
 
 		for _, m := range res.Modules {
 			// Check for ignored dependencies set via an annotation to the Python
@@ -195,20 +198,20 @@ type comment string
 
 // asAnnotation returns an annotation object if the comment has the
 // annotationPrefix.
-func (c *comment) asAnnotation() *annotation {
+func (c *comment) asAnnotation() (*annotation, error) {
 	uncomment := strings.TrimLeft(string(*c), "# ")
 	if !strings.HasPrefix(uncomment, annotationPrefix) {
-		return nil
+		return nil, nil
 	}
 	withoutPrefix := strings.TrimPrefix(uncomment, annotationPrefix)
 	annotationParts := strings.SplitN(withoutPrefix, " ", 2)
 	if len(annotationParts) < 2 {
-		return nil
+		return nil, fmt.Errorf("`%s` is not valid annotation", *c)
 	}
 	return &annotation{
 		kind:  annotationKind(annotationParts[0]),
 		value: annotationParts[1],
-	}
+	}, nil
 }
 
 // annotation represents a single Gazelle annotation parsed from a Python
@@ -227,10 +230,13 @@ type annotations struct {
 
 // annotationsFromComments returns all the annotations parsed out of the
 // comments of a Python module.
-func annotationsFromComments(comments []comment) *annotations {
+func annotationsFromComments(comments []comment) (*annotations, error) {
 	ignore := make(map[string]struct{})
 	for _, comment := range comments {
-		annotation := comment.asAnnotation()
+		annotation, err := comment.asAnnotation()
+		if err != nil {
+			return nil, err
+		}
 		if annotation != nil {
 			if annotation.kind == annotationKindIgnore {
 				modules := strings.Split(annotation.value, ",")
@@ -246,7 +252,7 @@ func annotationsFromComments(comments []comment) *annotations {
 	}
 	return &annotations{
 		ignore: ignore,
-	}
+	}, nil
 }
 
 // ignored returns true if the given module was ignored via the ignore

--- a/gazelle/parser.go
+++ b/gazelle/parser.go
@@ -202,6 +202,9 @@ func (c *comment) asAnnotation() *annotation {
 	}
 	withoutPrefix := strings.TrimPrefix(uncomment, annotationPrefix)
 	annotationParts := strings.SplitN(withoutPrefix, " ", 2)
+	if len(annotationParts) < 2 {
+		return nil
+	}
 	return &annotation{
 		kind:  annotationKind(annotationParts[0]),
 		value: annotationParts[1],

--- a/gazelle/testdata/ignored_invalid_imported_module/__init__.py
+++ b/gazelle/testdata/ignored_invalid_imported_module/__init__.py
@@ -1,5 +1,6 @@
 # gazelle:ignore abcdefg1,abcdefg2
 # gazelle:ignore abcdefg3
+# gazelle:ignore
 
 import abcdefg1
 import abcdefg2

--- a/gazelle/testdata/ignored_invalid_imported_module/__init__.py
+++ b/gazelle/testdata/ignored_invalid_imported_module/__init__.py
@@ -1,6 +1,5 @@
 # gazelle:ignore abcdefg1,abcdefg2
 # gazelle:ignore abcdefg3
-# gazelle:ignore
 
 import abcdefg1
 import abcdefg2

--- a/gazelle/testdata/invalid_annotation/README.md
+++ b/gazelle/testdata/invalid_annotation/README.md
@@ -1,0 +1,2 @@
+# Invalid  annotation
+This test case asserts that the parse step fails as expected due to invalid annotation format.

--- a/gazelle/testdata/invalid_annotation/WORKSPACE
+++ b/gazelle/testdata/invalid_annotation/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/testdata/invalid_annotation/__init__.py
+++ b/gazelle/testdata/invalid_annotation/__init__.py
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/gazelle/testdata/invalid_annotation/test.yaml
+++ b/gazelle/testdata/invalid_annotation/test.yaml
@@ -1,0 +1,5 @@
+---
+expect:
+  exit_code: 1
+  stderr: |
+    gazelle: ERROR: failed to parse annotations: `# gazelle:ignore` is not valid annotation

--- a/gazelle/testdata/invalid_annotation/test.yaml
+++ b/gazelle/testdata/invalid_annotation/test.yaml
@@ -2,4 +2,4 @@
 expect:
   exit_code: 1
   stderr: |
-    gazelle: ERROR: failed to parse annotations: `# gazelle:ignore` is not valid annotation
+    gazelle: ERROR: failed to parse annotations: `# gazelle:ignore` requires a value


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If `# gazelle:ignore` line exists  gazelle panics. 

commit hash  6434e34fb0b7f527d3f4451b702086a2d396b021 (added new test line)
//gazelle:gazelle_test failes 
```go

exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //gazelle:gazelle_test
-----------------------------------------------------------------------------
--- FAIL: TestGazelleBinary (12.00s)
    --- FAIL: TestGazelleBinary/ignored_invalid_imported_module (0.38s)
        python_test.go:188: expected gazelle exit code: 0
            got: 2
        python_test.go:188: expected gazelle stderr: 
            got: panic: runtime error: index out of range [1] with length 1
            
            goroutine 1 [running]:
            github.com/bazelbuild/rules_python/gazelle.(*comment).asAnnotation(0x1004293c0?)
            	gazelle/parser.go:207 +0x13c
            github.com/bazelbuild/rules_python/gazelle.annotationsFromComments({0x14000031040, 0x4, 0x1f8?})
            	gazelle/parser.go:230 +0xac
            github.com/bazelbuild/rules_python/gazelle.(*python3Parser).parse(0x140001c6338, 0x14000010130)
            	gazelle/parser.go:131 +0x5a4
            github.com/bazelbuild/rules_python/gazelle.(*Python).GenerateRules(0x0?, {0x14000142370, {0x1400007a690, 0x6f}, {0x0, 0x0}, 0x140001a26e0, {0x0, 0x0, 0x0}, ...})
            	gazelle/generate.go:197 +0x68c
            main.runFixUpdate.func1({0x1400007a690, 0x6f}, {0x0, 0x0}, 0x14000142370, 0x0?, 0x140001a26e0, {0x0, 0x0, 0x0}, ...)
            	external/bazel_gazelle/cmd/gazelle/fix-update.go:298 +0xc88
            github.com/bazelbuild/bazel-gazelle/walk.Walk.func1(0x14000142370, {0x1400007a690, 0x6f}, {0x0, 0x0}, 0x0)
            	external/bazel_gazelle/walk/walk.go:179 +0x3ec
            github.com/bazelbuild/bazel-gazelle/walk.Walk(0x14000142370, {0x1400007e730?, 0x5, 0x5}, {0x140000694f0, 0x1, 0x1}, 0x0, 0x1400015f588)
            	external/bazel_gazelle/walk/walk.go:182 +0x190
            main.runFixUpdate({0x1400001e084, 0x6f}, 0x16fd42c0c?, {0x14000012050, 0x1, 0x1})
            	external/bazel_gazelle/cmd/gazelle/fix-update.go:275 +0x580
            main.run({0x1400001e084?, 0x6f?}, {0x14000012050?, 0x1?, 0x1?})
            	external/bazel_gazelle/cmd/gazelle/gazelle.go:95 +0x230
            main.main()
            	external/bazel_gazelle/cmd/gazelle/gazelle.go:72 +0xe4
            
        python_test.go:142: "" exists
        python_test.go:142: "/ignored_invalid_imported_module" exists
        python_test.go:142: "/ignored_invalid_imported_module/BUILD" exists
        python_test.go:142: "/ignored_invalid_imported_module/README.md" exists
        python_test.go:142: "/ignored_invalid_imported_module/WORKSPACE" exists
        python_test.go:142: "/ignored_invalid_imported_module/__init__.py" exists
        python_test.go:142: "/ignored_invalid_imported_module/gazelle_python.yaml" exists
        python_test.go:142: "/ignored_invalid_imported_module/test.yaml" exists
FAIL


```

## What is the new behavior?

Ignores erorr. This is similar behavior if module name is invalid.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

