### PR TITLE
tests: Add skylib to various test dependencies to fix CI

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -20,6 +20,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 def rules_python_internal_deps():
     """Fetches all required dependencies for rules_python tests and tools."""
 
+    # This version is also used in python/tests/toolchains/workspace_template/WORKSPACE.tmpl
+    # and tests/ignore_root_user_error/WORKSPACE.
+    # If you update this dependency, please update the tests as well.
     maybe(
         http_archive,
         name = "bazel_skylib",

--- a/python/tests/toolchains/workspace_template/WORKSPACE.tmpl
+++ b/python/tests/toolchains/workspace_template/WORKSPACE.tmpl
@@ -25,3 +25,15 @@ python_register_toolchains(
     name = "python",
     python_version = "%python_version%",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+    ],
+    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()

--- a/tests/ignore_root_user_error/WORKSPACE
+++ b/tests/ignore_root_user_error/WORKSPACE
@@ -10,3 +10,18 @@ python_register_toolchains(
     ignore_root_user_error = True,
     python_version = "3.9",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()


### PR DESCRIPTION
This fixes a problem where bazel skylib does not load during the toolchain integration test.

The skylib dependency was introduced by #1191, but skylib was not present in the WORKSPACE configs of several things. To fix, skylib just needs to be added to the workspace files.