### PR TITLE
feat: stop generating imports when not necessary

### DIFF
--- a/gazelle/python/target.go
+++ b/gazelle/python/target.go
@@ -122,6 +122,11 @@ func (t *targetBuilder) setTestonly() *targetBuilder {
 // case, the value we add is on Bazel sub-packages to be able to perform imports
 // relative to the root project package.
 func (t *targetBuilder) generateImportsAttribute() *targetBuilder {
+	if t.pythonProjectRoot == "" {
+		// When gazelle:python_root is not set or is at the root of the repo, we don't need
+		// to set imports, because that's the Bazel's default.
+		return t
+	}
 	p, _ := filepath.Rel(t.bzlPackage, t.pythonProjectRoot)
 	p = filepath.Clean(p)
 	if p == "." {

--- a/gazelle/python/testdata/dependency_resolution_order/bar/BUILD.out
+++ b/gazelle/python/testdata/dependency_resolution_order/bar/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "bar",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/dependency_resolution_order/baz/BUILD.out
+++ b/gazelle/python/testdata/dependency_resolution_order/baz/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "baz",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/dependency_resolution_order/foo/BUILD.out
+++ b/gazelle/python/testdata/dependency_resolution_order/foo/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "foo",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/dependency_resolution_order/somewhere/bar/BUILD.out
+++ b/gazelle/python/testdata/dependency_resolution_order/somewhere/bar/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "bar",
     srcs = ["__init__.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/first_party_file_and_directory_modules/foo/BUILD.out
+++ b/gazelle/python/testdata/first_party_file_and_directory_modules/foo/BUILD.out
@@ -6,7 +6,6 @@ py_library(
         "__init__.py",
         "bar.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//one"],
 )

--- a/gazelle/python/testdata/first_party_file_and_directory_modules/one/BUILD.out
+++ b/gazelle/python/testdata/first_party_file_and_directory_modules/one/BUILD.out
@@ -6,6 +6,5 @@ py_library(
         "__init__.py",
         "two.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/from_imports/foo/BUILD.out
+++ b/gazelle/python/testdata/from_imports/foo/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "foo",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/from_imports/import_from_init_py/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_from_init_py/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_from_init_py",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo/bar"],
 )

--- a/gazelle/python/testdata/from_imports/import_from_multiple/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_from_multiple/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_from_multiple",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//foo/bar",

--- a/gazelle/python/testdata/from_imports/import_nested_file/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_nested_file/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_nested_file",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo/bar:baz"],
 )

--- a/gazelle/python/testdata/from_imports/import_nested_module/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_nested_module/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_nested_module",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo/bar"],
 )

--- a/gazelle/python/testdata/from_imports/import_nested_var/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_nested_var/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_nested_var",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo/bar:baz"],
 )

--- a/gazelle/python/testdata/from_imports/import_top_level_var/BUILD.out
+++ b/gazelle/python/testdata/from_imports/import_top_level_var/BUILD.out
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "import_top_level_var",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo"],
 )

