### PR TITLE
fix: plugin_output in py_proto_library rule

### DIFF
--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -75,6 +75,7 @@ def _py_proto_aspect_impl(target, ctx):
             name_mapper = lambda name: name.replace("-", "_").replace(".", "/"),
         )
 
+        # Handles multiple repository and virtual import cases
         proto_root = proto_info.proto_source_root
         if proto_root.startswith(ctx.bin_dir.path):
             plugin_output = proto_root

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -75,12 +75,21 @@ def _py_proto_aspect_impl(target, ctx):
             name_mapper = lambda name: name.replace("-", "_").replace(".", "/"),
         )
 
+        proto_root = proto_info.proto_source_root
+        if proto_root.startswith(ctx.bin_dir.path):
+            plugin_output = proto_root
+        else:
+            plugin_output = ctx.bin_dir.path + "/" + proto_root
+
+        if plugin_output == ".":
+            plugin_output = ctx.bin_dir.path
+
         proto_common.compile(
             actions = ctx.actions,
             proto_info = proto_info,
             proto_lang_toolchain_info = proto_lang_toolchain_info,
             generated_files = generated_sources,
-            plugin_output = ctx.bin_dir.path,
+            plugin_output = plugin_output,
         )
 
     # Generated sources == Python sources


### PR DESCRIPTION
plugin_output was wrong in case multiple repositories are involved and/or _virtual_imports. 

The code is taken from `cc_proto_library` and has been verified in practice.
