### PR TITLE
fix: expose ignore_root_user_error with the module extension api

### DIFF
--- a/python/extensions.bzl
+++ b/python/extensions.bzl
@@ -30,6 +30,7 @@ def _python_impl(module_ctx):
                 # Toolchain registration in bzlmod is done in MODULE file
                 register_toolchains = False,
                 register_coverage_tool = attr.configure_coverage_tool,
+                ignore_root_user_error = attr.ignore_root_user_error,
             )
 
 python = module_extension(
@@ -43,6 +44,11 @@ python = module_extension(
                 ),
                 "name": attr.string(mandatory = True),
                 "python_version": attr.string(mandatory = True),
+                "ignore_root_user_error": attr.bool(
+                    default = False,
+                    doc = "Whether the check for root should be ignored or not. This causes cache misses with .pyc files.",
+                    mandatory = False,
+                ),
             },
         ),
     },


### PR DESCRIPTION
PR Instructions/requirements

Exposes one of the many args that used to be exposed via pre-module functions.

----

Q: Was there a reason that a limited argument set was made available with the module api?