--- a/gazelle/python/testdata/from_imports/std_module/BUILD.out
+++ b/gazelle/python/testdata/from_imports/std_module/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "std_module",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/naming_convention/dont_rename/BUILD.out
+++ b/gazelle/python/testdata/naming_convention/dont_rename/BUILD.out
@@ -3,14 +3,12 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 py_library(
     name = "dont_rename",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
 py_binary(
     name = "my_dont_rename_binary",
     srcs = ["__main__.py"],
-    imports = [".."],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],
     deps = [":dont_rename"],
@@ -19,7 +17,6 @@ py_binary(
 py_test(
     name = "my_dont_rename_test",
     srcs = ["__test__.py"],
-    imports = [".."],
     main = "__test__.py",
     deps = [":dont_rename"],
 )

--- a/gazelle/python/testdata/naming_convention/resolve_conflict/BUILD.out
+++ b/gazelle/python/testdata/naming_convention/resolve_conflict/BUILD.out
@@ -9,14 +9,12 @@ go_test(name = "resolve_conflict_test")
 py_library(
     name = "my_resolve_conflict_library",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
 py_binary(
     name = "my_resolve_conflict_binary",
     srcs = ["__main__.py"],
-    imports = [".."],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],
     deps = [":my_resolve_conflict_library"],
@@ -25,7 +23,6 @@ py_binary(
 py_test(
     name = "my_resolve_conflict_test",
     srcs = ["__test__.py"],
-    imports = [".."],
     main = "__test__.py",
     deps = [":my_resolve_conflict_library"],
 )

--- a/gazelle/python/testdata/python_ignore_files_directive/bar/BUILD.out
+++ b/gazelle/python/testdata/python_ignore_files_directive/bar/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "bar",
     srcs = ["baz.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/relative_imports/package2/BUILD.out
+++ b/gazelle/python/testdata/relative_imports/package2/BUILD.out
@@ -8,6 +8,5 @@ py_library(
         "module4.py",
         "subpackage1/module5.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/sibling_imports/pkg/BUILD.out
+++ b/gazelle/python/testdata/sibling_imports/pkg/BUILD.out
@@ -7,20 +7,17 @@ py_library(
         "a.py",
         "b.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
 py_test(
     name = "test_util",
     srcs = ["test_util.py"],
-    imports = [".."],
 )
 
 py_test(
     name = "unit_test",
     srcs = ["unit_test.py"],
-    imports = [".."],
     deps = [
         ":pkg",
         ":test_util",

--- a/gazelle/python/testdata/simple_library_without_init/foo/BUILD.out
+++ b/gazelle/python/testdata/simple_library_without_init/foo/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "foo",
     srcs = ["foo.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/simple_test_with_conftest/bar/BUILD.out
+++ b/gazelle/python/testdata/simple_test_with_conftest/bar/BUILD.out
@@ -6,7 +6,6 @@ py_library(
         "__init__.py",
         "bar.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
@@ -14,14 +13,12 @@ py_library(
     name = "conftest",
     testonly = True,
     srcs = ["conftest.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
 py_test(
     name = "bar_test",
     srcs = ["__test__.py"],
-    imports = [".."],
     main = "__test__.py",
     deps = [
         ":bar",

--- a/gazelle/python/testdata/subdir_sources/foo/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/foo/BUILD.out
@@ -8,6 +8,5 @@ py_library(
         "baz/baz.py",
         "foo.py",
     ],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/subdir_sources/foo/has_build/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/foo/has_build/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "has_build",
     srcs = ["python/my_module.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/subdir_sources/foo/has_init/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/foo/has_init/BUILD.out
@@ -6,6 +6,5 @@ py_library(
         "__init__.py",
         "python/my_module.py",
     ],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/subdir_sources/foo/has_main/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/foo/has_main/BUILD.out
@@ -3,14 +3,12 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 py_library(
     name = "has_main",
     srcs = ["python/my_module.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_binary(
     name = "has_main_bin",
     srcs = ["__main__.py"],
-    imports = ["../.."],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],
     deps = [":has_main"],

--- a/gazelle/python/testdata/subdir_sources/foo/has_test/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/foo/has_test/BUILD.out
@@ -3,14 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 py_library(
     name = "has_test",
     srcs = ["python/my_module.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_test(
     name = "has_test_test",
     srcs = ["__test__.py"],
-    imports = ["../.."],
     main = "__test__.py",
     deps = [":has_test"],
 )

--- a/gazelle/python/testdata/subdir_sources/one/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/one/BUILD.out
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "one",
     srcs = ["__init__.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/subdir_sources/one/two/BUILD.out
+++ b/gazelle/python/testdata/subdir_sources/one/two/BUILD.out
@@ -6,7 +6,6 @@ py_library(
         "__init__.py",
         "three.py",
     ],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//foo"],
 )


### PR DESCRIPTION
When gazelle:python_root is not set or is at the root of the repo, we don't need to set imports for python rules, because that's the Bazel's default. This would reduce unnecessary verbosity.