### PR TITLE
fix: bcr releaser email

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -14,5 +14,5 @@
 
 fixedReleaser:
   login: f0rmiga
-  email: thulio@aspect.dev
+  email: 3149049+f0rmiga@users.noreply.github.com
 moduleRoots: [".", "gazelle"]


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-central-registry/pull/863.

The aspect email is no longer associated with the github user, so the CLA bot but doesn't
think think the CLA is signed. To fix, change the email the BCR PRs are published under
to an address that is associated with the github user (and thus the CLA).