### PR TITLE
doc: correct name of rules_python in bzlmod support doc

### DIFF
--- a/BZLMOD_SUPPORT.md
+++ b/BZLMOD_SUPPORT.md
@@ -1,6 +1,6 @@
 # Bzlmod support
 
-## `rule_python` `bzlmod` support
+## `rules_python` `bzlmod` support
 
 - Status: Beta
 - Full Feature Parity: No


### PR DESCRIPTION
The project name was misspelled as "rule_python"; corrected to "rules_python"