### PR TITLE
fix: coverage: rename html.py file to htmlx.py to avoid a clash while loading html deps

### DIFF
--- a/python/private/coverage_deps.bzl
+++ b/python/private/coverage_deps.bzl
@@ -153,6 +153,10 @@ filegroup(
         ),
         patch_args = ["-p1"],
         patches = [_coverage_patch],
+        patch_cmds = [
+            "mv coverage/html.py coverage/htmlx.py",
+            "sed -i'.py' -e 's/coverage.html/coverage.htmlx/g' coverage/control.py",
+        ],
         sha256 = sha256,
         type = "zip",
         urls = [url],


### PR DESCRIPTION
This is to avoid a clash when loading the html python std library;

See issue #1196 