### PR TITLE
fix: don't test on release

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,8 +1,0 @@
-# Bazel settings to apply on CI only
-# Included with a --bazelrc option in the call to bazel
-build --announce_rc
-test --test_output=errors
-build --disk_cache=$HOME/.cache/bazel
-build --repository_cache=$HOME/.cache/bazel-repo
-# For bazel-in-bazel testing
-test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: bazel test //...
-        env:
-          # Bazelisk will download bazel to here
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
       - name: Prepare workspace snippet
         run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release


### PR DESCRIPTION
The tags that are released already have a more comprehensive test run attached to them, so we don't need to spend a lot of time re-testing on GitHub Actions during release.