### PR TITLE
fix: Use GitHub download URL for BCR URL instead of archive URL.

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
     "integrity": "",
     "strip_prefix": "{REPO}-{VERSION}",
-    "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_python-{TAG}.tar.gz"
 }


### PR DESCRIPTION
This is to prevent the issue where the checksum of the auto-generated archive files may change due to GitHub internal changes.

Fixes #1072