### PR TITLE
fix: make `import python.runfiles` work with `--experimental_python_import_all_repositories=false`

### DIFF
--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -27,6 +27,11 @@ py_library(
         "__init__.py",
         "runfiles.py",
     ],
+    imports = [
+        # Add the repo root so `import python.runfiles.runfiles` works. This makes it agnostic
+        # to the --experimental_python_import_all_repositories setting.
+        "../..",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Because `--experimental_python_import_all_repositories` defaults to true, every repository's directory is added to `sys.path`, which makes `import python.runfiles` work.

However, we shouldn't rely on that behavior for a couple reasons:
  * We recommend disabling it for fewer sys.path entries (even non-Python related
    repos get added to the path).
  * Some users _must_ disable it because the resulting PYTHONPATH is too long.

To fix, set the `imports` attribute on `//python/runfiles:runfiles` so that `import python.runfiles` works. The net result is the `rules_python` repo directory is added
to sys.path even if `--experimental_python_import_all_repositories=false`.

Fixes #1241