### PR TITLE
fix: ensure 'patches' attr is included for the canonical representation of the toolchain

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -323,6 +323,7 @@ py_runtime_pair(
         "distutils_content": rctx.attr.distutils_content,
         "ignore_root_user_error": rctx.attr.ignore_root_user_error,
         "name": rctx.attr.name,
+        "patches": rctx.attr.patches,
         "platform": platform,
         "python_version": python_version,
         "release_filename": release_filename,


### PR DESCRIPTION
Fixes the logspew I introduced in #1004

Before:
```
DEBUG: Rule 'python3_8_x86_64-unknown-linux-gnu' indicated that a canonical reproducible form can be obtained by dropping arguments ["patches"]
DEBUG: Repository python3_8_x86_64-unknown-linux-gnu instantiated at:
  /cache/repo/WORKSPACE:344:27: in <toplevel>
  /cache/bazel/6fadd30f776596320f945376fa05bc65/external/rules_python/python/repositories.bzl:300:26: in python_register_toolchains
Repository rule python_repository defined at:
  /cache/bazel/6fadd30f776596320f945376fa05bc65/external/rules_python/python/repositories.bzl:204:36: in <toplevel>
```

After:
```
```