### PR TITLE
Handling imports from sibling modules

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -209,7 +209,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			}
 		}
 
-		pyLibrary = newTargetBuilder(pyLibraryKind, pyLibraryTargetName, pythonProjectRoot, args.Rel).
+		pyLibrary = newTargetBuilder(pyLibraryKind, pyLibraryTargetName, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
 			setUUID(label.New("", args.Rel, pyLibraryTargetName).String()).
 			addVisibility(visibility).
 			addSrcs(pyLibraryFilenames).
@@ -246,7 +246,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			}
 		}
 
-		pyBinaryTarget := newTargetBuilder(pyBinaryKind, pyBinaryTargetName, pythonProjectRoot, args.Rel).
+		pyBinaryTarget := newTargetBuilder(pyBinaryKind, pyBinaryTargetName, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
 			setMain(pyBinaryEntrypointFilename).
 			addVisibility(visibility).
 			addSrc(pyBinaryEntrypointFilename).
@@ -286,7 +286,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			}
 		}
 
-		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel).
+		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
 			setUUID(label.New("", args.Rel, conftestTargetname).String()).
 			addSrc(conftestFilename).
 			addModuleDependencies(deps).
@@ -322,7 +322,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 				}
 			}
 		}
-		return newTargetBuilder(pyTestKind, pyTestTargetName, pythonProjectRoot, args.Rel).
+		return newTargetBuilder(pyTestKind, pyTestTargetName, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
 			addSrcs(pyTestFilenames).
 			addModuleDependencies(deps).
 			generateImportsAttribute()

--- a/gazelle/python/testdata/subdir_sources/one/two/README.md
+++ b/gazelle/python/testdata/subdir_sources/one/two/README.md
@@ -1,0 +1,2 @@
+# Same package imports
+This test case asserts that no `deps` is needed when a module imports another module in the same package

--- a/gazelle/python/testdata/subdir_sources/one/two/__init__.py
+++ b/gazelle/python/testdata/subdir_sources/one/two/__init__.py
@@ -1,3 +1,4 @@
 import foo.baz.baz as baz
+import three
 
 _ = baz

--- a/gazelle/python/testdata/with_third_party_requirements/BUILD.out
+++ b/gazelle/python/testdata/with_third_party_requirements/BUILD.out
@@ -20,8 +20,5 @@ py_binary(
     srcs = ["__main__.py"],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],
-    deps = [
-        ":with_third_party_requirements",
-        "@gazelle_python_test_baz//:pkg",
-    ],
+    deps = [":with_third_party_requirements"],
 )

--- a/gazelle/python/testdata/with_third_party_requirements/README.md
+++ b/gazelle/python/testdata/with_third_party_requirements/README.md
@@ -1,5 +1,7 @@
 # With third-party requirements
 
-This test case asserts that a `py_library` is generated with dependencies
+This test case asserts that 
+* a `py_library` is generated with dependencies
 extracted from its sources and a `py_binary` is generated embeding the
 `py_library` and inherits its dependencies, without specifying the `deps` again.
+* when a third-party library and a module in the same package having the same name, the one in the same package takes precedence.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When a Python module imports another one in the same package, it can use the file name without the directory names. When Gazelle generate the targets, they are either in the same target or in sibling targets already depending on each other. However, Gazelle still tries to resolve them, even though no dependency resolution is needed


## What is the new behavior?
Identify imports in sibling modules and ignore them.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

