### PR TITLE
fix(bzlmod+gazelle): update BCR release presubmit to use correct example

### DIFF
--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 bcr_test_module:
-  module_path: "../examples/build_file_generation"
+  module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
   tasks:


### PR DESCRIPTION
The bzlmod-compatible build_file_generation example was moved to the bzlmod_build_file_generation example.

This should fix the automatic build/release of the gazelle BCR module.