### PR TITLE
test: cleanup gazelle tests and run them in parallel

### DIFF
--- a/gazelle/python/python_test.go
+++ b/gazelle/python/python_test.go
@@ -74,6 +74,7 @@ func TestGazelleBinary(t *testing.T) {
 
 func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 	t.Run(name, func(t *testing.T) {
+		t.Parallel()
 		var inputs, goldens []testtools.FileSpec
 
 		var config *testYAML
@@ -132,8 +133,8 @@ func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 		}
 
 		testdataDir, cleanup := testtools.CreateFiles(t, inputs)
-		defer cleanup()
-		defer func() {
+		t.Cleanup(cleanup)
+		t.Cleanup(func() {
 			if !t.Failed() {
 				return
 			}
@@ -145,14 +146,14 @@ func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 				t.Logf("%q exists", strings.TrimPrefix(path, testdataDir))
 				return nil
 			})
-		}()
+		})
 
 		workspaceRoot := filepath.Join(testdataDir, name)
 
 		args := []string{"-build_file_name=BUILD,BUILD.bazel"}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+		t.Cleanup(cancel)
 		cmd := exec.CommandContext(ctx, gazellePath, args...)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout

--- a/gazelle/python/python_test.go
+++ b/gazelle/python/python_test.go
@@ -74,8 +74,7 @@ func TestGazelleBinary(t *testing.T) {
 
 func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 	t.Run(name, func(t *testing.T) {
-		var inputs []testtools.FileSpec
-		var goldens []testtools.FileSpec
+		var inputs, goldens []testtools.FileSpec
 
 		var config *testYAML
 		for _, f := range files {

--- a/gazelle/python/python_test.go
+++ b/gazelle/python/python_test.go
@@ -110,35 +110,41 @@ func testPath(t *testing.T, name string, files []bazel.RunfileEntry) {
 					Path:    filepath.Join(name, strings.TrimSuffix(shortPath, ".in")),
 					Content: string(content),
 				})
-			} else if strings.HasSuffix(shortPath, ".out") {
+				continue
+			}
+
+			if strings.HasSuffix(shortPath, ".out") {
 				goldens = append(goldens, testtools.FileSpec{
 					Path:    filepath.Join(name, strings.TrimSuffix(shortPath, ".out")),
 					Content: string(content),
 				})
-			} else {
-				inputs = append(inputs, testtools.FileSpec{
-					Path:    filepath.Join(name, shortPath),
-					Content: string(content),
-				})
-				goldens = append(goldens, testtools.FileSpec{
-					Path:    filepath.Join(name, shortPath),
-					Content: string(content),
-				})
+				continue
 			}
+
+			inputs = append(inputs, testtools.FileSpec{
+				Path:    filepath.Join(name, shortPath),
+				Content: string(content),
+			})
+			goldens = append(goldens, testtools.FileSpec{
+				Path:    filepath.Join(name, shortPath),
+				Content: string(content),
+			})
 		}
 
 		testdataDir, cleanup := testtools.CreateFiles(t, inputs)
 		defer cleanup()
 		defer func() {
-			if t.Failed() {
-				filepath.Walk(testdataDir, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					t.Logf("%q exists", strings.TrimPrefix(path, testdataDir))
-					return nil
-				})
+			if !t.Failed() {
+				return
 			}
+
+			filepath.Walk(testdataDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				t.Logf("%q exists", strings.TrimPrefix(path, testdataDir))
+				return nil
+			})
 		}()
 
 		workspaceRoot := filepath.Join(testdataDir, name)


### PR DESCRIPTION
Whilst iterating on the gazelle plugin I noticed that the
tests are taking a really long time to complete (`17s` on
my Linux laptop) and running them in parallel reduces that
time to less than `5s`, which becomes fast enough for the
time being.

Summary:
- refactor: define `inputs` and `goldens` on the same line
- refactor: reduce indentation by early returns
- feat: run tests in parallel and use t.Cleanup
