### PR TITLE
Make toolchain acceptance tests work with latest Bazel build CI pipeline

### DIFF
--- a/python/tests/toolchains/run_acceptance_test.py.tmpl
+++ b/python/tests/toolchains/run_acceptance_test.py.tmpl
@@ -23,9 +23,8 @@ class TestPythonVersion(unittest.TestCase):
         os.chdir("%test_location%")
         rules_python_path = os.path.join(os.environ["TEST_SRCDIR"], "rules_python")
 
+        test_tmpdir = os.environ["TEST_TMPDIR"]
         if %is_windows%:
-            test_tmpdir = os.environ["TEST_TMPDIR"]
-
             home = os.path.join(test_tmpdir, "HOME")
             os.mkdir(home)
             os.environ["HOME"] = home
@@ -33,6 +32,16 @@ class TestPythonVersion(unittest.TestCase):
             local_app_data = os.path.join(test_tmpdir, "LocalAppData")
             os.mkdir(local_app_data)
             os.environ["LocalAppData"] = local_app_data
+
+        # Bazelisk requires a cache directory be set
+        os.environ["XDG_CACHE_HOME"] = os.path.join(test_tmpdir, "xdg-cache-home")
+
+        # Unset this so this this works when called by Bazel's latest Bazel build
+        # pipeline. It sets the following combination, which interfer with each other:
+        # * --sandbox_tmpfs_path=/tmp
+        # * --test_env=USE_BAZEL_VERSION
+        # * USE_BAZEL_VERSION=/tmp/<something>
+        os.environ.pop("USE_BAZEL_VERSION", None)
 
         with open(".bazelrc", "w") as bazelrc:
             bazelrc.write(
@@ -47,8 +56,11 @@ class TestPythonVersion(unittest.TestCase):
             )
 
     def test_match_toolchain(self):
-        stream = os.popen("bazel run @python//:python3 -- --version")
-        output = stream.read().strip()
+        output = subprocess.check_output(
+          f"bazel run @python//:python3 -- --version",
+          shell = True, # Shell needed to look up via PATH
+          text=True,
+        ).strip()
         self.assertEqual(output, "Python %python_version%")
 
         subprocess.run("bazel test //...", shell=True, check=True)

--- a/python/tests/toolchains/run_acceptance_test.py.tmpl
+++ b/python/tests/toolchains/run_acceptance_test.py.tmpl
@@ -37,7 +37,7 @@ class TestPythonVersion(unittest.TestCase):
         os.environ["XDG_CACHE_HOME"] = os.path.join(test_tmpdir, "xdg-cache-home")
 
         # Unset this so this works when called by Bazel's latest Bazel build
-        # pipeline. It sets the following combination, which interfer with each other:
+        # pipeline. It sets the following combination, which interfere with each other:
         # * --sandbox_tmpfs_path=/tmp
         # * --test_env=USE_BAZEL_VERSION
         # * USE_BAZEL_VERSION=/tmp/<something>

--- a/python/tests/toolchains/run_acceptance_test.py.tmpl
+++ b/python/tests/toolchains/run_acceptance_test.py.tmpl
@@ -36,7 +36,7 @@ class TestPythonVersion(unittest.TestCase):
         # Bazelisk requires a cache directory be set
         os.environ["XDG_CACHE_HOME"] = os.path.join(test_tmpdir, "xdg-cache-home")
 
-        # Unset this so this this works when called by Bazel's latest Bazel build
+        # Unset this so this works when called by Bazel's latest Bazel build
         # pipeline. It sets the following combination, which interfer with each other:
         # * --sandbox_tmpfs_path=/tmp
         # * --test_env=USE_BAZEL_VERSION


### PR DESCRIPTION
The latest Bazel build continous integration testing pipeline sets several flags and environment variables that end up interfering with each other:
 * `--sandbox_tmpfs_path=/tmp`
 * `--test_env=USE_BAZEL_VERSION`
 * `USE_BAZEL_VERSION=/tmp/<something>`
 * And Bazelisk is used to run Bazel

What happens is `USE_BAZEL_VERSION` points to Bazel in /tmp, but then the `--sandbox_tmpfs_path` flag prevents it from being readable. Later, when a test wants to run Bazel, Bazelisk is invoked. It is able to see that it should use a custom Bazel binary because of `--test_env`, but then can't read the file because of `--sandbox_tmpfs_path`, so then fails.

To fix, make the test runner that will run `bazel` unset `USE_BAZEL_VERSION` so Bazelisk doesn't try to use it.

This also exposed an issue with Bazelisk demanding a cache directory be specified, so set that environment variable to the test's temp dir to keep Bazelisk happy.

Fixes #856

