### PR TITLE
Pass cpp flags through in all cases to repository rule compilations

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -79,10 +79,6 @@ def _get_xcode_location_cflags(rctx):
     if not rctx.os.name.lower().startswith("mac os"):
         return []
 
-    # Only update the location when using a hermetic toolchain.
-    if not is_standalone_interpreter(rctx, rctx.attr.python_interpreter_target):
-        return []
-
     # Locate xcode-select
     xcode_select = rctx.which("xcode-select")
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

Bugfix

## What is the current behavior?

When using a layer of indirection to refer to a hermetic toolchain, python deps that compile local code fail to properly set the path to the local XCode install, causing compilation to fail (eg. when compiling `lxml`'s deps)

## What is the new behavior?

The CPP_FLAGS are set properly, and `lxml` will install from a repository rule cleanly

## Does this PR introduce a breaking change?

No

## Other information

I'm not entirely sure how to reproduce this with a test in this repo. It only showed up when we had some particularly gnarly setup with a repo at work.