### PR TITLE
Disable bytecode optimization during wheel installation

### DIFF
--- a/python/pip_install/extract_wheels/wheel.py
+++ b/python/pip_install/extract_wheels/wheel.py
@@ -84,6 +84,7 @@ class Wheel:
             interpreter="/dev/null",
             script_kind="posix",
             destdir=directory,
+            bytecode_levels=[],
         )
 
         with installer.sources.WheelFile.open(self.path) as wheel_source:

--- a/python/pip_install/extract_wheels/wheel.py
+++ b/python/pip_install/extract_wheels/wheel.py
@@ -84,7 +84,7 @@ class Wheel:
             interpreter="/dev/null",
             script_kind="posix",
             destdir=directory,
-            bytecode_levels=[],
+            bytecode_optimization_levels=[],
         )
 
         with installer.sources.WheelFile.open(self.path) as wheel_source:


### PR DESCRIPTION
Disables bytecode optimization when wheels are installed.

I've noticed some occasional failures in CI, which involve `__pycache__`. I believe this could be coming from bytecode compilation of third-party wheels. I think disabling this behaviour until there is a better understanding of the desired behaviour is a good idea.

The `installer` library is able to compile bytecode upon installation. https://buildkite.com/bazel/rules-python-python/builds/3864#01854d9d-9c71-4587-a8f4-86e6718c38e7 By default, level 0 is used (generates .pyc).