### PR TITLE
Feat: Using repo-relative labels

### DIFF
--- a/python/extensions/pip.bzl
+++ b/python/extensions/pip.bzl
@@ -15,9 +15,9 @@
 "pip module extension for use with bzlmod"
 
 load("@pythons_hub//:interpreters.bzl", "DEFAULT_PYTHON_VERSION", "INTERPRETER_LABELS")
-load("@rules_python//python:pip.bzl", "whl_library_alias")
+load("//python:pip.bzl", "whl_library_alias")
 load(
-    "@rules_python//python/pip_install:pip_repository.bzl",
+    "//python/pip_install:pip_repository.bzl",
     "locked_requirements_label",
     "pip_hub_repository_bzlmod",
     "pip_repository_attrs",
@@ -25,7 +25,7 @@ load(
     "use_isolated",
     "whl_library",
 )
-load("@rules_python//python/pip_install:requirements_parser.bzl", parse_requirements = "parse")
+load("//python/pip_install:requirements_parser.bzl", parse_requirements = "parse")
 load("//python/private:normalize_name.bzl", "normalize_name")
 load("//python/private:version_label.bzl", "version_label")
 

--- a/python/extensions/private/internal_deps.bzl
+++ b/python/extensions/private/internal_deps.bzl
@@ -8,7 +8,7 @@
 
 "Python toolchain module extension for internal rule use"
 
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
+load("//python/pip_install:repositories.bzl", "pip_install_dependencies")
 
 # buildifier: disable=unused-variable
 def _internal_deps_impl(module_ctx):


### PR DESCRIPTION
Updated two files that used 'load("@rules_python' instead of 'load("//python'.

Closes: https://github.com/bazelbuild/rules_python/issues/1296