### PR TITLE
Add cross-link to pip vendoring example in the docs

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -252,7 +252,7 @@ To do this, use the "write to source file" pattern documented in
 https://blog.aspect.dev/bazel-can-write-to-the-source-folder
 to put a copy of the generated requirements.bzl into your project.
 Then load the requirements.bzl file directly rather than from the generated repository.
-See the example in rules_python/examples/pip_parse_vendored.
+See the example in [rules_python/examples/pip_parse_vendored](../examples/pip_parse_vendored).
 
 
 **PARAMETERS**


### PR DESCRIPTION
Tiny docs ux touchup, found while reading https://blog.aspect.dev/avoid-eager-fetches :)