### PR TITLE
fix: allow omitting the `strip_prefix` in `tool_versions`

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -313,7 +313,6 @@ python_repository = repository_rule(
         ),
         "strip_prefix": attr.string(
             doc = "A directory prefix to strip from the extracted files.",
-            mandatory = True,
         ),
         "url": attr.string(
             doc = "The URL of the interpreter to download",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?


- [x] Bugfix

## What is the current behavior?

Currently `bazel` will error out if one does not specify a `strip_prefix` in a custom `tool_versions` dict. But if a user retrieves interpreter archives from another source, the `strip_prefix` might not be necessary.

A workaround is `'strip_prefix': ''`.

Issue Number: N/A


## What is the new behavior?

Omitting the `strip_prefix` in `tool_versions` is allowed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No