### PR TITLE
runfiles: Apply repo mapping to Rlocation path

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -29,7 +29,7 @@ pip.parse(
 )
 use_repo(pip, "pip")
 
-bazel_dep(name = "other_module", version = "")
+bazel_dep(name = "other_module", version = "", repo_name = "our_other_module")
 local_path_override(
     module_name = "other_module",
     path = "other_module",

--- a/examples/bzlmod/other_module/other_module/pkg/lib.py
+++ b/examples/bzlmod/other_module/other_module/pkg/lib.py
@@ -7,3 +7,7 @@ def GetRunfilePathWithCurrentRepository():
     # For a non-main repository, the name of the runfiles directory is equal to
     # the canonical repository name.
     return r.Rlocation(own_repo + "/other_module/pkg/data/data.txt")
+
+
+def GetRunfilePathWithRepoMapping():
+    return runfiles.Create().Rlocation("other_module/other_module/pkg/data/data.txt")

--- a/examples/bzlmod/runfiles/BUILD.bazel
+++ b/examples/bzlmod/runfiles/BUILD.bazel
@@ -5,14 +5,14 @@ py_test(
     srcs = ["runfiles_test.py"],
     data = [
         "data/data.txt",
-        "@other_module//other_module/pkg:data/data.txt",
+        "@our_other_module//other_module/pkg:data/data.txt",
     ],
     env = {
         "DATA_RLOCATIONPATH": "$(rlocationpath data/data.txt)",
-        "OTHER_MODULE_DATA_RLOCATIONPATH": "$(rlocationpath @other_module//other_module/pkg:data/data.txt)",
+        "OTHER_MODULE_DATA_RLOCATIONPATH": "$(rlocationpath @our_other_module//other_module/pkg:data/data.txt)",
     },
     deps = [
-        "@other_module//other_module/pkg:lib",
+        "@our_other_module//other_module/pkg:lib",
         "@rules_python//python/runfiles",
     ],
 )

--- a/examples/bzlmod/runfiles/runfiles_test.py
+++ b/examples/bzlmod/runfiles/runfiles_test.py
@@ -11,11 +11,28 @@ class RunfilesTest(unittest.TestCase):
     def testCurrentRepository(self):
         self.assertEqual(runfiles.Create().CurrentRepository(), "")
 
+    def testRunfilesWithRepoMapping(self):
+        data_path = runfiles.Create().Rlocation("example_bzlmod/runfiles/data/data.txt")
+        with open(data_path) as f:
+            self.assertEqual(f.read().strip(), "Hello, example_bzlmod!")
+
     def testRunfileWithRlocationpath(self):
         data_rlocationpath = os.getenv("DATA_RLOCATIONPATH")
         data_path = runfiles.Create().Rlocation(data_rlocationpath)
         with open(data_path) as f:
             self.assertEqual(f.read().strip(), "Hello, example_bzlmod!")
+
+    def testRunfileInOtherModuleWithOurRepoMapping(self):
+        data_path = runfiles.Create().Rlocation(
+            "our_other_module/other_module/pkg/data/data.txt"
+        )
+        with open(data_path) as f:
+            self.assertEqual(f.read().strip(), "Hello, other_module!")
+
+    def testRunfileInOtherModuleWithItsRepoMapping(self):
+        data_path = lib.GetRunfilePathWithRepoMapping()
+        with open(data_path) as f:
+            self.assertEqual(f.read().strip(), "Hello, other_module!")
 
     def testRunfileInOtherModuleWithCurrentRepository(self):
         data_path = lib.GetRunfilePathWithCurrentRepository()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Python runfiles library fails to find runfiles specified with apparent repository names when Bzlmod is enabled.

## What is the new behavior?

When a repo mapping manifest is available in runfiles, it is parsed and used to map apparent repository names to canonical ones in paths passed to Rlocation. The current repository, which is required to know which part of the mapping to apply, is either determined using `CurrentRepository` or can be passed in explicitly.

With this commit, runfiles lookups should succeed with Bzlmod without code changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

