### PR TITLE
fix: remove reference to @bazel_tools//tools/python/private:defs.bzl

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -32,16 +32,6 @@ _DOCS = {
 # because they're only used for doc generation. This way, we avoid requiring
 # our users to depend on Skylib.
 
-# Requires Bazel 0.29 onward for public visibility of these .bzl files.
-bzl_library(
-    name = "bazel_python_tools",
-    srcs = [
-        "@bazel_tools//tools/python:srcs_version.bzl",
-        "@bazel_tools//tools/python:toolchain.bzl",
-        "@bazel_tools//tools/python:utils.bzl",
-    ],
-)
-
 bzl_library(
     name = "bazel_repo_tools",
     srcs = [
@@ -56,7 +46,7 @@ bzl_library(
         "//python/private:reexports.bzl",
     ],
     deps = [
-        ":bazel_python_tools",
+        ":bazel_repo_tools",
         "//python:defs_bzl",
         "//python/private:reexports_bzl",
     ],

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -36,7 +36,6 @@ _DOCS = {
 bzl_library(
     name = "bazel_python_tools",
     srcs = [
-        "@bazel_tools//tools/python:private/defs.bzl",
         "@bazel_tools//tools/python:srcs_version.bzl",
         "@bazel_tools//tools/python:toolchain.bzl",
         "@bazel_tools//tools/python:utils.bzl",


### PR DESCRIPTION
The file was removed in Bazel@HEAD in https://github.com/bazelbuild/bazel/pull/17545
This fixes failures when using rules_python with Bazel@HEAD.

Addresses: https://github.com/bazelbuild/bazel/issues/17874
