### PR TITLE
fix: move coverage pkg to end of sys.path to avoid collisions

### DIFF
--- a/python/pip_install/tools/dependency_resolver/dependency_resolver.py
+++ b/python/pip_install/tools/dependency_resolver/dependency_resolver.py
@@ -14,15 +14,9 @@
 
 "Set defaults for the pip-compile command to run it under Bazel"
 
-import sys
-
-# If we are running under coverage, we need to move the coverage package to the
-# end of the path so that it doesn't interfere with the pip-compile package.
-if "/coverage" == sys.path[0][-len("/coverage") :]:
-    sys.path.append(sys.path.pop(0))
-
 import os
 import re
+import sys
 from pathlib import Path
 from shutil import copyfile
 

--- a/python/pip_install/tools/dependency_resolver/dependency_resolver.py
+++ b/python/pip_install/tools/dependency_resolver/dependency_resolver.py
@@ -14,9 +14,15 @@
 
 "Set defaults for the pip-compile command to run it under Bazel"
 
+import sys
+
+# If we are running under coverage, we need to move the coverage package to the
+# end of the path so that it doesn't interfere with the pip-compile package.
+if "/coverage" == sys.path[0][-len("/coverage") :]:
+    sys.path.append(sys.path.pop(0))
+
 import os
 import re
-import sys
 from pathlib import Path
 from shutil import copyfile
 

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -36,6 +36,7 @@ filegroup(
 # on Skylib.)
 exports_files(
     [
+        "coverage.patch",
         "py_package.bzl",
         "py_wheel.bzl",
         "reexports.bzl",

--- a/python/private/coverage.patch
+++ b/python/private/coverage.patch
@@ -1,0 +1,15 @@
+# Because of how coverage is run, the current directory is the first in
+# sys.path. This is a problem for the tests, because they may import a module of
+# the same name as a module in the current directory.
+diff --git a/coverage/cmdline.py b/coverage/cmdline.py
+index dbf66e0a..780505ac 100644
+--- a/coverage/cmdline.py
++++ b/coverage/cmdline.py
+@@ -937,6 +937,7 @@ def main(argv=None):
+     This is installed as the script entry point.
+ 
+     """
++    sys.path.append(sys.path.pop(0))
+     if argv is None:
+         argv = sys.argv[1:]
+     try:

--- a/python/private/coverage_deps.bzl
+++ b/python/private/coverage_deps.bzl
@@ -97,6 +97,8 @@ _coverage_deps = {
 }
 #END: managed by update_coverage_deps.py script
 
+_coverage_patch = Label("//python/private:coverage.patch")
+
 def coverage_dep(name, python_version, platform, visibility, install = True):
     """Register a singe coverage dependency based on the python version and platform.
 
@@ -149,6 +151,8 @@ filegroup(
     """.format(
             visibility = visibility,
         ),
+        patch_args = ["-p1"],
+        patches = [_coverage_patch],
         sha256 = sha256,
         type = "zip",
         urls = [url],


### PR DESCRIPTION
When we run tests for the locked requirements files, pip-compile will import pip internally, and eventually, it tries to import `html.entries`, which is part of the standard library. Since the `coverage` package provides an `html.py` file, it ends up being picked up by pip if the `coverage` package is early on the `sys.path`.

This patch presents a generic fix for the problem with coverage by moving its own directory to the end of `sys.path`.