### PR TITLE
feat: add bzl_library for proto.bzl

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -53,6 +53,17 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "proto_bzl",
+    srcs = [
+        "proto.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//python/private/proto:py_proto_library_bzl",
+    ],
+)
+
 # Filegroup of bzl files that can be used by downstream rules for documentation generation
 filegroup(
     name = "bzl",

--- a/python/private/proto/BUILD
+++ b/python/private/proto/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
 package(default_visibility = ["//visibility:public"])
@@ -22,6 +23,16 @@ filegroup(
     name = "distribution",
     srcs = glob(["**"]),
     visibility = ["//python/private:__pkg__"],
+)
+
+bzl_library(
+    name = "py_proto_library_bzl",
+    srcs = ["py_proto_library.bzl"],
+    visibility = ["//python:__pkg__"],
+    deps = [
+        "//python:defs_bzl",
+        "@rules_proto//proto:defs",
+    ],
 )
 
 proto_lang_toolchain(


### PR DESCRIPTION
This is mostly so Google internal tooling can find the complete deps, but also as a best practice for consumption by other rules and tools.
