### PR TITLE
fix: gazelle correctly adds new py_test rules

### DIFF
--- a/gazelle/python/kinds.go
+++ b/gazelle/python/kinds.go
@@ -65,7 +65,7 @@ var pyKinds = map[string]rule.KindInfo{
 		},
 	},
 	pyTestKind: {
-		MatchAny: true,
+		MatchAny: false,
 		NonEmptyAttrs: map[string]bool{
 			"deps":       true,
 			"main":       true,

--- a/gazelle/python/testdata/multiple_tests/BUILD.in
+++ b/gazelle/python/testdata/multiple_tests/BUILD.in
@@ -1,0 +1,12 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "multiple_tests",
+    srcs = ["__init__.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_test(
+    name = "bar_test",
+    srcs = ["bar_test.py"],
+)

--- a/gazelle/python/testdata/multiple_tests/BUILD.out
+++ b/gazelle/python/testdata/multiple_tests/BUILD.out
@@ -1,0 +1,17 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "multiple_tests",
+    srcs = ["__init__.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_test(
+    name = "bar_test",
+    srcs = ["bar_test.py"],
+)
+
+py_test(
+    name = "foo_test",
+    srcs = ["foo_test.py"],
+)

--- a/gazelle/python/testdata/multiple_tests/README.md
+++ b/gazelle/python/testdata/multiple_tests/README.md
@@ -1,0 +1,3 @@
+# Multiple tests
+
+This test case asserts that a second `py_test` rule is correctly created when a second `*_test.py` file is added to a package with an existing `py_test` rule.

--- a/gazelle/python/testdata/multiple_tests/WORKSPACE
+++ b/gazelle/python/testdata/multiple_tests/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/multiple_tests/bar_test.py
+++ b/gazelle/python/testdata/multiple_tests/bar_test.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class BarTest(unittest.TestCase):
+    def test_foo(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gazelle/python/testdata/multiple_tests/foo_test.py
+++ b/gazelle/python/testdata/multiple_tests/foo_test.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class FooTest(unittest.TestCase):
+    def test_foo(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gazelle/python/testdata/multiple_tests/test.yaml
+++ b/gazelle/python/testdata/multiple_tests/test.yaml
@@ -1,0 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+expect:
+  exit_code: 0


### PR DESCRIPTION
Since https://github.com/bazelbuild/rules_python/pull/999, gazelle can generate multiple `py_test` rules in a single package (when it finds multiple `*_test.py` or `test_*.py` files and no `__test__.py` file). In this case, adding new test files to a package with pre-existing `py_test` rules is not handled properly due to the `MatchAny` property on the `py_test` kind - it will match the existing `py_test` rule and edit it instead of adding a new test rule. This PR disables the matching so that new `py_test` rules are properly generated.