### PR TITLE
revert(bzlmod)!: allow bzlmod pip.parse to implicitly use default python version

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -11,10 +11,6 @@ local_path_override(
     path = "../..",
 )
 
-# Setting python.toolchain is optional as rules_python
-# sets a toolchain for you, using the latest supported version
-# of Python.  We do recomend that you set a version here.
-
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
@@ -91,10 +87,9 @@ use_repo(pip, "whl_mods_hub")
 # call.
 # Alternatively, `python_interpreter_target` can be used to directly specify
 # the Python interpreter to run to resolve dependencies.
-# Because we do not have a python_version defined here
-# pip.parse uses the python toolchain that is set as default.
 pip.parse(
     hub_name = "pip",
+    python_version = "3.9",
     requirements_lock = "//:requirements_lock_3_9.txt",
     requirements_windows = "//:requirements_windows_3_9.txt",
     # These modifications were created above and we

--- a/python/extensions/pip.bzl
+++ b/python/extensions/pip.bzl
@@ -348,16 +348,14 @@ Targets from different hubs should not be used together.
 """,
         ),
         "python_version": attr.string(
-            default = DEFAULT_PYTHON_VERSION,
+            mandatory = True,
             doc = """
 The Python version to use for resolving the pip dependencies. If not specified,
 then the default Python version (as set by the root module or rules_python)
 will be used.
 
 The version specified here must have a corresponding `python.toolchain()`
-configured. This attribute defaults to the version of the toolchain
-that is set as the default Python version.  Or if only one toolchain
-is used, this attribute defaults to that version of Python.
+configured.
 """,
         ),
         "whl_modifications": attr.label_keyed_string_dict(


### PR DESCRIPTION
Reverts bazelbuild/rules_python#1303

The main issue is that `pip.parse()` accepts a locked requirements file -- this means
the requirements are specific to a particular Python version[1]. Because the default Python
version can arbitrarily change, the lock file may not be valid for the Python version
that is used at runtime. The net result is a module will use dependencies for e.g. Python
3.8, but will use 3.9 at runtime. Additionally, the dependencies resolved for 3.8 will
be created under names such as `@foo_39` (because that's the python_version pip.parse sees),
which is just more confusing.

BREAKING CHANGE:
  * pip.parse() must have `python_version` explicitly set. Set it to the Python version
    used to resolve the requirements file.

[1] Lock files aren't necessarily version specific, but we don't currently support the
environment markers in lock files to make them cross-python-version compatible.