### PR TITLE
Don’t use keyword argument for TestEnvironment.

### DIFF
--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -62,7 +62,7 @@ def _transition_py_impl(ctx):
         # RunEnvironmentInfo is not exposed in Bazel < 5.3.
         # https://github.com/bazelbuild/rules_python/issues/901
         # https://github.com/bazelbuild/bazel/commit/dbdfa07e92f99497be9c14265611ad2920161483
-        testing.TestEnvironment(environment = env),
+        testing.TestEnvironment(env),
     ]
     return providers
 


### PR DESCRIPTION
This was only introduced very
recently (https://github.com/bazelbuild/bazel/pull/14849/commits/98b064bddc80da95e46df7cd2ec7073108e62946#diff-be59c30c90e1bc4760029739db3469d256d7784e7e7335bf3180fde39b0bcd5b) and isn’t available in most Bazel versions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When building a `py_binary` target that comes from a hermetic toolchain (as described in https://github.com/bazelbuild/rules_python#toolchain-registration) under e.g. Bazel 5.1, the build will fail with an error such as

```
ERROR: […]/BUILD:51:10: in _transition_py_binary rule //[…]: 
Traceback (most recent call last):
	File "[…]/external/rules_python/python/config_settings/transition.bzl", line 65, column 32, in _transition_py_impl
		testing.TestEnvironment(environment = env),
Error in TestEnvironment: TestEnvironment() got named argument for positional-only parameter 'environment'
```

Issue Number: N/A


## What is the new behavior?

I haven't tested the change, but it seems trivial enough.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

