### PR TITLE
fix(bzlmod)!: Bump compatibility level

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_python",
     version = "0.0.0",
-    compatibility_level = 1,
+    compatibility_level = 2,
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
https://github.com/bazelbuild/rules_python/commit/1c581242c25925a1bd6764608877ec170724f11d introduces a change to the extension API provided by rules_python that are not backwards compatible so bump compatibility_level before the next release.

BREAKING CHANGES
The extension API has changed in this release so the compatibility level has been bumped.