### PR TITLE
tests: Force analysis test labels to resolve within @rules_python context

### DIFF
--- a/tools/build_defs/python/tests/py_test/py_test_tests.bzl
+++ b/tools/build_defs/python/tests/py_test/py_test_tests.bzl
@@ -22,6 +22,12 @@ load(
 )
 load("//tools/build_defs/python/tests:util.bzl", pt_util = "util")
 
+# Explicit Label() calls are required so that it resolves in @rules_python context instead of
+# @rules_testing context.
+_FAKE_CC_TOOLCHAIN = Label("//tools/build_defs/python/tests:cc_toolchain_suite")
+_PLATFORM_MAC = Label("//tools/build_defs/python/tests:mac")
+_PLATFORM_LINUX = Label("//tools/build_defs/python/tests:linux")
+
 _tests = []
 
 def _test_mac_requires_darwin_for_execution(name, config):
@@ -44,8 +50,8 @@ def _test_mac_requires_darwin_for_execution(name, config):
         target = name + "_subject",
         config_settings = {
             "//command_line_option:cpu": "darwin_x86_64",
-            "//command_line_option:crosstool_top": "@rules_python//tools/build_defs/python/tests:cc_toolchain_suite",
-            "//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:mac",
+            "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
+            "//command_line_option:platforms": [_PLATFORM_MAC],
         },
     )
 
@@ -75,8 +81,8 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
         target = name + "_subject",
         config_settings = {
             "//command_line_option:cpu": "k8",
-            "//command_line_option:crosstool_top": "@rules_python//tools/build_defs/python/tests:cc_toolchain_suite",
-            "//command_line_option:platforms": "@rules_python//tools/build_defs/python/tests:linux",
+            "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
+            "//command_line_option:platforms": [_PLATFORM_LINUX],
         },
     )
 


### PR DESCRIPTION
When a string label is passed to the `@rules_testing` analysis_test functions, the strings are evaluated within the context of @rules_testing because that is where the actual rule invocation happens. Without bzlmod, this just requires qualifying the labels with the repo name (which is what was being done) because there's just a flat global namespace of repos.

With bzlmod enabled, repo mapping happens, so rules_testing tries to resolve those repo names using its repo mapping, which doesn't work because rules_testing's mapping doesn't include every repo using it.