### PR TITLE
cleanup: fix typo: libraries, not libaries

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,7 +13,7 @@ bazel_integration_test(
 )
 
 build_test(
-    name = "bzl_libaries_build_test",
+    name = "bzl_libraries_build_test",
     targets = [
         # keep sorted
         "//python:current_py_toolchain_bzl",


### PR DESCRIPTION
Silent r's are tricky.