### PR TITLE
fix: correct the labels returned by all_requirements lists

### DIFF
--- a/examples/build_file_generation/WORKSPACE.bzlmod
+++ b/examples/build_file_generation/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# This file will be used when bzlmod is enabled, keep it empty
+# to ensure that all of the setup is done in MODULE.bazel

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -370,11 +370,11 @@ def _pip_repository_bzlmod_impl(rctx):
     rctx.file("BUILD.bazel", build_contents)
     rctx.template("requirements.bzl", rctx.attr._template, substitutions = {
         "%%ALL_REQUIREMENTS%%": _format_repr_list([
-            "@@{}//{}".format(repo_name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:pkg".format(rctx.attr.name, p)
+            "@{}//{}".format(repo_name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:pkg".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
         "%%ALL_WHL_REQUIREMENTS%%": _format_repr_list([
-            "@@{}//{}:whl".format(repo_name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:whl".format(rctx.attr.name, p)
+            "@{}//{}:whl".format(repo_name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:whl".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
         "%%NAME%%": rctx.attr.name,


### PR DESCRIPTION
This apparently was not working to begin with, but the CI running the
example did not catch it because we did not have an empty `WORKSPACE.bzlmod`
file.

Tested with the CI and with a clean cache on the local laptop.
