### PR TITLE
chore: revert publish wheel on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare workspace snippet
         run: .github/workflows/workspace_snippet.sh > release_notes.txt
-      - name: Build wheel dist
-        run: bazel build --stamp --embed_label=${{ github.ref_name }} //python/runfiles:wheel.dist
-      - name: Publish runfiles package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Note, the PYPI_API_TOKEN was added on
-          # https://github.com/bazelbuild/rules_python/settings/secrets/actions 
-          # and currently uses a token which authenticates as https://pypi.org/user/alexeagle/
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: bazel-bin/python/runfiles/dist
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
our 0.17 release is stuck on this step.
Partially reverts #995

We can try again after #1021 lands