### PR TITLE
test: Set mac platform for test_mac_requires_darwin_for_execution

### DIFF
--- a/tools/build_defs/python/tests/py_test/py_test_tests.bzl
+++ b/tools/build_defs/python/tests/py_test/py_test_tests.bzl
@@ -45,7 +45,7 @@ def _test_mac_requires_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "darwin_x86_64",
             "//command_line_option:crosstool_top": "@rules_python//tools/build_defs/python/tests:cc_toolchain_suite",
-            #"//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:mac",
+            "//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:mac",
         },
     )
 


### PR DESCRIPTION
This makes the test pass on Bazel built from head. The failure appears due to not forcing the test to a Mac platform, so the underlying logic in `py_test` to detect the Mac platform fails and doesn't add the ExecutionInfo with the necessary info.

Work towards bazelbuild/bazel/issues/18170