### PR TITLE
fix: use `only-binary` for `download_only` `pip download`

### DIFF
--- a/python/pip_install/tools/wheel_installer/wheel_installer.py
+++ b/python/pip_install/tools/wheel_installer/wheel_installer.py
@@ -406,7 +406,8 @@ def main() -> None:
     pip_args = (
         [sys.executable, "-m", "pip"]
         + (["--isolated"] if args.isolated else [])
-        + ["download" if args.download_only else "wheel", "--no-deps"]
+        + (["download", "--only-binary=:all:"] if args.download_only else ["wheel"])
+        + ["--no-deps"]
         + deserialized_args["extra_pip_args"]
     )
 


### PR DESCRIPTION
[`wheel_installer` assumes that if the pip command succeeded, there must be at least one `*.whl` file](https://github.com/lpulley/rules_python/blob/fdec44120aa45d748ab804f1d019002c6949b449/python/pip_install/tools/wheel_installer/wheel_installer.py#L439), but this is not currently true when `download_only` is enabled and the package provides no wheel; a `.tar.gz` will happily be downloaded, pip will succeed, and the `next(iter(glob.glob("*.whl")))` call will fail, producing a mysterious `StopIteration`:

```
Saved ./artifactory-0.1.17.tar.gz
Successfully downloaded artifactory
 (Traceback (most recent call last):
  File "[redacted]/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "[redacted]/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "[redacted]/external/rules_python/python/pip_install/tools/wheel_installer/wheel_installer.py", line 450, in <module>
    main()
  File "[redacted]/external/rules_python/python/pip_install/tools/wheel_installer/wheel_installer.py", line 438, in main
    whl = next(iter(glob.glob("*.whl")))
StopIteration
)
```

By using `--only-binary=:all:` when using `pip download`, the pip command will fail if there is no suitable wheel to be downloaded. This should make the error much more obvious, since with `--only-binary=:all:` and no suitable wheel, pip fails and reports an error like this:

```
ERROR: Could not find a version that satisfies the requirement artifactory (from versions: none)
ERROR: No matching distribution found for artifactory
```