### PR TITLE
feat: add public entry point for PyCcLinkParamsInfo

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -80,6 +80,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "py_cc_link_params_info_bzl",
+    srcs = ["py_cc_link_params_info.bzl"],
+)
+
+bzl_library(
     name = "py_import_bzl",
     srcs = ["py_import.bzl"],
     deps = [":py_info_bzl"],

--- a/python/py_cc_link_params_info.bzl
+++ b/python/py_cc_link_params_info.bzl
@@ -1,0 +1,3 @@
+"""Public entry point for PyCcLinkParamsInfo."""
+
+PyCcLinkParamsInfo = PyCcLinkParamsProvider

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -20,6 +20,7 @@ build_test(
         "//python:defs_bzl",
         "//python:proto_bzl",
         "//python:py_binary_bzl",
+        "//python:py_cc_link_params_info_bzl",
         "//python:py_import_bzl",
         "//python:py_info_bzl",
         "//python:py_library_bzl",


### PR DESCRIPTION
This provides a public entry point for loading the underlying `PyCcLinkParamsProvider` provider that is built into Bazel. This provider isn't yet usable from Bazel, but adding a loadable way for it to migrate off the built-in rules is the first step.

Work towards #1069
