### PR TITLE
fix(bzlmod)!: Changing repository name "python_aliases" to "python_versions"

### DIFF
--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -8,8 +8,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@pip//:requirements.bzl", "all_requirements", "all_whl_requirements", "requirement")
 load("@python_3_9//:defs.bzl", py_test_with_transition = "py_test")
-load("@python_aliases//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
-load("@python_aliases//3.9:defs.bzl", compile_pip_requirements_3_9 = "compile_pip_requirements")
+load("@python_versions//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
+load("@python_versions//3.9:defs.bzl", compile_pip_requirements_3_9 = "compile_pip_requirements")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 # This stanza calls a rule that generates targets for managing pip dependencies

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -35,7 +35,7 @@ python.toolchain(
 # See the tests folder for various examples on using multiple Python versions.
 # The names "python_3_9" and "python_3_10" are autmatically created by the repo
 # rules based on the `python_version` arg values.
-use_repo(python, "python_3_10", "python_3_9", "python_aliases")
+use_repo(python, "python_3_10", "python_3_9", "python_versions")
 
 # This extension allows a user to create modifications to how rules_python
 # creates different wheel repositories.  Different attributes allow the user

--- a/examples/bzlmod/tests/BUILD.bazel
+++ b/examples/bzlmod/tests/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@python_aliases//3.10:defs.bzl", py_binary_3_10 = "py_binary", py_test_3_10 = "py_test")
-load("@python_aliases//3.11:defs.bzl", py_binary_3_11 = "py_binary", py_test_3_11 = "py_test")
-load("@python_aliases//3.9:defs.bzl", py_binary_3_9 = "py_binary", py_test_3_9 = "py_test")
+load("@python_versions//3.10:defs.bzl", py_binary_3_10 = "py_binary", py_test_3_10 = "py_test")
+load("@python_versions//3.11:defs.bzl", py_binary_3_11 = "py_binary", py_test_3_11 = "py_test")
+load("@python_versions//3.9:defs.bzl", py_binary_3_9 = "py_binary", py_test_3_9 = "py_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 py_binary(

--- a/python/extensions/python.bzl
+++ b/python/extensions/python.bzl
@@ -163,7 +163,7 @@ def _python_impl(module_ctx):
     # This is require in order to support multiple version py_test
     # and py_binary
     multi_toolchain_aliases(
-        name = "python_aliases",
+        name = "python_versions",
         python_versions = {
             version: entry.toolchain_name
             for version, entry in global_toolchain_versions.items()


### PR DESCRIPTION
I think this name is more informative for a public API. The functionality it exposes are rules/macros that use a specific Python version to be used. These aren't really aliases.

This commit renames "python_aliases" to "python_versions". This isn't technically a breaking
change because bzlmod support is still beta, but we'll flag it as such just in case.

BREAKING CHANGE:
  * The `python_aliases` repo is renamed to `python_versions`. You will need to either
    update references from `@python_aliases` to `@python_versions`, or use repo-remapping
    to alias the old name (`use_repo(python, python_aliases="python_versions")`)

Closes #1273