### PR TITLE
Fix hyphen in requirement didn't work with bzlmod (#952)

### DIFF
--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -16,6 +16,7 @@ py_library(
     deps = [
         requirement("pylint"),
         requirement("tabulate"),
+        requirement("python-dateutil"),
     ],
 )
 

--- a/examples/bzlmod/requirements.in
+++ b/examples/bzlmod/requirements.in
@@ -3,3 +3,4 @@ s3cmd~=2.1.0
 yamllint>=1.28.0
 tabulate~=0.9.0
 pylint~=2.15.5
+python-dateutil>=2.8.2

--- a/examples/bzlmod/requirements_lock.txt
+++ b/examples/bzlmod/requirements_lock.txt
@@ -68,7 +68,9 @@ pylint==2.15.9 \
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-    # via s3cmd
+    # via
+    #   -r ./requirements.in
+    #   s3cmd
 python-magic==0.4.27 \
     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b \
     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3

--- a/examples/bzlmod/requirements_windows.txt
+++ b/examples/bzlmod/requirements_windows.txt
@@ -72,7 +72,9 @@ pylint==2.15.9 \
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-    # via s3cmd
+    # via
+    #   -r ./requirements.in
+    #   s3cmd
 python-magic==0.4.27 \
     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b \
     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -287,7 +287,11 @@ alias(
     name = "{name}_dist_info",
     actual = "@{repo_prefix}{dep}//:dist_info",
 )
-""".format(name = _clean_pkg_name(requirement[0]), repo_prefix = rctx.attr.repo_prefix, dep = requirement[0])
+""".format(
+            name = _clean_pkg_name(requirement[0]),
+            repo_prefix = rctx.attr.repo_prefix,
+            dep = _clean_pkg_name(requirement[0]),
+        )
 
     return build_content
 


### PR DESCRIPTION
This fixes a issue with the repository generation function where it was missing a _clean_pkg_name() for the second reference to the requirement name.

Fixes #952

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #952 

`requirement("dependency")` didn't work if the dependency had any number of hyphens in its name (for example `requirement("google-cloud-storage")`  did not work in a BUILD.bazel file.

The error encountered was, for example:
```
bazel:106:6: no such package '@[unknown repo 'pip_typing-extensions' requested from 
@rules_python~0.16.1~pip~pip]//': The repository '@[unknown repo 'pip_python-dateutil' requested from 
@rules_python~0.16.1~pip~pip]' could not be resolved: No repository visible 
as '@pip_python-dateutil' from repository '@rules_python~0.16.1~pip~pip' and referenced by 
'@rules_python~0.16.1~pip~pip//:python_dateutil_pkg'
```

## What is the new behavior?

`requirement("dependency")` now works with hyphens in the name.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

