### PR TITLE
feat: propagate visibility attribute for py_wheel publishing

### DIFF
--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -172,6 +172,7 @@ def py_wheel(name, twine = None, **kwargs):
             imports = ["."],
             main = twine_main,
             deps = [twine],
+            visibility = kwargs.get("visibility"),
         )
 
 py_wheel_rule = _py_wheel


### PR DESCRIPTION
py_wheel does not propagate "visibility" attribute to the "publish" rule.  The visibility attribute on py_wheel target is not propagated to the auto-generated "publish" target. This commit adds the visibility attribute.

Closes: https://github.com/bazelbuild/rules_python/issues/1192