### PR TITLE
fix: windows `*.lib` interface in `python_headers`

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -246,6 +246,12 @@ filegroup(
     ),
 )
 
+cc_import(
+    name = "interface",
+    interface_library = "libs/python{python_version_nodot}.lib",
+    system_provided = True,
+)
+
 filegroup(
     name = "includes",
     srcs = glob(["include/**/*.h"]),
@@ -253,6 +259,10 @@ filegroup(
 
 cc_library(
     name = "python_headers",
+    deps = select({{
+        "@bazel_tools//src/conditions:windows": [":interface"],
+        "//conditions:default": None,
+    }}),
     hdrs = [":includes"],
     includes = [
         "include",


### PR DESCRIPTION
A user might use `python_headers` to build an extension module that does not itself pull in the python shared library. On Windows, this needs to expose the `*.lib` interface file to compile correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?

Currently a user on Windows can not compile a native extension module and build against `python_headers`.

Issue Number: N/A


## What is the new behavior?

It is fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
