### PR TITLE
feat: add bzl_library for defs.bzl and its dependencies

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -23,6 +23,7 @@ In an ideal renaming, we'd move the packaging rules to a different package so
 that @rules_python//python is only concerned with the core rules.
 """
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":defs.bzl", "current_py_toolchain")
 
 package(default_visibility = ["//visibility:public"])
@@ -40,8 +41,19 @@ filegroup(
     visibility = ["//:__pkg__"],
 )
 
+bzl_library(
+    name = "defs_bzl",
+    srcs = [
+        "defs.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//python/private:bazel_tools_bzl",
+        "//python/private:reexports_bzl",
+    ],
+)
+
 # Filegroup of bzl files that can be used by downstream rules for documentation generation
-# Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
 filegroup(
     name = "bzl",
     srcs = [

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//python:versions.bzl", "print_toolchains_checksums")
 load(":stamp.bzl", "stamp_build_setting")
 
@@ -24,10 +25,27 @@ filegroup(
 )
 
 # Filegroup of bzl files that can be used by downstream rules for documentation generation
-# Using a filegroup rather than bzl_library to not give a transitive dependency on Skylib
 filegroup(
     name = "bzl",
     srcs = glob(["**/*.bzl"]),
+    visibility = ["//python:__pkg__"],
+)
+
+bzl_library(
+    name = "reexports_bzl",
+    srcs = ["reexports.bzl"],
+    visibility = ["//python:__pkg__"],
+    deps = [":bazel_tools_bzl"],
+)
+
+# @bazel_tools can't define bzl_library itself, so we just put a wrapper around it.
+bzl_library(
+    name = "bazel_tools_bzl",
+    srcs = [
+        "@bazel_tools//tools/python:srcs_version.bzl",
+        "@bazel_tools//tools/python:toolchain.bzl",
+        "@bazel_tools//tools/python:utils.bzl",
+    ],
     visibility = ["//python:__pkg__"],
 )
 


### PR DESCRIPTION
This is so that the transitive dependencies of defs.bzl can be easily found and validated; some Google internal tooling does this validation.

The old comment indicated bzl_library wasn't used to avoid a dependency on skylib, however, we've since added a dependency on skylib.

Work towards #1069
