### PR TITLE
fix: bump installer to handle windows better

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -37,8 +37,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__installer",
-        "https://files.pythonhosted.org/packages/bf/42/fe5f10fd0d58d5d8231a0bc39e664de09992f960597e9fbd3753f84423a3/installer-0.6.0-py3-none-any.whl",
-        "ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038",
+        "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+        "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
     ),
     (
         "pypi__packaging",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_python/issues/1121.