### PR TITLE
feat(bzlmod): Allow bzlmod pip.parse to reference the default python toolchain and interpreter

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -11,6 +11,10 @@ local_path_override(
     path = "../..",
 )
 
+# Setting python.toolchain is optional as rules_python
+# sets a toolchain for you, using the latest supported version
+# of Python.  We do recomend that you set a version here.
+
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
@@ -87,9 +91,10 @@ use_repo(pip, "whl_mods_hub")
 # call.
 # Alternatively, `python_interpreter_target` can be used to directly specify
 # the Python interpreter to run to resolve dependencies.
+# Because we do not have a python_version defined here
+# pip.parse uses the python toolchain that is set as default.
 pip.parse(
     hub_name = "pip",
-    python_version = "3.9",
     requirements_lock = "//:requirements_lock_3_9.txt",
     requirements_windows = "//:requirements_windows_3_9.txt",
     # These modifications were created above and we

--- a/python/extensions/pip.bzl
+++ b/python/extensions/pip.bzl
@@ -347,14 +347,16 @@ Targets from different hubs should not be used together.
 """,
         ),
         "python_version": attr.string(
-            mandatory = True,
+            default = DEFAULT_PYTHON_VERSION,
             doc = """
 The Python version to use for resolving the pip dependencies. If not specified,
 then the default Python version (as set by the root module or rules_python)
 will be used.
 
 The version specified here must have a corresponding `python.toolchain()`
-configured.
+configured. This attribute defaults to the version of the toolchain
+that is set as the default Python version.  Or if only one toolchain
+is used, this attribute defaults to that version of Python.
 """,
         ),
         "whl_modifications": attr.label_keyed_string_dict(


### PR DESCRIPTION
This commit defaults `the pip.parse` `python_version` attribute to the default version of
Python, as configured by the `python.toolchain` extension. This allows a user to use the
Python version set by rules_python or the root module. Also, this makes setting the
attribute optional (as it has a default) and we automatically select the interpreter.

Closes #1267