### PR TITLE
runfiles: Drop outdated comments about vendoring

### DIFF
--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -12,23 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We'd like to alias the runfiles target @bazel_tools//tools/python/runfiles.
-# However, we need its source file to exist in the runfiles tree under this
-# repo's name, so that it can be imported as
-#
-#     from rules_python.python.runfiles import runfiles
-#
-# in user code. This requires either adding a symlink to runfiles or copying
-# the file with an action.
-#
-# Both solutions are made more difficult by the fact that runfiles.py is not
-# directly exported by its package. We could try to get a handle on its File
-# object by unpacking the runfiles target's providers, but this seems hacky
-# and is probably more effort than it's worth. Also, it's not trivial to copy
-# files in a cross-platform (i.e. Windows-friendly) way.
-#
-# So instead, we just vendor in runfiles.py here.
-
 load("//python:defs.bzl", "py_library")
 
 filegroup(

--- a/python/runfiles/runfiles.py
+++ b/python/runfiles/runfiles.py
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-###############################################################################
-# Vendored in from bazelbuild/bazel (tools/python/runfiles/runfiles.py) at    #
-# commit 6c60a8ec049b6b8540c473969dd7bd1dad46acb9 (2019-07-19). See           #
-# //python/runfiles:BUILD for details.                                        #
-###############################################################################
-
 """Runfiles lookup library for Bazel-built Python binaries and tests.
 
 USAGE:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Comments about the runfiles library being vendored from bazel_tools and canonically living there instead of in rules_python.

## What is the new behavior?

The runfiles library now canonically lives in rules_python and has been updated multiple times since its original import from bazel_tools.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

