### PR TITLE
feat: allow extra dependencies to be passed to pip-compile

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -29,9 +29,9 @@ whl_library_alias(<a href="#whl_library_alias-name">name</a>, <a href="#whl_libr
 ## compile_pip_requirements
 
 <pre>
-compile_pip_requirements(<a href="#compile_pip_requirements-name">name</a>, <a href="#compile_pip_requirements-extra_args">extra_args</a>, <a href="#compile_pip_requirements-py_binary">py_binary</a>, <a href="#compile_pip_requirements-py_test">py_test</a>, <a href="#compile_pip_requirements-requirements_in">requirements_in</a>, <a href="#compile_pip_requirements-requirements_txt">requirements_txt</a>,
-                         <a href="#compile_pip_requirements-requirements_darwin">requirements_darwin</a>, <a href="#compile_pip_requirements-requirements_linux">requirements_linux</a>, <a href="#compile_pip_requirements-requirements_windows">requirements_windows</a>, <a href="#compile_pip_requirements-visibility">visibility</a>,
-                         <a href="#compile_pip_requirements-tags">tags</a>, <a href="#compile_pip_requirements-kwargs">kwargs</a>)
+compile_pip_requirements(<a href="#compile_pip_requirements-name">name</a>, <a href="#compile_pip_requirements-extra_args">extra_args</a>, <a href="#compile_pip_requirements-extra_deps">extra_deps</a>, <a href="#compile_pip_requirements-py_binary">py_binary</a>, <a href="#compile_pip_requirements-py_test">py_test</a>, <a href="#compile_pip_requirements-requirements_in">requirements_in</a>,
+                         <a href="#compile_pip_requirements-requirements_txt">requirements_txt</a>, <a href="#compile_pip_requirements-requirements_darwin">requirements_darwin</a>, <a href="#compile_pip_requirements-requirements_linux">requirements_linux</a>,
+                         <a href="#compile_pip_requirements-requirements_windows">requirements_windows</a>, <a href="#compile_pip_requirements-visibility">visibility</a>, <a href="#compile_pip_requirements-tags">tags</a>, <a href="#compile_pip_requirements-kwargs">kwargs</a>)
 </pre>
 
 Generates targets for managing pip dependencies with pip-compile.
@@ -53,6 +53,7 @@ It also generates two targets for running pip-compile:
 | :------------- | :------------- | :------------- |
 | <a id="compile_pip_requirements-name"></a>name |  base name for generated targets, typically "requirements".   |  none |
 | <a id="compile_pip_requirements-extra_args"></a>extra_args |  passed to pip-compile.   |  <code>[]</code> |
+| <a id="compile_pip_requirements-extra_deps"></a>extra_deps |  extra dependencies passed to pip-compile.   |  <code>[]</code> |
 | <a id="compile_pip_requirements-py_binary"></a>py_binary |  the py_binary rule to be used.   |  <code>&lt;function py_binary&gt;</code> |
 | <a id="compile_pip_requirements-py_test"></a>py_test |  the py_test rule to be used.   |  <code>&lt;function py_test&gt;</code> |
 | <a id="compile_pip_requirements-requirements_in"></a>requirements_in |  file expressing desired dependencies.   |  <code>None</code> |

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -6,6 +6,7 @@ load("//python/pip_install:repositories.bzl", "requirement")
 def compile_pip_requirements(
         name,
         extra_args = [],
+        extra_deps = [],
         py_binary = _py_binary,
         py_test = _py_test,
         requirements_in = None,
@@ -30,6 +31,7 @@ def compile_pip_requirements(
     Args:
         name: base name for generated targets, typically "requirements".
         extra_args: passed to pip-compile.
+        extra_deps: extra dependencies passed to pip-compile.
         py_binary: the py_binary rule to be used.
         py_test: the py_test rule to be used.
         requirements_in: file expressing desired dependencies.
@@ -83,7 +85,7 @@ def compile_pip_requirements(
         requirement("importlib_metadata"),
         requirement("zipp"),
         requirement("more_itertools"),
-    ]
+    ] + extra_deps
 
     attrs = {
         "args": args,


### PR DESCRIPTION
I was hitting a problem when running pip-compile on a requirements.in file and being able to pass extra dependencies solved my problem, so this may be helpful to everyone.