### PR TITLE
fix(bzlmod): correctly template repository macros for requirements, etc

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -367,6 +367,10 @@ def _pip_repository_bzlmod_impl(rctx):
     else:
         build_contents += _bzlmod_pkg_aliases(repo_name, bzl_packages)
 
+    macro_tmpl = "@@{name}//:{{}}_{{}}".format(name = rctx.attr.name)
+    if rctx.attr.incompatible_generate_aliases:
+        macro_tmpl = "@@{name}//{{}}:{{}}".format(name = rctx.attr.name)
+
     rctx.file("BUILD.bazel", build_contents)
     rctx.template("requirements.bzl", rctx.attr._template, substitutions = {
         "%%ALL_REQUIREMENTS%%": _format_repr_list([
@@ -377,8 +381,8 @@ def _pip_repository_bzlmod_impl(rctx):
             "@{}//{}:whl".format(repo_name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:whl".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
-        "%%NAME%%": rctx.attr.name,
         "%%REQUIREMENTS_LOCK%%": str(requirements_txt),
+        "%%TMPL%%": macro_tmpl,
     })
 
 pip_repository_bzlmod_attrs = {

--- a/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
+++ b/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
@@ -12,13 +12,13 @@ def _clean_name(name):
     return name.replace("-", "_").replace(".", "_").lower()
 
 def requirement(name):
-    return "@@%%NAME%%//:" + _clean_name(name) + "_pkg"
+    return "%%TMPL%%".format(_clean_name(name), "pkg")
 
 def whl_requirement(name):
-    return "@@%%NAME%%//:" + _clean_name(name) + "_whl"
+    return "%%TMPL%%".format(_clean_name(name), "whl")
 
 def data_requirement(name):
-    return "@@%%NAME%%//:" + _clean_name(name) + "_data"
+    return "%%TMPL%%".format(_clean_name(name), "data")
 
 def dist_info_requirement(name):
-    return "@@%%NAME%%//:" + _clean_name(name) + "_dist_info"
+    return "%%TMPL%%".format(_clean_name(name), "dist_info")

--- a/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
+++ b/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
@@ -12,13 +12,13 @@ def _clean_name(name):
     return name.replace("-", "_").replace(".", "_").lower()
 
 def requirement(name):
-    return "%%TMPL%%".format(_clean_name(name), "pkg")
+    return "%%MACRO_TMPL%%".format(_clean_name(name), "pkg")
 
 def whl_requirement(name):
-    return "%%TMPL%%".format(_clean_name(name), "whl")
+    return "%%MACRO_TMPL%%".format(_clean_name(name), "whl")
 
 def data_requirement(name):
-    return "%%TMPL%%".format(_clean_name(name), "data")
+    return "%%MACRO_TMPL%%".format(_clean_name(name), "data")
 
 def dist_info_requirement(name):
-    return "%%TMPL%%".format(_clean_name(name), "dist_info")
+    return "%%MACRO_TMPL%%".format(_clean_name(name), "dist_info")


### PR DESCRIPTION
It seems that the macros for specifying the requirements break when the
user starts using `incompatible_generate_aliases=True`. This PR fixes
this.

Testing done:
1. Modify the example:
   ```
   $ git diff
   diff --git a/examples/bzlmod/MODULE.bazel b/examples/bzlmod/MODULE.bazel
   index ce91228..1750210 100644
   --- a/examples/bzlmod/MODULE.bazel
   +++ b/examples/bzlmod/MODULE.bazel
   @@ -26,6 +26,7 @@ register_toolchains(
    pip = use_extension("@rules_python//python:extensions.bzl", "pip")
    pip.parse(
        name = "pip",
   +    incompatible_generate_aliases=True,
        requirements_lock = "//:requirements_lock.txt",
        requirements_windows = "//:requirements_windows.txt",
    )
   ```
2. Run `bazel build ...` and check that it is still working.

I noticed this when working on #1189 and creating a separate PR for easier cherry-picking if we wanted to make a patch release which includes this. I am not sure how I could make an automated test for this other than creating a separate example.
