### PR TITLE
fix: Fix compile_pip_requirements for our use case

### DIFF
--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -17,6 +17,8 @@
 load("//python:defs.bzl", _py_binary = "py_binary", _py_test = "py_test")
 load("//python/pip_install:repositories.bzl", "requirement")
 
+_DEFAULT_TAGS = ["no-sandbox", "no-remote-exec", "requires-network"]
+
 def compile_pip_requirements(
         name,
         extra_args = [],
@@ -29,7 +31,7 @@ def compile_pip_requirements(
         requirements_linux = None,
         requirements_windows = None,
         visibility = ["//visibility:private"],
-        tags = None,
+        tags = _DEFAULT_TAGS,
         **kwargs):
     """Generates targets for managing pip dependencies with pip-compile.
 
@@ -54,9 +56,10 @@ def compile_pip_requirements(
         requirements_darwin: File of darwin specific resolve output to check validate if requirement.in has changes.
         requirements_windows: File of windows specific resolve output to check validate if requirement.in has changes.
         tags: tagging attribute common to all build rules, passed to both the _test and .update rules.
+              default: [{tags_default}]
         visibility: passed to both the _test and .update rules.
         **kwargs: other bazel attributes passed to the "_test" rule.
-    """
+    """.format(tags_default = ", ".join([repr(tag) for tag in _DEFAULT_TAGS]))
     requirements_in = name + ".in" if requirements_in == None else requirements_in
     requirements_txt = name + ".txt" if requirements_txt == None else requirements_txt
 
@@ -102,9 +105,6 @@ def compile_pip_requirements(
     ] + extra_deps
 
     tags = tags or []
-    tags.append("requires-network")
-    tags.append("no-remote-exec")
-    tags.append("no-sandbox")
     attrs = {
         "args": args,
         "data": data,

--- a/python/pip_install/tools/dependency_resolver/dependency_resolver.py
+++ b/python/pip_install/tools/dependency_resolver/dependency_resolver.py
@@ -23,9 +23,9 @@ from pathlib import Path
 import piptools.writer as piptools_writer
 from piptools.scripts.compile import cli
 
-# Replace the os.replace function with shutil.copy to work around os.replace not being able to
+# Replace the os.replace function with shutil.move to work around os.replace not being able to
 # replace or move files across filesystems.
-os.replace = shutil.copy
+os.replace = shutil.move
 
 # Next, we override the annotation_style_split and annotation_style_line functions to replace the
 # backslashes in the paths with forward slashes. This is so that we can have the same requirements


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [X] Build related changes

## What is the current behavior?

`compile_pip_requirements`:
- Forced the `no-remote-exec` tag on all its users, conflicting with our current toolchain + RBE setup.
- Use `shutil.copy` to copy files around. While this works for the current script, it broke in our remote execution enviornment, since it tries to open the destination file for writing.

## What is the new behavior?

- Make the tags optional. I chose to implement them as an overridable default because it more closer resembles the current implementation, but I think there is latitude to make some required (e.g. `requires-network`) and some optional (`no-remote-exec`).
- `shutil.move` can move files across namespaces, and preserves the semantics of `os.replace` better.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

