### PR TITLE
fix: use 'repo' as prefix when constructing annotations label

### DIFF
--- a/python/pip_install/tools/lock_file_generator/lock_file_generator.py
+++ b/python/pip_install/tools/lock_file_generator/lock_file_generator.py
@@ -300,7 +300,7 @@ If set, it will take precedence over python_interpreter.",
         annotated_requirements.update(
             {
                 name: "@{}//:{}.annotation.json".format(
-                    args.repo_prefix.rstrip("_"), name
+                    args.repo, name
                 )
             }
         )


### PR DESCRIPTION
The annotations are written into the `repo` workspace (as in, where the `requirements.bzl` file is) rather than where the packages are. 
These may well be the same if not setting `repo_prefix` (hence that `rstrip`), but if the user has set `repo_prefix`, then we no longer want to read annotations from the package path, but rather the repo workspace, which is just `repo`.

(11-repo_prefix_on_annotations.patch)