### PR TITLE
clean up UUID

### DIFF
--- a/gazelle/deps.bzl
+++ b/gazelle/deps.bzl
@@ -1,4 +1,4 @@
-"This file managed by `bazel run //:update_go_deps`"
+"This file managed by `bazel run //:gazelle_update_repos`"
 
 load("@bazel_gazelle//:deps.bzl", _go_repository = "go_repository")
 
@@ -134,12 +134,6 @@ def gazelle_deps():
         importpath = "github.com/google/go-cmp",
         sum = "h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=",
         version = "v0.5.9",
-    )
-    go_repository(
-        name = "com_github_google_uuid",
-        importpath = "github.com/google/uuid",
-        sum = "h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=",
-        version = "v1.3.0",
     )
     go_repository(
         name = "com_github_pelletier_go_toml",

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -210,7 +210,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		pyLibrary = newTargetBuilder(pyLibraryKind, pyLibraryTargetName, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
-			setUUID(label.New("", args.Rel, pyLibraryTargetName).String()).
+			setId(label.New("", args.Rel, pyLibraryTargetName).String()).
 			addVisibility(visibility).
 			addSrcs(pyLibraryFilenames).
 			addModuleDependencies(deps).
@@ -254,7 +254,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			generateImportsAttribute()
 
 		if pyLibrary != nil {
-			pyBinaryTarget.addModuleDependency(module{Name: pyLibrary.PrivateAttr(uuidKey).(string)})
+			pyBinaryTarget.addModuleDependency(module{Name: pyLibrary.PrivateAttr(idKey).(string)})
 		}
 
 		pyBinary := pyBinaryTarget.build()
@@ -287,7 +287,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 
 		conftestTarget := newTargetBuilder(pyLibraryKind, conftestTargetname, pythonProjectRoot, args.Rel, pyLibraryFilenames.Union(pyTestFilenames)).
-			setUUID(label.New("", args.Rel, conftestTargetname).String()).
+			setId(label.New("", args.Rel, conftestTargetname).String()).
 			addSrc(conftestFilename).
 			addModuleDependencies(deps).
 			addVisibility(visibility).
@@ -358,11 +358,11 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 	for _, pyTestTarget := range pyTestTargets {
 		if pyLibrary != nil {
-			pyTestTarget.addModuleDependency(module{Name: pyLibrary.PrivateAttr(uuidKey).(string)})
+			pyTestTarget.addModuleDependency(module{Name: pyLibrary.PrivateAttr(idKey).(string)})
 		}
 
 		if conftest != nil {
-			pyTestTarget.addModuleDependency(module{Name: conftest.PrivateAttr(uuidKey).(string)})
+			pyTestTarget.addModuleDependency(module{Name: conftest.PrivateAttr(idKey).(string)})
 		}
 
 		pyTest := pyTestTarget.build()

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -25,10 +25,10 @@ const (
 	// resolvedDepsKey is the attribute key used to pass dependencies that don't
 	// need to be resolved by the dependency resolver in the Resolver step.
 	resolvedDepsKey = "_gazelle_python_resolved_deps"
-	// uuidKey is the attribute key used to uniquely identify a py_library
+	// idKey is the attribute key used to uniquely identify a py_library
 	// target that should be imported by a py_test or py_binary in the same
 	// Bazel package.
-	uuidKey = "_gazelle_python_library_uuid"
+	idKey = "_gazelle_python_library_id"
 )
 
 // Resolver satisfies the resolve.Resolver interface. It resolves dependencies
@@ -57,10 +57,10 @@ func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []reso
 			provides = append(provides, provide)
 		}
 	}
-	if r.PrivateAttr(uuidKey) != nil {
+	if r.PrivateAttr(idKey) != nil {
 		provide := resolve.ImportSpec{
 			Lang: languageName,
-			Imp:  r.PrivateAttr(uuidKey).(string),
+			Imp:  r.PrivateAttr(idKey).(string),
 		}
 		provides = append(provides, provide)
 	}

--- a/gazelle/python/target.go
+++ b/gazelle/python/target.go
@@ -15,7 +15,7 @@ type targetBuilder struct {
 	name              string
 	pythonProjectRoot string
 	bzlPackage        string
-	uuid              string
+	id                string
 	srcs              *treeset.Set
 	siblingSrcs       *treeset.Set
 	deps              *treeset.Set
@@ -41,12 +41,12 @@ func newTargetBuilder(kind, name, pythonProjectRoot, bzlPackage string, siblingS
 	}
 }
 
-// setUUID sets the given UUID for the target. It's used to index the generated
+// setId sets the given id for the target. It's used to index the generated
 // target based on this value in addition to the other ways the targets can be
 // imported. py_{binary,test} targets in the same Bazel package can add a
-// virtual dependency to this UUID that gets resolved in the Resolver interface.
-func (t *targetBuilder) setUUID(uuid string) *targetBuilder {
-	t.uuid = uuid
+// virtual dependency to this id that gets resolved in the Resolver interface.
+func (t *targetBuilder) setId(id string) *targetBuilder {
+	t.id = id
 	return t
 }
 
@@ -124,8 +124,8 @@ func (t *targetBuilder) generateImportsAttribute() *targetBuilder {
 // build returns the assembled *rule.Rule for the target.
 func (t *targetBuilder) build() *rule.Rule {
 	r := rule.NewRule(t.kind, t.name)
-	if t.uuid != "" {
-		r.SetPrivateAttr(uuidKey, t.uuid)
+	if t.id != "" {
+		r.SetPrivateAttr(idKey, t.id)
 	}
 	if !t.srcs.Empty() {
 		r.SetAttr("srcs", t.srcs.Values())


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
There are still some variables and functions with "UUID" in their name, although we no longer used UUID to identify `py_library` targets. The `gazelle_deps` macro still includes the google/uuid library.


## What is the new behavior?
* Change from names from "UUID" to more general "id" to hide implementation details of the id generation
* `bazel run //:gazelle_update_repos` to clean up google/uuid library


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
* `bazel run //:gazelle_update_repos` doesn't generate the `load` statement correctly. I had to manually revert it back.
* We may also consider adding the `py_library`'s module name to `py_test` and `py_binary`'s deps, so it will be resolved just like regular imports and we no longer need any id for the `py_library`. The only problem is when a module is at the root of a Python project, the module name becomes empty, which is not valid.

