### PR TITLE
py_proto_libray: Add api_deps to transitive_sources

### DIFF
--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -93,7 +93,8 @@ def _py_proto_aspect_impl(target, ctx):
     )
     transitive_sources = depset(
         direct = python_sources,
-        transitive = [dep.transitive_sources for dep in deps],
+        transitive = [dep.transitive_sources for dep in deps] +
+                     [dep[PyInfo].transitive_sources for dep in api_deps],
     )
 
     return [


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?

Sources from runtime needed by py_proto_library are not added to PyInfo.

## What is the new behavior?

The sources are added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
