### PR TITLE
cleanup: Remove license comment in proto build file

### DIFF
--- a/python/private/proto/BUILD
+++ b/python/private/proto/BUILD
@@ -17,7 +17,7 @@ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 filegroup(
     name = "distribution",


### PR DESCRIPTION
The license comments aren't necessary anymore.