### PR TITLE
test: Remove testonly=True from test toolchain implementations

### DIFF
--- a/tests/cc/BUILD.bazel
+++ b/tests/cc/BUILD.bazel
@@ -28,7 +28,6 @@ toolchain(
 
 py_cc_toolchain(
     name = "fake_py_cc_toolchain_impl",
-    testonly = True,
     headers = ":fake_headers",
     python_version = "3.999",
     tags = PREVENT_IMPLICIT_BUILDING_TAGS,
@@ -37,7 +36,6 @@ py_cc_toolchain(
 # buildifier: disable=native-cc
 cc_library(
     name = "fake_headers",
-    testonly = True,
     hdrs = ["fake_header.h"],
     data = ["data.txt"],
     includes = ["fake_include"],


### PR DESCRIPTION
Upcoming Bazel versions enforce testonly-ness through toolchain lookup, so when `:current_py_cc_headers` depends on (via toolchain lookup) a `py_cc_toolchain(testonly=True)` target, an error occurs.

To fix, just remove testonly=True from the toolchain implementation.

Fixes #1324