### PR TITLE
fix: various py_proto_library fixes

### DIFF
--- a/examples/py_proto_library/.bazelignore
+++ b/examples/py_proto_library/.bazelignore
@@ -1,0 +1,1 @@
+external_workspace

--- a/examples/py_proto_library/BUILD.bazel
+++ b/examples/py_proto_library/BUILD.bazel
@@ -2,14 +2,26 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
+proto_library(
+    name = "pricetag_proto",
+    srcs = ["pricetag.proto"],
+)
+
+proto_library(
+    name = "pricetag_with_prefix_proto",
+    srcs = ["tostrip/pricetag_with_prefix.proto"],
+    import_prefix = "prefixed",
+    strip_import_prefix = "tostrip",
+)
+
 py_proto_library(
     name = "pricetag_proto_py_pb2",
     deps = [":pricetag_proto"],
 )
 
-proto_library(
-    name = "pricetag_proto",
-    srcs = ["pricetag.proto"],
+py_proto_library(
+    name = "pricetag_with_prefix_proto_py_pb2",
+    deps = [":pricetag_with_prefix_proto"],
 )
 
 py_test(
@@ -18,5 +30,32 @@ py_test(
     main = "test.py",
     deps = [
         ":pricetag_proto_py_pb2",
+    ],
+)
+
+py_test(
+    name = "pricetag_with_prefix_test",
+    srcs = ["test_with_prefix.py"],
+    main = "test_with_prefix.py",
+    deps = [
+        ":pricetag_with_prefix_proto_py_pb2",
+    ],
+)
+
+py_test(
+    name = "external_test",
+    srcs = ["external_test.py"],
+    main = "external_test.py",
+    deps = [
+        "@external_workspace//:external_pricetag_proto_py_pb2",
+    ],
+)
+
+py_test(
+    name = "external_with_prefix_test",
+    srcs = ["external_with_prefix_test.py"],
+    main = "external_with_prefix_test.py",
+    deps = [
+        "@external_workspace//:external_pricetag_with_prefix_proto_py_pb2",
     ],
 )

--- a/examples/py_proto_library/BUILD.bazel
+++ b/examples/py_proto_library/BUILD.bazel
@@ -7,21 +7,9 @@ proto_library(
     srcs = ["pricetag.proto"],
 )
 
-proto_library(
-    name = "pricetag_with_prefix_proto",
-    srcs = ["tostrip/pricetag_with_prefix.proto"],
-    import_prefix = "prefixed",
-    strip_import_prefix = "tostrip",
-)
-
 py_proto_library(
     name = "pricetag_proto_py_pb2",
     deps = [":pricetag_proto"],
-)
-
-py_proto_library(
-    name = "pricetag_with_prefix_proto_py_pb2",
-    deps = [":pricetag_with_prefix_proto"],
 )
 
 py_test(
@@ -33,6 +21,21 @@ py_test(
     ],
 )
 
+# if you use import_prefix or strip_import_prefix on a proto_library the resulting python module path will be altered
+# without stripping "tostrip" our module path would have been tostrip.pricetag_with_prefix_pb2
+# after stripping, the prefix is added, resulting in the path being prefixed.pricetag_with_prefix_pb2
+proto_library(
+    name = "pricetag_with_prefix_proto",
+    srcs = ["tostrip/pricetag_with_prefix.proto"],
+    import_prefix = "prefixed",
+    strip_import_prefix = "tostrip",
+)
+
+py_proto_library(
+    name = "pricetag_with_prefix_proto_py_pb2",
+    deps = [":pricetag_with_prefix_proto"],
+)
+
 py_test(
     name = "pricetag_with_prefix_test",
     srcs = ["test_with_prefix.py"],
@@ -42,6 +45,8 @@ py_test(
     ],
 )
 
+# see external_workspace/BUILD.bazel for the definitions of the dependencies in these tests
+# when consuming py_proto_libraries in different workspaces, the external worksapce name is the first element of the import path
 py_test(
     name = "external_test",
     srcs = ["external_test.py"],
@@ -51,6 +56,7 @@ py_test(
     ],
 )
 
+# note that for stripped or prefixed proto_libraries in external worksaces, you do not need the external workspace name
 py_test(
     name = "external_with_prefix_test",
     srcs = ["external_with_prefix_test.py"],

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -6,6 +6,7 @@ local_repository(
     path = "../..",
 )
 
+# this is used to simulate py_proto_libraries in an external workspace
 local_repository(
     name = "external_workspace",
     path = "external_workspace",

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -6,6 +6,11 @@ local_repository(
     path = "../..",
 )
 
+local_repository(
+    name = "external_workspace",
+    path = "external_workspace",
+)
+
 # When not using this example in the rules_python git repo you would load the python
 # rules using http_archive(), as documented in the release notes.
 

--- a/examples/py_proto_library/WORKSPACE.bzlmod
+++ b/examples/py_proto_library/WORKSPACE.bzlmod
@@ -1,3 +1,4 @@
+# this is used to simulate py_proto_libraries in an external workspace
 local_repository(
     name = "external_workspace",
     path = "external_workspace",

--- a/examples/py_proto_library/WORKSPACE.bzlmod
+++ b/examples/py_proto_library/WORKSPACE.bzlmod
@@ -1,0 +1,4 @@
+local_repository(
+    name = "external_workspace",
+    path = "external_workspace",
+)

--- a/examples/py_proto_library/external_test.py
+++ b/examples/py_proto_library/external_test.py
@@ -1,11 +1,12 @@
 import sys
 import unittest
 
-import pricetag_pb2
+import external_workspace.external_pricetag_pb2
+
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
-        got = pricetag_pb2.PriceTag(
+        got = external_workspace.external_pricetag_pb2.PriceTag(
             name="dollar",
             cost=5.00,
         )

--- a/examples/py_proto_library/external_test.py
+++ b/examples/py_proto_library/external_test.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import unittest
 
@@ -6,6 +20,7 @@ import external_workspace.external_pricetag_pb2
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
+        # trivial test to verify the pb2 module is loaded and works
         got = external_workspace.external_pricetag_pb2.PriceTag(
             name="dollar",
             cost=5.00,

--- a/examples/py_proto_library/external_with_prefix_test.py
+++ b/examples/py_proto_library/external_with_prefix_test.py
@@ -1,9 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 import external_prefixed.external_pricetag_pb2
 
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
+        # trivial test to verify the pb2 module is loaded and works
         got = external_prefixed.external_pricetag_pb2.PriceTag(
             name="dollar",
             cost=5.00,

--- a/examples/py_proto_library/external_with_prefix_test.py
+++ b/examples/py_proto_library/external_with_prefix_test.py
@@ -1,11 +1,10 @@
-import sys
 import unittest
+import external_prefixed.external_pricetag_pb2
 
-import pricetag_pb2
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
-        got = pricetag_pb2.PriceTag(
+        got = external_prefixed.external_pricetag_pb2.PriceTag(
             name="dollar",
             cost=5.00,
         )

--- a/examples/py_proto_library/external_workspace/BUILD.bazel
+++ b/examples/py_proto_library/external_workspace/BUILD.bazel
@@ -1,9 +1,18 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
+# this package simulates usage of py_proto_library in an external repo
+# the definitions are mostly the same as the main build file but will be under @external_workspace//
+
 proto_library(
     name = "external_pricetag_proto",
     srcs = ["external_pricetag.proto"],
+)
+
+py_proto_library(
+    name = "external_pricetag_proto_py_pb2",
+    visibility = ["//visibility:public"],
+    deps = [":external_pricetag_proto"],
 )
 
 proto_library(
@@ -14,13 +23,7 @@ proto_library(
 )
 
 py_proto_library(
-    name = "external_pricetag_proto_py_pb2",
-    deps = [":external_pricetag_proto"],
-    visibility = ["//visibility:public"],
-)
-
-py_proto_library(
     name = "external_pricetag_with_prefix_proto_py_pb2",
-    deps = [":external_pricetag_with_prefix_proto"],
     visibility = ["//visibility:public"],
+    deps = [":external_pricetag_with_prefix_proto"],
 )

--- a/examples/py_proto_library/external_workspace/BUILD.bazel
+++ b/examples/py_proto_library/external_workspace/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
+
+proto_library(
+    name = "external_pricetag_proto",
+    srcs = ["external_pricetag.proto"],
+)
+
+proto_library(
+    name = "external_pricetag_with_prefix_proto",
+    srcs = ["tostrip/external_pricetag.proto"],
+    import_prefix = "external_prefixed",
+    strip_import_prefix = "tostrip",
+)
+
+py_proto_library(
+    name = "external_pricetag_proto_py_pb2",
+    deps = [":external_pricetag_proto"],
+    visibility = ["//visibility:public"],
+)
+
+py_proto_library(
+    name = "external_pricetag_with_prefix_proto_py_pb2",
+    deps = [":external_pricetag_with_prefix_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/py_proto_library/external_workspace/external_pricetag.proto
+++ b/examples/py_proto_library/external_workspace/external_pricetag.proto
@@ -1,1 +1,8 @@
-../pricetag.proto
+syntax = "proto3";
+
+package rules_python;
+
+message PriceTag {
+  string name = 2;
+  double cost = 1;
+}

--- a/examples/py_proto_library/external_workspace/external_pricetag.proto
+++ b/examples/py_proto_library/external_workspace/external_pricetag.proto
@@ -1,0 +1,1 @@
+../pricetag.proto

--- a/examples/py_proto_library/external_workspace/tostrip/external_pricetag.proto
+++ b/examples/py_proto_library/external_workspace/tostrip/external_pricetag.proto
@@ -1,1 +1,8 @@
-../../pricetag.proto
+syntax = "proto3";
+
+package rules_python;
+
+message PriceTag {
+  string name = 2;
+  double cost = 1;
+}

--- a/examples/py_proto_library/external_workspace/tostrip/external_pricetag.proto
+++ b/examples/py_proto_library/external_workspace/tostrip/external_pricetag.proto
@@ -1,0 +1,1 @@
+../../pricetag.proto

--- a/examples/py_proto_library/test.py
+++ b/examples/py_proto_library/test.py
@@ -1,10 +1,26 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import unittest
 
 import pricetag_pb2
 
+
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
+        # trivial test to verify the pb2 module is loaded and works
         got = pricetag_pb2.PriceTag(
             name="dollar",
             cost=5.00,

--- a/examples/py_proto_library/test_with_prefix.py
+++ b/examples/py_proto_library/test_with_prefix.py
@@ -1,11 +1,10 @@
-import sys
 import unittest
+import prefixed.pricetag_with_prefix_pb2
 
-import pricetag_pb2
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
-        got = pricetag_pb2.PriceTag(
+        got = prefixed.pricetag_with_prefix_pb2.PriceTag(
             name="dollar",
             cost=5.00,
         )

--- a/examples/py_proto_library/test_with_prefix.py
+++ b/examples/py_proto_library/test_with_prefix.py
@@ -1,9 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 import prefixed.pricetag_with_prefix_pb2
 
 
 class TestCase(unittest.TestCase):
     def test_pricetag(self):
+        # trivial test to verify the pb2 module is loaded and works
         got = prefixed.pricetag_with_prefix_pb2.PriceTag(
             name="dollar",
             cost=5.00,

--- a/examples/py_proto_library/tostrip/pricetag_with_prefix.proto
+++ b/examples/py_proto_library/tostrip/pricetag_with_prefix.proto
@@ -1,1 +1,8 @@
-../pricetag.proto
+syntax = "proto3";
+
+package rules_python;
+
+message PriceTag {
+  string name = 2;
+  double cost = 1;
+}

--- a/examples/py_proto_library/tostrip/pricetag_with_prefix.proto
+++ b/examples/py_proto_library/tostrip/pricetag_with_prefix.proto
@@ -1,0 +1,1 @@
+../pricetag.proto

--- a/python/private/proto/BUILD.bazel
+++ b/python/private/proto/BUILD.bazel
@@ -37,6 +37,20 @@ bzl_library(
 
 proto_lang_toolchain(
     name = "python_toolchain",
+    blacklisted_protos = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:compiler_plugin_proto",
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:field_mask_proto",
+        "@com_google_protobuf//:source_context_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:type_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
     command_line = "--python_out=%s",
     progress_message = "Generating Python proto_library %{label}",
     runtime = "@com_google_protobuf//:protobuf_python",

--- a/python/private/proto/BUILD.bazel
+++ b/python/private/proto/BUILD.bazel
@@ -37,6 +37,9 @@ bzl_library(
 
 proto_lang_toolchain(
     name = "python_toolchain",
+    # proto_common will generate extraneous pb2 files for the built-in proto files unless we blacklist them here
+    # these proto files already have implementation in the runtime which we are implicitly adding as a dependency
+    # to all py_proto_libraries
     blacklisted_protos = [
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:api_proto",

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -229,9 +229,6 @@ proto_library(
 )
 ```""",
     attrs = {
-        "_proto_toolchain": attr.label(
-            default = ":python_toolchain",
-        ),
         "deps": attr.label_list(
             doc = """
               The list of `proto_library` rules to generate Python libraries for.
@@ -240,6 +237,9 @@ proto_library(
               It can be any target providing `ProtoInfo`.""",
             providers = [ProtoInfo],
             aspects = [_py_proto_aspect],
+        ),
+        "_proto_toolchain": attr.label(
+            default = ":python_toolchain",
         ),
     },
     provides = [PyInfo],

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -37,7 +37,10 @@ def _get_import_path(ctx, proto_info):
     """
     Attempts to resolve the import path
 
-    This can get fairly convoluted if import prefixing/stripping is used
+    This can get fairly convoluted if import prefixing/stripping is used.
+
+    Reference from cc_proto_library which needs to do similar stuff (_get_strip_include_prefix mainly):
+    https://github.com/bazelbuild/bazel/blob/master/src/main/starlark/builtins_bzl/common/cc/cc_proto_library.bzl
     """
     proto_root = proto_info.proto_source_root
     if proto_root == "." or proto_root == ctx.label.workspace_root:


### PR DESCRIPTION
- Adds blacklisting of the well-known types in the python runtime provided by the toolchain/runtime, as this can cause duplicate generation of these protos in some cases. This conditionally tries to use proto_common.experimental_should_generate_code if it can since this API isn't necessarily stable
- Tweaks how the runtime provided protos are injected in the runfiles, the current mechanism collects and propagates this in the aspect but it seems unnecessary, as this can just be done in the terminal rule once
- Adds proper import prefixing/stripping support, including in external repos
- Adds various unit tests that verify various import prefixing/stripping and external repo import combinations