### PR TITLE
tests: Set linux platform for test_non_mac_doesnt_require_darwin_for_execution

### DIFF
--- a/tools/build_defs/python/tests/py_test/py_test_tests.bzl
+++ b/tools/build_defs/python/tests/py_test/py_test_tests.bzl
@@ -76,7 +76,7 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "k8",
             "//command_line_option:crosstool_top": "@rules_python//tools/build_defs/python/tests:cc_toolchain_suite",
-            #"//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:linux",
+            "//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:linux",
         },
     )
 


### PR DESCRIPTION
This is the inverse test of the one testing for the mac platform. As before, the line forcing the platform to a non-mac platform was commented out, which meant, when a mac host built it, it would build the underlying target for Mac, which violated the test's assumptions.

Work towards bazelbuild/bazel/issues/18170