### PR TITLE
fix(bzlmod): Fixing Windows Python Interpreter symlink issues

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -80,8 +80,8 @@ def _resolve_python_interpreter(rctx):
         if str(Label("//:unused")).startswith("@@"):
             (os, _) = get_host_os_arch(rctx)
 
-            # If we have Windows the symlink will not work directly and we need
-            # to resolve the realpath.
+            # On Windows, the symlink doesn't work because Windows attempts to find
+            # Python DLLs where the symlink is, not where the symlink points.
             if os == WINDOWS_NAME:
                 python_interpreter = python_interpreter.realpath
     elif "/" not in python_interpreter:


### PR DESCRIPTION
When using Windows you cannot run the symlink directly.

Because of how symlinks work in Windows we need to path realpath resolve the link.
Unlike Linux and OSX we cannot execute the Python symlink directly. Windows throws an error "-1073741515", when we execute the symlink directory.  This error means that the Python binary cannot find dlls. This is because the symlink that we create is not in the same folder as the dlls.