### PR TITLE
chore: bump buildifier to 6.1.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,7 +16,7 @@
 buildifier:
   # keep these arguments in sync with .pre-commit-config.yaml
   # Use a specific version to avoid skew issues when new versions are released.
-  version: 6.0.0
+  version: 6.1.0
   warnings: "all"
 .minimum_supported_version: &minimum_supported_version
   # For testing minimum supported version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: buildifier
         args: &args 


### PR DESCRIPTION
Bump the buildifier to the latest version in pre-commit and CI at the same time.

Tested by:
```
# Revert the fixes made by buildifier 6.1 in #1148
git revert 64684ae0498576ad2a09fa528fed07afa5e7307d

# do not commit the changes

# run buildifier on all files
pre-commit run -a buildifier

# observe that the files got fixed
```

Related to #1148 and #1151.
