### PR TITLE
fix: manually ignore bazel-* directories to make using custom Bazel builds easier

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,8 @@
+# Normally these are ignored, but if you're using a custom
+# build of Bazel with a custom --output_user_root value, Bazel
+# tries to follow the symlinks of the other builds and finds
+# the WORKSPACE, BUILD, etc files and tries to build them.
+bazel-rules_python
+bazel-bin
+bazel-out
+bazel-testlogs


### PR DESCRIPTION
Normally, Bazel will ignore its convenience symlinks, so putting them in the .bazelignore file isn't necessary. However, when `--output_user_root` is set, which is beneficial to set when using different Bazel versions (it preserves the analysis cache between versions), the symlinks aren't ignored. Putting them in the bazelignore file fixes this.