### PR TITLE
fix: Include filename when parsing imports for gazelle

### DIFF
--- a/gazelle/python/parse.py
+++ b/gazelle/python/parse.py
@@ -27,7 +27,7 @@ from tokenize import COMMENT, tokenize
 
 def parse_import_statements(content, filepath):
     modules = list()
-    tree = ast.parse(content)
+    tree = ast.parse(content, filename=filepath)
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for subnode in node.names:


### PR DESCRIPTION
If the import scanner stumbles across a file with a syntax error, gazelle dies with a message that fails to specify what file it choked on.  Fix that.

Before: 
```
  File "<unknown>", line 28
    class FilesystemDatasetProvider:
IndentationError: expected an indented block
"""
```

After:
```
  File "libs/remote/python/filesystem_dataset.py", line 28
    class FilesystemDatasetProvider:
IndentationError: expected an indented block
"""
```