### PR TITLE
[docs] Fixing rule name in coverage.md docs

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -23,7 +23,7 @@ python.toolchain(
 For WORKSPACE configuration:
 
 ```starlark
-register_python_toolchains(
+python_register_toolchains(
    register_coverage_tool = True,
 )
 ```


### PR DESCRIPTION
The docs explains that for activating coverage support we use `register_coverage_tool = True` inside the rule `register_python_toolchains`. There is no such rule, the actual rule name is `python_register_toolchains`

Signed-off-by: Andrés Felipe Barco Santa <andres@engflow.com>