### PR TITLE
feat(gazelle): support multiple requirements files in manifest generation

### DIFF
--- a/examples/build_file_generation/BUILD.bazel
+++ b/examples/build_file_generation/BUILD.bazel
@@ -42,6 +42,8 @@ gazelle_python_manifest(
     name = "gazelle_python_manifest",
     modules_mapping = ":modules_map",
     pip_repository_name = "pip",
+    # NOTE: We can pass a list just like in `bzlmod_build_file_generation` example
+    # but we keep a single target here for regression testing.
     requirements = "//:requirements_lock.txt",
     # NOTE: we can use this flag in order to make our setup compatible with
     # bzlmod.

--- a/examples/bzlmod_build_file_generation/BUILD.bazel
+++ b/examples/bzlmod_build_file_generation/BUILD.bazel
@@ -49,7 +49,10 @@ gazelle_python_manifest(
     name = "gazelle_python_manifest",
     modules_mapping = ":modules_map",
     pip_repository_name = "pip",
-    requirements = "//:requirements_lock.txt",
+    requirements = [
+        "//:requirements_lock.txt",
+        "//:requirements_windows.txt",
+    ],
     # NOTE: we can use this flag in order to make our setup compatible with
     # bzlmod.
     use_pip_repository_aliases = True,

--- a/examples/bzlmod_build_file_generation/gazelle_python.yaml
+++ b/examples/bzlmod_build_file_generation/gazelle_python.yaml
@@ -232,6 +232,7 @@ manifest:
     isort.wrap: isort
     isort.wrap_modes: isort
     lazy_object_proxy: lazy_object_proxy
+    lazy_object_proxy.cext: lazy_object_proxy
     lazy_object_proxy.compat: lazy_object_proxy
     lazy_object_proxy.simple: lazy_object_proxy
     lazy_object_proxy.slots: lazy_object_proxy
@@ -587,4 +588,4 @@ manifest:
   pip_repository:
     name: pip
     use_pip_repository_aliases: true
-integrity: d979738b10adbbaff0884837e4414688990491c6c40f6a25d58b9bb564411477
+integrity: cee7684391c4a8a1ff219cd354deae61cdcdee70f2076789aabd5249f3c4eca9

--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -30,7 +30,9 @@ def gazelle_python_manifest(
 
     Args:
         name: the name used as a base for the targets.
-        requirements: the target for the requirements.txt file.
+        requirements: the target for the requirements.txt file or a list of
+            requirements files that will be concatenated before passing on to
+            the manifest generator.
         pip_repository_name: the name of the pip_install or pip_repository target.
         use_pip_repository_aliases: boolean flag to enable using user-friendly
             python package aliases.
@@ -54,6 +56,16 @@ def gazelle_python_manifest(
     update_target_label = "//{}:{}".format(native.package_name(), update_target)
 
     manifest_generator_hash = Label("//manifest/generate:generate_lib_sources_hash")
+
+    if type(requirements) == "list":
+        native.genrule(
+            name = name + "_requirements_gen",
+            srcs = sorted(requirements),
+            outs = [name + "_requirements.txt"],
+            cmd_bash = "cat $(SRCS) > $@",
+            cmd_bat = "type $(SRCS) > $@",
+        )
+        requirements = name + "_requirements_gen"
 
     update_args = [
         "--manifest-generator-hash",


### PR DESCRIPTION
For certain workflows it is useful to calculate the integrity hash of
the manifest file based on a number of requirements files. The
requirements locking is usually done by executing a script on each
platform and having gazelle manifest generator be aware that more than
one requirements file may affect the outcome (e.g. the wheels that get
passed to modules map may come from multi_pip_parse rule) is generally
useful.

This change modifies the generation macro to concatenate the requirements
files into one before passing it to the manifest generator.
