### PR TITLE
Using label as id for py targets

### DIFF
--- a/gazelle/go.mod
+++ b/gazelle/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/emirpasic/gods v1.18.1
 	github.com/ghodss/yaml v1.0.0
-	github.com/google/uuid v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/gazelle/go.sum
+++ b/gazelle/go.sum
@@ -38,8 +38,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "@com_github_emirpasic_gods//lists/singlylinkedlist",
         "@com_github_emirpasic_gods//sets/treeset",
         "@com_github_emirpasic_gods//utils",
-        "@com_github_google_uuid//:uuid",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -210,7 +210,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		pyLibrary = newTargetBuilder(pyLibraryKind, pyLibraryTargetName, pythonProjectRoot, args.Rel).
-			setUUID(fmt.Sprintf("//%s:%s", args.Rel, pyLibraryTargetName)).
+			setUUID(label.New("", args.Rel, pyLibraryTargetName).String()).
 			addVisibility(visibility).
 			addSrcs(pyLibraryFilenames).
 			addModuleDependencies(deps).
@@ -287,7 +287,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel).
-			setUUID(fmt.Sprintf("//%s:%s", args.Rel, conftestTargetname)).
+			setUUID(label.New("", args.Rel, conftestTargetname).String()).
 			addSrc(conftestFilename).
 			addModuleDependencies(deps).
 			addVisibility(visibility).

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -12,13 +12,11 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/rules_python/gazelle/pythonconfig"
 	"github.com/bmatcuk/doublestar"
 	"github.com/emirpasic/gods/lists/singlylinkedlist"
 	"github.com/emirpasic/gods/sets/treeset"
 	godsutils "github.com/emirpasic/gods/utils"
-	"github.com/google/uuid"
-
-	"github.com/bazelbuild/rules_python/gazelle/pythonconfig"
 )
 
 const (
@@ -212,7 +210,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		pyLibrary = newTargetBuilder(pyLibraryKind, pyLibraryTargetName, pythonProjectRoot, args.Rel).
-			setUUID(uuid.Must(uuid.NewUUID()).String()).
+			setUUID(fmt.Sprintf("//%s:%s", args.Rel, pyLibraryTargetName)).
 			addVisibility(visibility).
 			addSrcs(pyLibraryFilenames).
 			addModuleDependencies(deps).
@@ -289,7 +287,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel).
-			setUUID(uuid.Must(uuid.NewUUID()).String()).
+			setUUID(fmt.Sprintf("//%s:%s", args.Rel, conftestTargetname)).
 			addSrc(conftestFilename).
 			addModuleDependencies(deps).
 			addVisibility(visibility).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Gazelle plugin generates a UUID for each `py_library` target for `py_binary` and `py_test` in the same package to refer to. However, creating another identifier such as UUID is not necessary because Bazel already has id for each target, which is its label.

Furthermore, in some large monorepos where it's too slow for Gazelle to index the whole repo, we turn off the indexing with `bazel run //:gazelle -- -index=false` and rely on [CrossResolver](https://github.com/bazelbuild/bazel-gazelle/blob/77e0f34c43a9f5e95f6af93485a4bd83942ed3c6/resolve/index.go#L66) to resolve dependencies based on paths conventions. The UUID makes it impossible to resolve dependencies without indexing the whole repository.


## What is the new behavior?
Reuse Bazel label as the id for the library and avoid depending on the UUID library. Now CrossResolvers can easily resolve same-package dependencies


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
If this approach is acceptable, I can create a follow up PR to rename variables to reflect the fact that we are no longer using UUID
