### PR TITLE
runfiles: Fix usage instructions

### DIFF
--- a/python/runfiles/runfiles.py
+++ b/python/runfiles/runfiles.py
@@ -27,12 +27,12 @@ USAGE:
       py_binary(
           name = "my_binary",
           ...
-          deps = ["@bazel_tools//tools/python/runfiles"],
+          deps = ["@rules_python//python/runfiles"],
       )
 
 2.  Import the runfiles library.
 
-      from bazel_tools.tools.python.runfiles import runfiles
+      from python.runfiles import runfiles
 
 3.  Create a Runfiles object and use rlocation to look up runfile paths:
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Docs reference `bazel_tools` and import instructions fail with Bzlmod.

## What is the new behavior?

The canonical location for the runfiles library going forward will be the rules_python repo, so users should load from it. Since repository names are essentially dynamic with Bzlmod, they should not be used in import statements.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

