### PR TITLE
feat: allow absolute urls in `tool_versions`

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -275,7 +275,10 @@ def get_release_info(platform, python_version, base_url = DEFAULT_RELEASE_BASE_U
         python_version = python_version,
         build = "shared-install_only" if (WINDOWS_NAME in platform) else "install_only",
     )
-    url = "/".join([base_url, release_filename])
+    if "://" in release_filename:  # is absolute url?
+        url = release_filename
+    else:
+        url = "/".join([base_url, release_filename])
 
     patches = tool_versions[python_version].get("patches", [])
     if type(patches) == type({}):


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
> could not find any to adapt / not sure how/where to introduce them
- [ ] Docs have been added / updated (for bug fixes / features)
> did not find relevant docs


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature (please, look at the "Scope of the project" section in the README.md file)


## What is the current behavior?

`python_register_toolchains()` allows to pass in `tool_version`. But the given `url` are appended to the `base_url` even if they are already an absolute `url`. 

Issue Number: N/A


## What is the new behavior?

With the new behavior, a user can load `TOOL_VERSIONS` from `@rules_python` and extend the dictionary with custom versions  pulled from custom locations while still using the defaults `@rules_python` provides. More importantly, this allows to pull artifacts for different python versions from different hosts.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

