### PR TITLE
tests: make analysis tests support --incompatible_enable_cc_toolchain_resolution

### DIFF
--- a/tools/build_defs/python/tests/BUILD.bazel
+++ b/tools/build_defs/python/tests/BUILD.bazel
@@ -53,6 +53,13 @@ cc_toolchain(
     toolchain_identifier = "mac-toolchain",
 )
 
+toolchain(
+    name = "mac_toolchain_definition",
+    target_compatible_with = ["@platforms//os:macos"],
+    toolchain = ":mac_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 fake_cc_toolchain_config(
     name = "mac_toolchain_config",
     target_cpu = "darwin_x86_64",
@@ -70,6 +77,13 @@ cc_toolchain(
     supports_param_files = 0,
     toolchain_config = ":linux_toolchain_config",
     toolchain_identifier = "linux-toolchain",
+)
+
+toolchain(
+    name = "linux_toolchain_definition",
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":linux_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 fake_cc_toolchain_config(

--- a/tools/build_defs/python/tests/py_test/py_test_tests.bzl
+++ b/tools/build_defs/python/tests/py_test/py_test_tests.bzl
@@ -25,6 +25,7 @@ load("//tools/build_defs/python/tests:util.bzl", pt_util = "util")
 # Explicit Label() calls are required so that it resolves in @rules_python context instead of
 # @rules_testing context.
 _FAKE_CC_TOOLCHAIN = Label("//tools/build_defs/python/tests:cc_toolchain_suite")
+_FAKE_CC_TOOLCHAINS = [str(Label("//tools/build_defs/python/tests:all"))]
 _PLATFORM_MAC = Label("//tools/build_defs/python/tests:mac")
 _PLATFORM_LINUX = Label("//tools/build_defs/python/tests:linux")
 
@@ -52,6 +53,7 @@ def _test_mac_requires_darwin_for_execution(name, config):
             "//command_line_option:cpu": "darwin_x86_64",
             "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
             "//command_line_option:platforms": [_PLATFORM_MAC],
+            "//command_line_option:extra_toolchains": _FAKE_CC_TOOLCHAINS,
         },
     )
 
@@ -83,6 +85,7 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
             "//command_line_option:cpu": "k8",
             "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
             "//command_line_option:platforms": [_PLATFORM_LINUX],
+            "//command_line_option:extra_toolchains": _FAKE_CC_TOOLCHAINS,
         },
     )
 

--- a/tools/build_defs/python/tests/py_test/py_test_tests.bzl
+++ b/tools/build_defs/python/tests/py_test/py_test_tests.bzl
@@ -52,8 +52,8 @@ def _test_mac_requires_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "darwin_x86_64",
             "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
-            "//command_line_option:platforms": [_PLATFORM_MAC],
             "//command_line_option:extra_toolchains": _FAKE_CC_TOOLCHAINS,
+            "//command_line_option:platforms": [_PLATFORM_MAC],
         },
     )
 
@@ -84,8 +84,8 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "k8",
             "//command_line_option:crosstool_top": _FAKE_CC_TOOLCHAIN,
-            "//command_line_option:platforms": [_PLATFORM_LINUX],
             "//command_line_option:extra_toolchains": _FAKE_CC_TOOLCHAINS,
+            "//command_line_option:platforms": [_PLATFORM_LINUX],
         },
     )
 


### PR DESCRIPTION
The analysis tests transition to different platforms to test some platform-specific logic.

When cc toolchain registration is enabled, this also requires that a more complete
toolchain be defined and available.