### PR TITLE
fix: use a consistent buildifier version for CI and pre-commit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,8 +14,8 @@
 
 ---
 buildifier:
-  version: latest
-  # keep this argument in sync with .pre-commit-config.yaml
+  # keep these arguments in sync with .pre-commit-config.yaml
+  version: 6.0.0
   warnings: "all"
 .minimum_supported_version: &minimum_supported_version
   # For testing minimum supported version.

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,6 +15,7 @@
 ---
 buildifier:
   # keep these arguments in sync with .pre-commit-config.yaml
+  # Use a specific version to avoid skew issues when new versions are released.
   version: 6.0.0
   warnings: "all"
 .minimum_supported_version: &minimum_supported_version


### PR DESCRIPTION
The CI may be broken because it is using the latest version of buildifier (`6.1.0`) and the pre-commit hooks are using `6.0.0`. `6.1.0` added extra sorting, so it is now not enough to just run `pre-commit run -a buildifier` to fix the errors. I have submitted a PR to update the pre-commit hooks in https://github.com/keith/pre-commit-buildifier/pull/14 and until it is merged and a new version is tagged we should use an older version of the buildifier to ensure the build is green.
