### PR TITLE
cleanup: Remove license type comment; they're no longer required

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,7 @@ load(":version.bzl", "BAZEL_VERSION")
 
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files([
     "LICENSE",

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -15,7 +15,7 @@
 load("//python:versions.bzl", "print_toolchains_checksums")
 load(":stamp.bzl", "stamp_build_setting")
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 filegroup(
     name = "distribution",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -15,7 +15,7 @@ load("//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 # Implementation detail of py_wheel rule.
 py_binary(


### PR DESCRIPTION
The `# License type` comments are no longer required. Removing it makes it easier to import the source into Google.