### PR TITLE
fix: docs for ignore_root_user_error at the module level

### DIFF
--- a/python/extensions.bzl
+++ b/python/extensions.bzl
@@ -42,7 +42,11 @@ python = module_extension(
                     mandatory = False,
                     doc = "Whether or not to configure the default coverage tool for the toolchains.",
                 ),
-                "ignore_root_user_error": attr.bool(),
+                "ignore_root_user_error": attr.bool(
+                    default = False,
+                    doc = "Whether the check for root should be ignored or not. This causes cache misses with .pyc files.",
+                    mandatory = False,
+                ),
                 "name": attr.string(mandatory = True),
                 "python_version": attr.string(mandatory = True),
             },


### PR DESCRIPTION
PR Instructions/requirements

Exposes one of the many args that used to be exposed via pre-module functions.

----

Q: Was there a reason that a limited argument set was made available with the module api?