### PR TITLE
feat: produce publishable distribution archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Prepare workspace snippet
         run: .github/workflows/workspace_snippet.sh > release_notes.txt
       - name: Build wheel dist
-        run: bazel build --stamp --embed_label=${{ env.GITHUB_REF_NAME }} //python/runfiles:wheel
+        run: bazel build --stamp --embed_label=${{ env.GITHUB_REF_NAME }} //python/runfiles:wheel.dist
       - name: Publish runfiles package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -23,7 +23,7 @@ jobs:
           # https://github.com/bazelbuild/rules_python/settings/secrets/actions 
           # and currently uses a token which authenticates as https://pypi.org/user/alexeagle/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: bazel-bin/python/runfiles
+          packages_dir: bazel-bin/python/runfiles/dist
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -48,8 +48,8 @@ This also has the advantage that stamping information is included in the wheel's
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="py_wheel_dist-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_wheel_dist-out"></a>out |  -   | String | optional | <code>"dist"</code> |
-| <a id="py_wheel_dist-wheel"></a>wheel |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="py_wheel_dist-out"></a>out |  name of the resulting directory   | String | required |  |
+| <a id="py_wheel_dist-wheel"></a>wheel |  a [py_wheel rule](/docs/packaging.md#py_wheel_rule)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="py_wheel_rule"></a>

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -26,6 +26,32 @@ This rule is intended to be used as data dependency to py_wheel rule.
 | <a id="py_package-packages"></a>packages |  List of Python packages to include in the distribution. Sub-packages are automatically included.   | List of strings | optional | <code>[]</code> |
 
 
+<a id="py_wheel_dist"></a>
+
+## py_wheel_dist
+
+<pre>
+py_wheel_dist(<a href="#py_wheel_dist-name">name</a>, <a href="#py_wheel_dist-out">out</a>, <a href="#py_wheel_dist-wheel">wheel</a>)
+</pre>
+
+Prepare a dist/ folder, following Python's packaging standard practice.
+
+See https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives
+which recommends a dist/ folder containing the wheel file(s), source distributions, etc.
+
+This also has the advantage that stamping information is included in the wheel's filename.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_wheel_dist-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_wheel_dist-out"></a>out |  -   | String | optional | <code>"dist"</code> |
+| <a id="py_wheel_dist-wheel"></a>wheel |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+
+
 <a id="py_wheel_rule"></a>
 
 ## py_wheel_rule
@@ -68,7 +94,7 @@ in the way they expect.
 | <a id="py_wheel_rule-requires"></a>requires |  List of requirements for this package. See the section on [Declaring required dependency](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-dependencies) for details and examples of the format of this argument.   | List of strings | optional | <code>[]</code> |
 | <a id="py_wheel_rule-stamp"></a>stamp |  Whether to encode build information into the wheel. Possible values:<br><br>- <code>stamp = 1</code>: Always stamp the build information into the wheel, even in [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds. This setting should be avoided, since it potentially kills remote caching for the target and any downstream actions that depend on it.<br><br>- <code>stamp = 0</code>: Always replace build information by constant values. This gives good build result caching.<br><br>- <code>stamp = -1</code>: Embedding of build information is controlled by the [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.   | Integer | optional | <code>-1</code> |
 | <a id="py_wheel_rule-strip_path_prefixes"></a>strip_path_prefixes |  path prefixes to strip from files added to the generated package   | List of strings | optional | <code>[]</code> |
-| <a id="py_wheel_rule-version"></a>version |  Version number of the package. Note that this attribute supports stamp format strings (eg. <code>1.2.3-{BUILD_TIMESTAMP}</code>) as well as 'make variables' (e.g. <code>1.2.3-$(VERSION)</code>).   | String | required |  |
+| <a id="py_wheel_rule-version"></a>version |  Version number of the package.<br><br>Note that this attribute supports stamp format strings as well as 'make variables'. For example:   - <code>version = "1.2.3-{BUILD_TIMESTAMP}"</code>   - <code>version = "{BUILD_EMBED_LABEL}"</code>   - <code>version = "$(VERSION)"</code><br><br>Note that Bazel's output filename cannot include the stamp information, as outputs must be known during the analysis phase and the stamp data is available only during the action execution.<br><br>The [<code>py_wheel</code>](/docs/packaging.md#py_wheel) macro produces a <code>.dist</code>-suffix target which creates a <code>dist/</code> folder containing the wheel with the stamped name, suitable for publishing.<br><br>See [<code>py_wheel_dist</code>](/docs/packaging.md#py_wheel_dist) for more info.   | String | required |  |
 
 
 <a id="PyWheelInfo"></a>

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -63,8 +63,8 @@ This also has the advantage that stamping information is included in the wheel's
 """,
     implementation = _py_wheel_dist_impl,
     attrs = {
-        "out": attr.string(default = "dist"),
-        "wheel": attr.label(providers = [PyWheelInfo]),
+        "out": attr.string(doc = "name of the resulting directory", mandatory = True),
+        "wheel": attr.label(doc = "a [py_wheel rule](/docs/packaging.md#py_wheel_rule)", providers = [PyWheelInfo]),
     },
 )
 
@@ -117,11 +117,12 @@ def py_wheel(name, **kwargs):
         name:  A unique name for this target.
         **kwargs: other named parameters passed to the underlying [py_wheel rule](#py_wheel_rule)
     """
-    _py_wheel(name = name, **kwargs)
-
     py_wheel_dist(
         name = "{}.dist".format(name),
         wheel = name,
+        out = kwargs.pop("dist_folder", "{}_dist".format(name)),
     )
+
+    _py_wheel(name = name, **kwargs)
 
 py_wheel_rule = _py_wheel

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -73,11 +73,23 @@ Stamped targets are not rebuilt unless their dependencies change.
     ),
     "version": attr.string(
         mandatory = True,
-        doc = (
-            "Version number of the package. Note that this attribute " +
-            "supports stamp format strings (eg. `1.2.3-{BUILD_TIMESTAMP}`) " +
-            "as well as 'make variables' (e.g. `1.2.3-$(VERSION)`)."
-        ),
+        doc = """\
+Version number of the package.
+
+Note that this attribute supports stamp format strings as well as 'make variables'.
+For example:
+  - `version = "1.2.3-{BUILD_TIMESTAMP}"`
+  - `version = "{BUILD_EMBED_LABEL}"`
+  - `version = "$(VERSION)"`
+
+Note that Bazel's output filename cannot include the stamp information, as outputs must be known
+during the analysis phase and the stamp data is available only during the action execution.
+
+The [`py_wheel`](/docs/packaging.md#py_wheel) macro produces a `.dist`-suffix target which creates a
+`dist/` folder containing the wheel with the stamped name, suitable for publishing.
+
+See [`py_wheel_dist`](/docs/packaging.md#py_wheel_dist) for more info.
+""",
     ),
     "_stamp_flag": attr.label(
         doc = "A setting used to determine whether or not the `--stamp` flag is enabled",

--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -41,6 +41,7 @@ py_wheel(
         "License :: OSI Approved :: Apache Software License",
     ],
     description_file = "README.md",
+    dist_folder = "dist",
     distribution = "bazel_runfiles",
     homepage = "https://github.com/bazelbuild/rules_python",
     strip_path_prefixes = ["python"],


### PR DESCRIPTION
Fixes #741 

Also unblocks the stuck 0.17.0 release, which publishes a wheel for the first time.

This is a less ambitious attempt to solve our release problem than introducing `twine` in #1015 