### PR TITLE
tests: Expose test's fake_header.h so py_cc_toolchain tests can use it.

### DIFF
--- a/tests/cc/BUILD.bazel
+++ b/tests/cc/BUILD.bazel
@@ -19,6 +19,8 @@ load(":fake_cc_toolchain_config.bzl", "fake_cc_toolchain_config")
 
 package(default_visibility = ["//:__subpackages__"])
 
+exports_files(["fake_header.h"])
+
 toolchain(
     name = "fake_py_cc_toolchain",
     tags = PREVENT_IMPLICIT_BUILDING_TAGS,


### PR DESCRIPTION
Newer Bazel versions default to not exporting files by default; this explicitly exports the file so it can be referenced.
