### PR TITLE
Redirect stdout when checking imports.

### DIFF
--- a/gazelle/std_modules.go
+++ b/gazelle/std_modules.go
@@ -37,8 +37,8 @@ func init() {
 	cmd := exec.CommandContext(ctx, stdModulesScriptRunfile)
 
 	cmd.Stderr = os.Stderr
-	cmd.Env = []string{}
-
+	// All userland site-packages should be ignored.
+	cmd.Env = []string{"PYTHONNOUSERSITE=1"}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Printf("failed to initialize std_modules: %v\n", err)


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_python/issues/1006

Also, set PYTHONNOUSERSITE so that the script doesn't even look in site packages when checking modules.

Fix typo with capitilize.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1006 


## What is the new behavior?
```echo "pygame" | bazel run //gazelle:std_modules
false
```
No extraneous output.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

