### PR TITLE
Use 'os' instead of 'ioutil' in gazelle tests

### DIFF
--- a/gazelle/manifest/manifest_test.go
+++ b/gazelle/manifest/manifest_test.go
@@ -2,7 +2,6 @@ package manifest_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -44,7 +43,7 @@ func TestFile(t *testing.T) {
 			log.Println(err)
 			t.FailNow()
 		}
-		expected, err := ioutil.ReadFile("testdata/gazelle_python.yaml")
+		expected, err := os.ReadFile("testdata/gazelle_python.yaml")
 		if err != nil {
 			log.Println(err)
 			t.FailNow()

--- a/gazelle/python_test.go
+++ b/gazelle/python_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,9 +93,9 @@ func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 				continue
 			}
 
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
-				t.Errorf("ioutil.ReadFile(%q) error: %v", path, err)
+				t.Errorf("os.ReadFile(%q) error: %v", path, err)
 			}
 
 			if filepath.Base(shortPath) == "test.yaml" {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

We are currently using `ioutil.ReadFile` in `gazelle` tests even though it has been deprecated since `1.16` as per [official docs](https://golang.google.cn/pkg/io/ioutil/#ReadFile).

## What is the new behavior?

Use `os.ReadFile` instead as the package suggests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

