### PR TITLE
Doc how to do a patch release.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # For Developers
 
-## Releasing
+## Releasing major versions
 
 Start from a clean checkout at `main`.
 
@@ -17,11 +17,34 @@ those with only bug fixes and other minor changes bump the patch digit.
 1. Determine what will be the next release, following semver.
 1. Create a tag and push, e.g. `git tag 0.5.0 upstream/main && git push upstream --tags`
 1. Watch the release automation run on https://github.com/bazelbuild/rules_python/actions
-    
+
 #### After release creation in Github
 
 1. Ping @philwo to get the new release added to mirror.bazel.build. See [this comment on issue #400](https://github.com/bazelbuild/rules_python/issues/400#issuecomment-779159530) for more context.
 1. Announce the release in the #python channel in the Bazel slack (bazelbuild.slack.com).
+
+## Patch releases
+
+Patch releases are done similar to regular releases, except a branch is based
+from the release tag and changes are done in the patch-main branch. In the docs
+below, we assume we're creating the `0.18.1` patch release.
+
+### Steps
+
+1. Create patch branch locally: `git checkout -b main-0.18.1 0.18.0`
+2. Push to Github repo: `git push`
+
+From here, the `main-0.18.1` is like any other branch. Usually what you'll
+do is `git cherry-pick` specific commits from `main` to the patch's main:
+
+* `git cherry-pick <commit>`
+
+Then push your changes with `git push`.
+
+You can also go through the regular commit and pull request workflow.
+
+When ready, tag the patch-main branch like a regular release; see the regular
+releasing steps.
 
 ## Secrets
 


### PR DESCRIPTION
These are the steps I did for the 0.18.1 release.

I'm not _entirely_ sure these steps are 100% complete or accurate, but worked for me. A couple
oddities I encountered were:
 * I manually created a branch directly on the bazelbuild/rules_python repo through git;
   I couldn't figure out how to make a PR from my personal fork create a new branch
   in the bazelbuild/rules_python repo.
 * After syncing rickeylev/rules_python, pulling into my local rickeylev/rules_python repo,
   and checking out the patch's branch, it's upstream was set directly to
   bazelbuild/rules_python (not rickeylev/rules_python), so pushes started going directly
   into the repo, not via PRs. Not sure how/why this happened.

