### PR TITLE
Entrypoint script generation bug fix

### DIFF
--- a/python/pip_install/extract_wheels/bazel.py
+++ b/python/pip_install/extract_wheels/bazel.py
@@ -33,11 +33,11 @@ def generate_entry_point_contents(
         """\
         {shebang}
         import sys
-        from {module} import {attribute}
+        from {module} import {attribute_import}
         if __name__ == "__main__":
             sys.exit({attribute}())
         """.format(
-            shebang=shebang, module=module, attribute=attribute
+            shebang=shebang, module=module, attribute=attribute, attribute_import = attribute.split(".")[0]
         )
     )
 


### PR DESCRIPTION
Some entrypoints can be weird, calling a method of an imported class rather than directly calling a function.

In the case of `invoke`, having [this entrypoint](https://github.com/pyinvoke/invoke/blob/8f6c0617c7dc59b105dd1b92fb417e75adc21bea/setup.py#L51), the generated file had a line saying `from invoke.main import program.run`, which raises a syntax error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

A syntax error comes up if an entrypoint is a method of a class.


## What is the new behavior?

No more syntax error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

