### PR TITLE
docs: doc that the Conventional Commit style should be used for merged commits and PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
           - --warnings=all
       - id: buildifier-lint
         args: *args
+  # Enforce that commit messages allow for later changelog generation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.42.0
+    hooks:
+      # Requires that commitizen is already installed
+      - id: commitizen
+        stages: [commit-msg]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,13 +25,6 @@ repos:
           - --warnings=all
       - id: buildifier-lint
         args: *args
-  # Enforce that commit messages allow for later changelog generation
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.42.0
-    hooks:
-      # Requires that commitizen is already installed
-      - id: commitizen
-        stages: [commit-msg]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,8 @@ information on using pull requests.
 
 ### Commit messages
 
-Commit messages have some formatting rules enforced by commitizen and follow
-The general format is:
+Commit messages (upon merging) and PR messages should follow the [Conventional
+Commits](https://www.conventionalcommits.org/) style:
 
 ```
 type(scope)!: <summary>
@@ -130,7 +130,7 @@ BREAKING CHANGE: <summary>
 Where `(scope)` is optional, and `!` is only required if there is a breaking change.
 If a breaking change is introduced, then `BREAKING CHANGE:` is required.
 
-Common types:
+Common `type`s:
 
 * `build:` means it affects the building or development workflow.
 * `docs:` means only documentation is being added, updated, or fixed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,35 @@ information on using pull requests.
 
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 
+### Commit messages
+
+Commit messages have some formatting rules enforced by commitizen and follow
+The general format is:
+
+```
+type(scope)!: <summary>
+
+<body>
+
+BREAKING CHANGE: <summary>
+```
+
+Where `(scope)` is optional, and `!` is only required if there is a breaking change.
+If a breaking change is introduced, then `BREAKING CHANGE:` is required.
+
+Common types:
+
+* `build:` means it affects the building or development workflow.
+* `docs:` means only documentation is being added, updated, or fixed.
+* `feat:` means a user-visible feature is being added.
+* `fix:` means a user-visible behavior is being fixed.
+* `refactor:` means some sort of code cleanup that doesn't change user-visible behavior.
+* `revert:` means a prior change is being reverted in some way.
+* `test:` means only tests are being added.
+
+For the full details of types, see
+[Conventional Commits](https://www.conventionalcommits.org/).
+
 ## Generated files
 
 Some checked-in files are generated and need to be updated when a new PR is


### PR DESCRIPTION
Having a standard format for commit messages makes it easier to understand what general behaviors and functionality are being affected. This makes it easier to easier to generate changelog information for releases and quickly skim PRs.

The default commitizen style is used, which is Conventional Commits. Docs are updated to give a brief description of the format and common types.

This isn't enforced using pre-commit hooks because PRs squash commits and use the PR description for the merged commit message, which makes linting intermediate commits rather moot.