### PR TITLE
Remove empty line between copyright and build file docstring.

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """This package contains two sets of rules:
 
     1) the "core" Python rules, which were historically bundled with Bazel and


### PR DESCRIPTION
This makes modifying it with buildozer easier. When the empty line is present, Buildozer gets confused and adds loads() before the intended doc string.
