### PR TITLE
cleanup: Add placeholder comment to defs.bzl to make patching loads easier

### DIFF
--- a/python/defs.bzl
+++ b/python/defs.bzl
@@ -24,6 +24,8 @@ load("//python:py_test.bzl", _py_test = "py_test")
 load(":current_py_toolchain.bzl", _current_py_toolchain = "current_py_toolchain")
 load(":py_import.bzl", _py_import = "py_import")
 
+# Patching placeholder: end of loads
+
 # Exports of native-defined providers.
 
 PyInfo = internal_PyInfo


### PR DESCRIPTION
This just adds a no-op comment to defs.bzl to make patching its load statements easier.

Rather than looking for the last load (or the conveniently loaded "# Export ..." comment),
just have an explicit comment for it.