### PR TITLE
fix(toolchain): set correct return attrs to remove non-hermeticity warning

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -348,7 +348,7 @@ py_runtime_pair(
     rctx.file(STANDALONE_INTERPRETER_FILENAME, "# File intentionally left blank. Indicates that this is an interpreter repo created by rules_python.")
     rctx.file("BUILD.bazel", build_content)
 
-    return {
+    attrs = {
         "coverage_tool": rctx.attr.coverage_tool,
         "distutils": rctx.attr.distutils,
         "distutils_content": rctx.attr.distutils_content,
@@ -360,8 +360,14 @@ py_runtime_pair(
         "release_filename": release_filename,
         "sha256": rctx.attr.sha256,
         "strip_prefix": rctx.attr.strip_prefix,
-        "url": urls,
     }
+
+    if rctx.attr.url:
+        attrs["url"] = rctx.attr.url
+    else:
+        attrs["urls"] = urls
+
+    return attrs
 
 python_repository = repository_rule(
     _python_repository_impl,

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -106,11 +106,11 @@ def _python_repository_impl(rctx):
     python_version = rctx.attr.python_version
     python_short_version = python_version.rpartition(".")[0]
     release_filename = rctx.attr.release_filename
-    url = rctx.attr.urls or [rctx.attr.url]
+    urls = rctx.attr.urls or [rctx.attr.url]
 
     if release_filename.endswith(".zst"):
         rctx.download(
-            url = url,
+            url = urls,
             sha256 = rctx.attr.sha256,
             output = release_filename,
         )
@@ -153,7 +153,7 @@ def _python_repository_impl(rctx):
             fail(fail_msg)
     else:
         rctx.download_and_extract(
-            url = url,
+            url = urls,
             sha256 = rctx.attr.sha256,
             stripPrefix = rctx.attr.strip_prefix,
         )
@@ -360,7 +360,7 @@ py_runtime_pair(
         "release_filename": release_filename,
         "sha256": rctx.attr.sha256,
         "strip_prefix": rctx.attr.strip_prefix,
-        "url": url,
+        "url": urls,
     }
 
 python_repository = repository_rule(


### PR DESCRIPTION
Fixes the incorrect debug statement when downloading the toolchain for the first
time asking users to replace "urls" with "url" in the toolchain definition which
we maintain:
```
$ bazel build ...
... indicated that a canonical reproducible form can be obtained by modifying ...
```

Even though this is seen only once by the user, it may confuse them.

Summary of changes:
- refactor(toolchain): rename a local variable url -> urls
- fix(toolchain): set url return attrs correctly
