### PR TITLE
Fix requirement parser

### DIFF
--- a/python/pip_install/private/test/requirements_parser_tests.bzl
+++ b/python/pip_install/private/test/requirements_parser_tests.bzl
@@ -60,16 +60,16 @@ certifi==2021.10.8 \
 
     # Options
     asserts.equals(env, ["--pre"], parse("--pre\n").options)
-    asserts.equals(env, ["--find-links /my/local/archives"], parse("--find-links /my/local/archives\n").options)
-    asserts.equals(env, ["--pre", "--find-links /my/local/archives"], parse("""\
+    asserts.equals(env, ["--find-links", "/my/local/archives"], parse("--find-links /my/local/archives\n").options)
+    asserts.equals(env, ["--pre", "--find-links", "/my/local/archives"], parse("""\
 --pre
 --find-links /my/local/archives
 """).options)
-    asserts.equals(env, ["--pre", "--find-links /my/local/archives"], parse("""\
+    asserts.equals(env, ["--pre", "--find-links", "/my/local/archives"], parse("""\
 --pre # Comment
 --find-links /my/local/archives
 """).options)
-    asserts.equals(env, struct(requirements = [("FooProject", "FooProject==1.0.0")], options = ["--pre", "--find-links /my/local/archives"]), parse("""\
+    asserts.equals(env, struct(requirements = [("FooProject", "FooProject==1.0.0")], options = ["--pre", "--find-links", "/my/local/archives"]), parse("""\
 --pre # Comment
 FooProject==1.0.0
 --find-links /my/local/archives

--- a/python/pip_install/requirements_parser.bzl
+++ b/python/pip_install/requirements_parser.bzl
@@ -96,6 +96,9 @@ def _handleParseDependency(input, buffer, result):
 def _handleParseOption(input, buffer, result):
     if input == "\n" and buffer.endswith("\\"):
         return (_STATE.ParseOption, buffer[0:-1])
+    elif input == " ":
+        result.options.append(buffer.rstrip("\n"))
+        return (_STATE.ParseOption, "")
     elif input == "\n" or input == EOF:
         result.options.append(buffer.rstrip("\n"))
         return (_STATE.ConsumeSpace, "")


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Bazel build fails when requirements.txt contains `--extra-index-url https://foo.bar/` with the following error
```
Usage:   
  /home/tgeng/.pyenv/versions/3.10.7/bin/python3 -m pip wheel [options] <requirement specifier> ...
  /home/tgeng/.pyenv/versions/3.10.7/bin/python3 -m pip wheel [options] -r <requirements file> ...
  /home/tgeng/.pyenv/versions/3.10.7/bin/python3 -m pip wheel [options] [-e] <vcs project url> ...
  /home/tgeng/.pyenv/versions/3.10.7/bin/python3 -m pip wheel [options] [-e] <local project path> ...
  /home/tgeng/.pyenv/versions/3.10.7/bin/python3 -m pip wheel [options] <archive url/path> ...

no such option: --extra-index-url https://foo.bar/
Traceback (most recent call last):
  File "/home/tgeng/.pyenv/versions/3.10.7/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/tgeng/.pyenv/versions/3.10.7/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/tgeng/.cache/bazel/_bazel_tgeng/11c8d744707d72bad124e809aecc8f07/external/rules_python~override/python/pip_install/tools/wheel_installer/wheel_installer.py", line 449, in <module>
    main()
  File "/home/tgeng/.cache/bazel/_bazel_tgeng/11c8d744707d72bad124e809aecc8f07/external/rules_python~override/python/pip_install/tools/wheel_installer/wheel_installer.py", line 426, in main
    subprocess.run(pip_args, check=True, env=env)
  File "/home/tgeng/.pyenv/versions/3.10.7/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/tgeng/.pyenv/versions/3.10.7/bin/python3', '-m', 'pip', '--isolated', 'wheel', '--no-deps', '--extra-index-url https://foo.bar/', '-r', '/tmp/tmp4t4gnn79']' returned non-zero exit status 2.
```

Issue Number: N/A


## What is the new behavior?
Build works as expected

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

