### PR TITLE
fix: update gazelle to properly handle dot in package name.

### DIFF
--- a/gazelle/pythonconfig/BUILD.bazel
+++ b/gazelle/pythonconfig/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pythonconfig",
@@ -13,6 +13,12 @@ go_library(
         "@bazel_gazelle//label:go_default_library",
         "@com_github_emirpasic_gods//lists/singlylinkedlist",
     ],
+)
+
+go_test(
+    name = "pythonconfig_test",
+    srcs = ["pythonconfig_test.go"],
+    deps = [":pythonconfig"],
 )
 
 filegroup(

--- a/gazelle/pythonconfig/pythonconfig.go
+++ b/gazelle/pythonconfig/pythonconfig.go
@@ -90,6 +90,14 @@ var defaultIgnoreFiles = map[string]struct{}{
 	"setup.py": {},
 }
 
+func SanitizeDistribution(distributionName string) string {
+	sanitizedDistribution := strings.ToLower(distributionName)
+	sanitizedDistribution = strings.ReplaceAll(sanitizedDistribution, "-", "_")
+	sanitizedDistribution = strings.ReplaceAll(sanitizedDistribution, ".", "_")
+
+	return sanitizedDistribution
+}
+
 // Configs is an extension of map[string]*Config. It provides finding methods
 // on top of the mapping.
 type Configs map[string]*Config
@@ -218,8 +226,7 @@ func (c *Config) FindThirdPartyDependency(modName string) (string, bool) {
 				} else if gazelleManifest.PipRepository != nil {
 					distributionRepositoryName = gazelleManifest.PipRepository.Name
 				}
-				sanitizedDistribution := strings.ToLower(distributionName)
-				sanitizedDistribution = strings.ReplaceAll(sanitizedDistribution, "-", "_")
+				sanitizedDistribution := SanitizeDistribution(distributionName)
 
 				if gazelleManifest.PipRepository != nil && gazelleManifest.PipRepository.UsePipRepositoryAliases {
 					// @<repository_name>//<distribution_name>

--- a/gazelle/pythonconfig/pythonconfig_test.go
+++ b/gazelle/pythonconfig/pythonconfig_test.go
@@ -1,26 +1,29 @@
 package pythonconfig
 
 import (
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/bazelbuild/rules_python/gazelle/pythonconfig"
 )
 
-func TestDistributionSanitizingUpperCase(t *testing.T) {
-	distname := "DistWithUpperCase"
-	sanitized := pythonconfig.SanitizeDistribution(distname)
-
-	if sanitized != strings.ToLower(distname) {
-		t.Fatalf("Expected sanitized distribution name not to contain any upper case characters, got %s", sanitized)
+func TestDistributionSanitizing(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"upper case": {input: "DistWithUpperCase", want: "distwithuppercase"},
+		"dashes":     {input: "dist-with-dashes", want: "dist_with_dashes"},
+		"dots":       {input: "dist.with.dots", want: "dist_with_dots"},
+		"mixed":      {input: "To-be.sanitized", want: "to_be_sanitized"},
 	}
-}
 
-func TestDistributionStripsUnallowedCharacters(t *testing.T) {
-	distname := "some-dist.with.bad-chars"
-	sanitized := pythonconfig.SanitizeDistribution(distname)
-
-	if strings.Contains(sanitized, "-") || strings.Contains(sanitized, "."){
-		t.Fatalf("Expected sanitized distribution name not to contain any unallowed charecters ('-', '.'), got %s", sanitized)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := pythonconfig.SanitizeDistribution(tc.input)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("expected %#v, got %#v", tc.want, got)
+			}
+		})
 	}
 }

--- a/gazelle/pythonconfig/pythonconfig_test.go
+++ b/gazelle/pythonconfig/pythonconfig_test.go
@@ -21,8 +21,8 @@ func TestDistributionSanitizing(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := pythonconfig.SanitizeDistribution(tc.input)
-			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("expected %#v, got %#v", tc.want, got)
+			if tc.want != got {
+				t.Fatalf("expected %q, got %q", tc.want, got)
 			}
 		})
 	}

--- a/gazelle/pythonconfig/pythonconfig_test.go
+++ b/gazelle/pythonconfig/pythonconfig_test.go
@@ -1,0 +1,26 @@
+package pythonconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_python/gazelle/pythonconfig"
+)
+
+func TestDistributionSanitizingUpperCase(t *testing.T) {
+	distname := "DistWithUpperCase"
+	sanitized := pythonconfig.SanitizeDistribution(distname)
+
+	if sanitized != strings.ToLower(distname) {
+		t.Fatalf("Expected sanitized distribution name not to contain any upper case characters, got %s", sanitized)
+	}
+}
+
+func TestDistributionStripsUnallowedCharacters(t *testing.T) {
+	distname := "some-dist.with.bad-chars"
+	sanitized := pythonconfig.SanitizeDistribution(distname)
+
+	if strings.Contains(sanitized, "-") || strings.Contains(sanitized, "."){
+		t.Fatalf("Expected sanitized distribution name not to contain any unallowed charecters ('-', '.'), got %s", sanitized)
+	}
+}

--- a/gazelle/pythonconfig/pythonconfig_test.go
+++ b/gazelle/pythonconfig/pythonconfig_test.go
@@ -1,7 +1,6 @@
 package pythonconfig
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/bazelbuild/rules_python/gazelle/pythonconfig"


### PR DESCRIPTION
Some packages (ex: [github3.py](https://pypi.org/project/github3.py/)) have a dot (`.`) character in their name.

`pip_parse` will replace the dot (`.`) with an underscore (`_`) when generating the target name.

`gazelle` however keeps the the dot (`.`) in the name when generating the target dependency name.

This discrepancy means that after a gazelle pass, the repo does not build.

ex:
```
ERROR: <snip>/BUILD.bazel:3:11: no such package
'@python_deps_github3.py//': The repository '@python_deps_github3.py'
could not be resolved: Repository '@python_deps_github3.py' is not
defined and referenced by '<snip>'
```

This PR brings `gazelle` dependency target name generation in line with `pip_parse`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This introduces a breaking change in the sense that existing behavior will be changed. However, I do not believe the existing behavior actually leads to a functional state. 

## Other information

