### PR TITLE
build: Fixing buildifier

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -33,8 +33,8 @@ licenses(["notice"])
 filegroup(
     name = "distribution",
     srcs = glob(["**"]) + [
-        "//python/constraints:distribution",
         "//python/config_settings:distribution",
+        "//python/constraints:distribution",
         "//python/private:distribution",
         "//python/runfiles:distribution",
     ],

--- a/python/pip_install/BUILD.bazel
+++ b/python/pip_install/BUILD.bazel
@@ -2,10 +2,10 @@ filegroup(
     name = "distribution",
     srcs = glob(["*.bzl"]) + [
         "BUILD.bazel",
+        "//python/pip_install/private:distribution",
         "//python/pip_install/tools/dependency_resolver:distribution",
         "//python/pip_install/tools/lib:distribution",
         "//python/pip_install/tools/wheel_installer:distribution",
-        "//python/pip_install/private:distribution",
     ],
     visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
We have some changes with buildifier 6.1.0, and this commit fixes two files to allow ci to pass.