### PR TITLE
test(bzlmod): explicitly enable bzlmod in the test harness

### DIFF
--- a/tools/bazel_integration_test/test_runner.py
+++ b/tools/bazel_integration_test/test_runner.py
@@ -79,6 +79,7 @@ def main(conf_file):
                         "--override_module=rules_python=%s/rules_python"
                         % os.environ["TEST_SRCDIR"]
                     )
+                    bazel_args.append("--enable_bzlmod")
 
                 # Bazel's wrapper script needs this or you get
                 # 2020/07/13 21:58:11 could not get the user's cache directory: $HOME is not defined


### PR DESCRIPTION
Previously we would depend on the value of .bazelrc and this
change ensures that we are explicitly enable bzlmod via CLI
args. It seems that the `py_proto_library` integration tests
defined in the `//examples:BUILD.bazel` file were not running
using `bzlmod` before hand, however, they were correctly
executed in the CI.

Work towards #958.
