### PR TITLE
test: Adding tests for hermetic toolchains with bzlmod

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -106,6 +106,33 @@ tasks:
     test_flags:
       - "--test_tag_filters=-integration-test,-fix-windows"
 
+  bzlmod_ubuntu:
+    <<: *reusable_config
+    <<: *common_bzlmod_flags
+    name: Default bzlmod test on Ubuntu
+    platform: ubuntu2004
+    test_targets: ["//python/tests/toolchains/..."]
+  bzlmod_debian:
+    <<: *reusable_config
+    <<: *common_bzlmod_flags
+    name: Default bzlmod test on Debian
+    platform: debian11
+    test_targets: ["//python/tests/toolchains/..."]
+  bzlmod_macos:
+    <<: *reusable_config
+    <<: *common_bzlmod_flags
+    name: Default bzlmod test on macOS
+    platform: macos
+    test_targets: ["//python/tests/toolchains/..."]
+  bzlmod_windows:
+    <<: *reusable_config
+    <<: *common_bzlmod_flags
+    name: Default bzlmod test on Windows
+    platform: windows
+    test_flags:
+      - "--test_tag_filters=-integration-test,-fix-windows"
+    test_targets: ["//python/tests/toolchains/..."]
+
   rbe_min:
     <<: *minimum_supported_version
     <<: *reusable_config

--- a/python/tests/toolchains/workspace_template/BUILD.bazel
+++ b/python/tests/toolchains/workspace_template/BUILD.bazel
@@ -1,5 +1,6 @@
 exports_files([
     "BUILD.bazel.tmpl",
     "WORKSPACE.tmpl",
+    "MODULE.bzl.tmpl",
     "python_version_test.py",
 ])

--- a/python/tests/toolchains/workspace_template/MODULE.bzl.tmpl
+++ b/python/tests/toolchains/workspace_template/MODULE.bzl.tmpl
@@ -1,0 +1,38 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "workspace_test",
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "0.0.0")
+local_path_override(
+    module_name = "rules_python",
+    path = "",
+)
+
+python = use_extension("@rules_python//python:extensions.bzl", "python")
+python.toolchain(
+    name = "python",
+    configure_coverage_tool = True,
+    python_version = "%python_version%",
+)
+use_repo(python, "python")
+use_repo(python, "python_toolchains")
+
+register_toolchains(
+    "@python_toolchains//:all",
+)


### PR DESCRIPTION
This commit improves the toolchain tests to test that a hermetic version of Python is downloaded when running with bzlmod.
