### PR TITLE
feat: Create `all_data_requirements` alias

### DIFF
--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -6,7 +6,7 @@
 # The names @pip and @python_39 are values that are repository
 # names. Those names are defined in the MODULES.bazel file.
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@pip//:requirements.bzl", "all_requirements", "all_whl_requirements", "requirement")
+load("@pip//:requirements.bzl", "all_data_requirements", "all_requirements", "all_whl_requirements", "requirement")
 load("@python_3_9//:defs.bzl", py_test_with_transition = "py_test")
 load("@python_aliases//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
 load("@python_aliases//3.9:defs.bzl", compile_pip_requirements_3_9 = "compile_pip_requirements")

--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -84,6 +84,11 @@ build_test(
 )
 
 build_test(
+    name = "all_data_requirements",
+    targets = all_data_requirements,
+)
+
+build_test(
     name = "all_requirements",
     targets = all_requirements,
 )

--- a/examples/pip_parse_vendored/requirements.bzl
+++ b/examples/pip_parse_vendored/requirements.bzl
@@ -11,6 +11,8 @@ all_requirements = ["@pip_certifi//:pkg", "@pip_charset_normalizer//:pkg", "@pip
 
 all_whl_requirements = ["@pip_certifi//:whl", "@pip_charset_normalizer//:whl", "@pip_idna//:whl", "@pip_requests//:whl", "@pip_urllib3//:whl"]
 
+all_data_requirements = ["@pip_certifi//:data", "@pip_charset_normalizer//:data", "@pip_idna//:data", "@pip_requests//:data", "@pip_urllib3//:data"]
+
 _packages = [("pip_certifi", "certifi==2022.12.7     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"), ("pip_charset_normalizer", "charset-normalizer==2.1.1     --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845     --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"), ("pip_idna", "idna==3.4     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"), ("pip_requests", "requests==2.28.1     --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983     --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"), ("pip_urllib3", "urllib3==1.26.13     --hash=sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc     --hash=sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8")]
 _config = {"download_only": False, "enable_implicit_namespace_pkgs": False, "environment": {}, "extra_pip_args": [], "isolated": True, "pip_data_exclude": [], "python_interpreter": "python3", "python_interpreter_target": interpreter, "quiet": True, "repo": "pip", "repo_prefix": "pip_", "timeout": 600}
 _annotations = {}

--- a/python/pip_install/pip_hub_repository_requirements_bzlmod.bzl.tmpl
+++ b/python/pip_install/pip_hub_repository_requirements_bzlmod.bzl.tmpl
@@ -11,6 +11,8 @@ all_requirements = %%ALL_REQUIREMENTS%%
 
 all_whl_requirements = %%ALL_WHL_REQUIREMENTS%%
 
+all_data_requirements = %%ALL_DATA_REQUIREMENTS%%
+
 def _clean_name(name):
     return name.replace("-", "_").replace(".", "_").lower()
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -330,16 +330,16 @@ def _create_pip_repository_bzlmod(rctx, bzl_packages, requirements):
 
     rctx.file("BUILD.bazel", build_contents)
     rctx.template("requirements.bzl", rctx.attr._template, substitutions = {
+        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
+            macro_tmpl.format(p, "data")
+            for p in bzl_packages
+        ]),
         "%%ALL_REQUIREMENTS%%": _format_repr_list([
             macro_tmpl.format(p, p)
             for p in bzl_packages
         ]),
         "%%ALL_WHL_REQUIREMENTS%%": _format_repr_list([
             macro_tmpl.format(p, "whl")
-            for p in bzl_packages
-        ]),
-        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
-            macro_tmpl.format(p, "data")
             for p in bzl_packages
         ]),
         "%%MACRO_TMPL%%": macro_tmpl,
@@ -465,16 +465,16 @@ def _pip_repository_impl(rctx):
 
     rctx.file("BUILD.bazel", _BUILD_FILE_CONTENTS)
     rctx.template("requirements.bzl", rctx.attr._template, substitutions = {
+        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
+            "@{}//{}:data".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:data".format(rctx.attr.name, p)
+            for p in bzl_packages
+        ]),
         "%%ALL_REQUIREMENTS%%": _format_repr_list([
             "@{}//{}".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:pkg".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
         "%%ALL_WHL_REQUIREMENTS%%": _format_repr_list([
             "@{}//{}:whl".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:whl".format(rctx.attr.name, p)
-            for p in bzl_packages
-        ]),
-        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
-            "@{}//{}:data".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:data".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
         "%%ANNOTATIONS%%": _format_dict(_repr_dict(annotations)),

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -338,6 +338,10 @@ def _create_pip_repository_bzlmod(rctx, bzl_packages, requirements):
             macro_tmpl.format(p, "whl")
             for p in bzl_packages
         ]),
+        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
+            macro_tmpl.format(p, "data")
+            for p in bzl_packages
+        ]),
         "%%MACRO_TMPL%%": macro_tmpl,
         "%%NAME%%": rctx.attr.name,
         "%%REQUIREMENTS_LOCK%%": requirements,
@@ -467,6 +471,10 @@ def _pip_repository_impl(rctx):
         ]),
         "%%ALL_WHL_REQUIREMENTS%%": _format_repr_list([
             "@{}//{}:whl".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:whl".format(rctx.attr.name, p)
+            for p in bzl_packages
+        ]),
+        "%%ALL_DATA_REQUIREMENTS%%": _format_repr_list([
+            "@{}//{}:data".format(rctx.attr.name, p) if rctx.attr.incompatible_generate_aliases else "@{}_{}//:data".format(rctx.attr.name, p)
             for p in bzl_packages
         ]),
         "%%ANNOTATIONS%%": _format_dict(_repr_dict(annotations)),

--- a/python/pip_install/pip_repository_requirements.bzl.tmpl
+++ b/python/pip_install/pip_repository_requirements.bzl.tmpl
@@ -10,6 +10,8 @@ all_requirements = %%ALL_REQUIREMENTS%%
 
 all_whl_requirements = %%ALL_WHL_REQUIREMENTS%%
 
+all_data_requirements = %%ALL_DATA_REQUIREMENTS%%
+
 _packages = %%PACKAGES%%
 _config = %%CONFIG%%
 _annotations = %%ANNOTATIONS%%

--- a/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
+++ b/python/pip_install/pip_repository_requirements_bzlmod.bzl.tmpl
@@ -8,6 +8,8 @@ all_requirements = %%ALL_REQUIREMENTS%%
 
 all_whl_requirements = %%ALL_WHL_REQUIREMENTS%%
 
+all_data_requirements = %%ALL_DATA_REQUIREMENTS%%
+
 def _clean_name(name):
     return name.replace("-", "_").replace(".", "_").lower()
 


### PR DESCRIPTION
Minor change.

I am creating a Python virtualenv with Bazel, and having `all_data_requirements` for data dependencies just like `all_requirements` would be very helpful.
