### PR TITLE
feat(bzlmod): Use a common constant for detecting bzlmod being enabled

### DIFF
--- a/python/cc/BUILD.bazel
+++ b/python/cc/BUILD.bazel
@@ -1,8 +1,8 @@
 # Package for C/C++ specific functionality of the Python rules.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load("//python/private:current_py_cc_headers.bzl", "current_py_cc_headers")
-load("//python/private:util.bzl", "BZLMOD_ENABLED")
 
 package(
     default_visibility = ["//:__subpackages__"],

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -16,6 +16,7 @@
 load("//python/pip_install:pip_repository.bzl", "pip_repository", _package_annotation = "package_annotation")
 load("//python/pip_install:repositories.bzl", "pip_install_dependencies")
 load("//python/pip_install:requirements.bzl", _compile_pip_requirements = "compile_pip_requirements")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load(":versions.bzl", "MINOR_MAPPING")
 
 compile_pip_requirements = _compile_pip_requirements
@@ -286,7 +287,7 @@ def _whl_library_render_alias_target(
         wheel_name):
     # The template below adds one @, but under bzlmod, the name
     # is canonical, so we have to add a second @.
-    if str(Label("//:unused")).startswith("@@"):
+    if BZLMOD_ENABLED:
         rules_python = "@" + rules_python
     alias = ["""\
 alias(

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -19,6 +19,7 @@ load("//python:versions.bzl", "WINDOWS_NAME")
 load("//python/pip_install:repositories.bzl", "all_requirements")
 load("//python/pip_install:requirements_parser.bzl", parse_requirements = "parse")
 load("//python/pip_install/private:srcs.bzl", "PIP_INSTALL_PY_SRCS")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load("//python/private:toolchains_repo.bzl", "get_host_os_arch")
 
 CPPFLAGS = "CPPFLAGS"
@@ -76,8 +77,7 @@ def _resolve_python_interpreter(rctx):
     if rctx.attr.python_interpreter_target != None:
         python_interpreter = rctx.path(rctx.attr.python_interpreter_target)
 
-        # If we have @@ we have bzlmod so we need to hand Windows differently.
-        if str(Label("//:unused")).startswith("@@"):
+        if BZLMOD_ENABLED:
             (os, _) = get_host_os_arch(rctx)
 
             # On Windows, the symlink doesn't work because Windows attempts to find

--- a/python/private/bzlmod_enabled.bzl
+++ b/python/private/bzlmod_enabled.bzl
@@ -1,0 +1,18 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Variable to check if bzlmod is enabled"""
+
+# When bzlmod is enabled, canonical repos names have @@ in them, while under
+# workspace builds, there is never a @@ in labels.
+BZLMOD_ENABLED = "@@" in str(Label("//:unused"))

--- a/python/private/util.bzl
+++ b/python/private/util.bzl
@@ -16,10 +16,6 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 
-# When bzlmod is enabled, canonical repos names have @@ in them, while under
-# workspace builds, there is never a @@ in labels.
-BZLMOD_ENABLED = "@@" in str(Label("//:unused"))
-
 def copy_propagating_kwargs(from_kwargs, into_kwargs = None):
     """Copies args that must be compatible between two targets with a dependency relationship.
 

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -19,6 +19,7 @@ For historic reasons, pip_repositories() is defined in //python:pip.bzl.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load("//python/private:coverage_deps.bzl", "coverage_dep")
 load(
     "//python/private:toolchains_repo.bzl",
@@ -498,9 +499,7 @@ def python_register_toolchains(
         **kwargs: passed to each python_repositories call.
     """
 
-    # If we have @@ we have bzlmod
-    bzlmod = str(Label("//:unused")).startswith("@@")
-    if bzlmod:
+    if BZLMOD_ENABLED:
         # you cannot used native.register_toolchains when using bzlmod.
         register_toolchains = False
 
@@ -580,7 +579,7 @@ def python_register_toolchains(
     )
 
     # in bzlmod we write out our own toolchain repos
-    if bzlmod:
+    if BZLMOD_ENABLED:
         return
 
     toolchains_repo(


### PR DESCRIPTION
Various parts of the codebase detect whether bzlmod is enabled or not. Most of them copy/paste the same if @ in Label(..) trick and use a comment to explain what they're doing.

Rather than copy/paste that everywhere, this commit uses a constant defined that does this once and reuses the constant value to determine if bzlmod is enabled.

Closes: https://github.com/bazelbuild/rules_python/issues/1295