### PR TITLE
chore: fix syntax that stardoc misunderstands as HTML

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -42,8 +42,8 @@ of some other compile_pip_requirements rule that references these requirements
 
 It also generates two targets for running pip-compile:
 
-- validate with `bazel test &lt;name&gt;_test`
-- update with   `bazel run &lt;name&gt;.update`
+- validate with `bazel test [name]_test`
+- update with   `bazel run [name].update`
 
 
 **PARAMETERS**

--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -39,8 +39,8 @@ def compile_pip_requirements(
 
     It also generates two targets for running pip-compile:
 
-    - validate with `bazel test <name>_test`
-    - update with   `bazel run <name>.update`
+    - validate with `bazel test [name]_test`
+    - update with   `bazel run [name].update`
 
     Args:
         name: base name for generated targets, typically "requirements".


### PR DESCRIPTION
Currently we render:
```
validate with bazel test &lt;name&gt;_test
update with bazel run &lt;name&gt;.update
```