### PR TITLE
Update bzlmod version for Gazelle plugin

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_python_gazelle_plugin",
-    version = "0.0.0",
+    version = "0.21.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
Update the bzlmod version for Gazelle plugin to the next release so we can use it as bzlmod.

@aignas FYI
