### PR TITLE
feat(gazelle): allow passing multiple files to the manifest generator

### DIFF
--- a/examples/build_file_generation/BUILD.bazel
+++ b/examples/build_file_generation/BUILD.bazel
@@ -42,7 +42,10 @@ gazelle_python_manifest(
     name = "gazelle_python_manifest",
     modules_mapping = ":modules_map",
     pip_repository_name = "pip",
-    requirements = "//:requirements_lock.txt",
+    requirements_files = [
+        "//:requirements_lock.txt",
+        "//:requirements_windows.txt",
+    ],
     # NOTE: we can use this flag in order to make our setup compatible with
     # bzlmod.
     use_pip_repository_aliases = True,

--- a/examples/build_file_generation/gazelle_python.yaml
+++ b/examples/build_file_generation/gazelle_python.yaml
@@ -115,4 +115,4 @@ manifest:
   pip_repository:
     name: pip
     use_pip_repository_aliases: true
-integrity: 030d6d99b56c32d6577e616b617260d0a93588af791269162e43391a5a4fa576
+integrity: 35d9c488d8dc6e6c8f315dd45e3c942e98ac5b28a2d29ba9430513290b0ea063

--- a/examples/bzlmod_build_file_generation/BUILD.bazel
+++ b/examples/bzlmod_build_file_generation/BUILD.bazel
@@ -50,7 +50,10 @@ gazelle_python_manifest(
     name = "gazelle_python_manifest",
     modules_mapping = ":modules_map",
     pip_repository_name = "pip",
-    requirements = "//:requirements_lock.txt",
+    requirements_files = [
+        "//:requirements_lock.txt",
+        "//:requirements_windows.txt",
+    ],
     # NOTE: we can use this flag in order to make our setup compatible with
     # bzlmod.
     use_pip_repository_aliases = True,

--- a/examples/bzlmod_build_file_generation/gazelle_python.yaml
+++ b/examples/bzlmod_build_file_generation/gazelle_python.yaml
@@ -232,6 +232,7 @@ manifest:
     isort.wrap: isort
     isort.wrap_modes: isort
     lazy_object_proxy: lazy_object_proxy
+    lazy_object_proxy.cext: lazy_object_proxy
     lazy_object_proxy.compat: lazy_object_proxy
     lazy_object_proxy.simple: lazy_object_proxy
     lazy_object_proxy.slots: lazy_object_proxy
@@ -587,4 +588,4 @@ manifest:
   pip_repository:
     name: pip
     use_pip_repository_aliases: true
-integrity: d979738b10adbbaff0884837e4414688990491c6c40f6a25d58b9bb564411477
+integrity: cee7684391c4a8a1ff219cd354deae61cdcdee70f2076789aabd5249f3c4eca9


### PR DESCRIPTION
For certain workflows it is useful to calculate the integrity hash of
the manifest file based on a number of requirements files. The
requirements locking is usually done by executing a script on each
platform and having gazelle manifest generator be aware that more than
one requirements file may affect the outcome (e.g. the wheels that get
passed to modules map may come from `multi_pip_parse` rule) is generally
useful.

This change modifies the `generator` to support multiple
`--requirements` flag specification and uses all files that got passed
to generate the final integrity hash.

NOTE: This may require users to regenerate the `gazelle_python.yaml` files due
to a change in integrity, otherwise this is a backwards compatible change.
