### PR TITLE
Fix misleading error message

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -60,11 +60,11 @@ def _resolve_python_interpreter(rctx):
     if rctx.attr.python_interpreter_target != None:
         target = rctx.attr.python_interpreter_target
         python_interpreter = rctx.path(target)
-    else:
-        if "/" not in python_interpreter:
-            python_interpreter = rctx.which(python_interpreter)
-        if not python_interpreter:
+    elif "/" not in python_interpreter:
+        found_python_interpreter = rctx.which(python_interpreter)
+        if not found_python_interpreter:
             fail("python interpreter `{}` not found in PATH".format(python_interpreter))
+        python_interpreter = found_python_interpreter
     return python_interpreter
 
 def _get_xcode_location_cflags(rctx):


### PR DESCRIPTION
When `rctx.which` can not find a program for the specified name, it returns `None`.
We should not override the original `python_interpreter` in this case, otherwise we'll see a misleading error message like ``Error in fail: python interpreter `None` not found in PATH``

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

