### PR TITLE
fix: Ignore tempoary pyc.NNN files in wheels

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -106,6 +106,7 @@ py_library(
         # to avoid non-determinism following pip install's behavior.
         "**/*.py",
         "**/*.pyc",
+        "**/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNN are created
         "**/* *",
         "**/*.dist-info/RECORD",
         "BUILD",

--- a/python/pip_install/tools/wheel_installer/wheel_installer.py
+++ b/python/pip_install/tools/wheel_installer/wheel_installer.py
@@ -226,6 +226,7 @@ def _generate_build_file_contents(
                 "**/* *",
                 "**/*.py",
                 "**/*.pyc",
+                "**/*.pyc.*", # During pyc creation, temp files named *.pyc.NNNN are created
                 # RECORD is known to contain sha256 checksums of files which might include the checksums
                 # of generated files produced when wheels are installed. The file is ignored to avoid
                 # Bazel caching issues.

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -219,6 +219,7 @@ def _python_repository_impl(rctx):
             # the definition of this filegroup will change, and depending rules will get invalidated."
             # See https://github.com/bazelbuild/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them."
             "**/__pycache__/*.pyc",
+            "**/__pycache__/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNN are created
             "**/__pycache__/*.pyo",
         ]
 


### PR DESCRIPTION
We ignore pyc files most everywhere (because they aren't deterministic), but part of the pyc creation process involves creating temporary files named `*.pyc.NNN`. Though these are supposed to be temporary files nobody sees, they seem to get picked up by a glob somewhere, somehow. I'm unable to figure out how that is happening, but ignoring them in the glob expressions should also suffice.

Fixes #1261