### PR TITLE
feat: generate py_library per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ A brief description of the categories of changes:
   the `py_binary` rule used to build it.
 * New Python versions available: `3.8.17`, `3.9.18`, `3.10.13`, `3.11.5` using
   https://github.com/indygreg/python-build-standalone/releases/tag/20230826.
+* (gazelle) New `# gazelle:python_generation_mode file` directive to support
+  generating one `py_library` per file.
 
 ### Removed
 

--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -189,9 +189,9 @@ Python-specific directives are as follows:
 | `# gazelle:python_validate_import_statements`| `true` |
 | Controls whether the Python import statements should be validated. Can be "true" or "false" | |
 | `# gazelle:python_generation_mode`| `package` |
-| Controls the target generation mode. Can be "package" or "project" | |
+| Controls the target generation mode. Can be "file", "package", or "project" | |
 | `# gazelle:python_library_naming_convention`| `$package_name$` |
-| Controls the `py_library` naming convention. It interpolates $package_name$ with the Bazel package name. E.g. if the Bazel package name is `foo`, setting this to `$package_name$_my_lib` would result in a generated target named `foo_my_lib`. | |
+| Controls the `py_library` naming convention. It interpolates \$package_name\$ with the Bazel package name. E.g. if the Bazel package name is `foo`, setting this to `$package_name$_my_lib` would result in a generated target named `foo_my_lib`. | |
 | `# gazelle:python_binary_naming_convention` | `$package_name$_bin` |
 | Controls the `py_binary` naming convention. Follows the same interpolation rules as `python_library_naming_convention`. | |
 | `# gazelle:python_test_naming_convention` | `$package_name$_test` |
@@ -206,11 +206,15 @@ Python source files are those ending in `.py` but not ending in `_test.py`.
 First, we look for the nearest ancestor BUILD file starting from the folder
 containing the Python source file.
 
-If there is no `py_library` in this BUILD file, one is created, using the
-package name as the target's name. This makes it the default target in the
-package.
+In package generation mode, if there is no `py_library` in this BUILD file, one
+is created using the package name as the target's name. This makes it the
+default target in the package. Next, all source files are collected into the
+`srcs` of the `py_library`.
 
-Next, all source files are collected into the `srcs` of the `py_library`.
+In project generation mode, all source files in subdirectories (that don't have
+BUILD files) are also collected.
+
+In file generation mode, each file is given its own target.
 
 Finally, the `import` statements in the source files are parsed, and
 dependencies are added to the `deps` attribute.

--- a/gazelle/python/configure.go
+++ b/gazelle/python/configure.go
@@ -137,8 +137,13 @@ func (py *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 			switch pythonconfig.GenerationModeType(strings.TrimSpace(d.Value)) {
 			case pythonconfig.GenerationModePackage:
 				config.SetCoarseGrainedGeneration(false)
+				config.SetPerFileGeneration(false)
+			case pythonconfig.GenerationModeFile:
+				config.SetCoarseGrainedGeneration(false)
+				config.SetPerFileGeneration(true)
 			case pythonconfig.GenerationModeProject:
 				config.SetCoarseGrainedGeneration(true)
+				config.SetPerFileGeneration(false)
 			default:
 				err := fmt.Errorf("invalid value for directive %q: %s",
 					pythonconfig.GenerationMode, d.Value)

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -153,12 +153,17 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 				if entry.IsDir() {
 					// If we are visiting a directory, we determine if we should
 					// halt digging the tree based on a few criterias:
-					//   1. The directory has a BUILD or BUILD.bazel files. Then
+					//   1. We are using per-file generation.
+					//   2. The directory has a BUILD or BUILD.bazel files. Then
 					//       it doesn't matter at all what it has since it's a
 					//       separate Bazel package.
-					//   2. (only for package and file generation) The directory has
-					// 		 an __init__.py, __main__.py or __test__.py, meaning
-					// 		 a BUILD file will be generated.
+					//   3. (only for package generation) The directory has an
+					//       __init__.py, __main__.py or __test__.py, meaning a
+					//       BUILD file will be generated.
+					if cfg.PerFileGeneration() {
+						return fs.SkipDir
+					}
+
 					if isBazelPackage(path) {
 						boundaryPackages[path] = struct{}{}
 						return nil

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -249,7 +249,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	if cfg.PerFileGeneration() {
 		pyLibraryFilenames.Each(func(index int, filename interface{}) {
 			if filename == pyLibraryEntrypointFilename {
-				stat, err := os.Stat(filename.(string))
+				stat, err := os.Stat(filepath.Join(args.Dir, filename.(string)))
 				if err != nil {
 					log.Fatalf("ERROR: %v\n", err)
 				}

--- a/gazelle/python/kinds.go
+++ b/gazelle/python/kinds.go
@@ -49,7 +49,8 @@ var pyKinds = map[string]rule.KindInfo{
 		},
 	},
 	pyLibraryKind: {
-		MatchAny: true,
+		MatchAny:   false,
+		MatchAttrs: []string{"srcs"},
 		NonEmptyAttrs: map[string]bool{
 			"deps":       true,
 			"srcs":       true,

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -151,10 +151,10 @@ func (py *Resolver) Resolve(
 			for len(moduleParts) > 1 {
 				// Iterate back through the possible imports until
 				// a match is found.
-				// For example, "from foo.bar import baz" where bar is a variable, we should try
-				// `foo.bar.baz` first, then `foo.bar`, then `foo`. In the first case, the import could be file `baz.py`
-				// in the directory `foo/bar`.
-				// Or, the import could be variable `bar` in file `foo/bar.py`.
+				// For example, "from foo.bar import baz" where baz is a module, we should try `foo.bar.baz` first, then
+				// `foo.bar`, then `foo`.
+				// In the first case, the import could be file `baz.py` in the directory `foo/bar`.
+				// Or, the import could be variable `baz` in file `foo/bar.py`.
 				// The import could also be from a standard module, e.g. `six.moves`, where
 				// the dependency is actually `six`.
 				moduleParts = moduleParts[:len(moduleParts)-1]

--- a/gazelle/python/testdata/dont_rename_target/BUILD.in
+++ b/gazelle/python/testdata/dont_rename_target/BUILD.in
@@ -2,4 +2,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
     name = "my_custom_target",
+    srcs = ["__init__.py"],
 )

--- a/gazelle/python/testdata/per_file/BUILD.in
+++ b/gazelle/python/testdata/per_file/BUILD.in
@@ -1,0 +1,11 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file
+
+# This target should be kept unmodified by Gazelle.
+py_library(
+    name = "custom",
+    srcs = ["bar.py"],
+    visibility = ["//visibility:private"],
+	tags = ["cant_touch_this"],
+)

--- a/gazelle/python/testdata/per_file/BUILD.out
+++ b/gazelle/python/testdata/per_file/BUILD.out
@@ -20,4 +20,5 @@ py_library(
     name = "foo",
     srcs = ["foo.py"],
     visibility = ["//:__subpackages__"],
+    deps = [":custom"],
 )

--- a/gazelle/python/testdata/per_file/BUILD.out
+++ b/gazelle/python/testdata/per_file/BUILD.out
@@ -1,0 +1,23 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file
+
+# This target should be kept unmodified by Gazelle.
+py_library(
+    name = "custom",
+    srcs = ["bar.py"],
+    tags = ["cant_touch_this"],
+    visibility = ["//visibility:private"],
+)
+
+py_library(
+    name = "baz",
+    srcs = ["baz.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/per_file/README.md
+++ b/gazelle/python/testdata/per_file/README.md
@@ -1,0 +1,3 @@
+# Per-file generation
+
+This test case generates one `py_library` per file.

--- a/gazelle/python/testdata/per_file/README.md
+++ b/gazelle/python/testdata/per_file/README.md
@@ -1,3 +1,5 @@
 # Per-file generation
 
 This test case generates one `py_library` per file.
+
+`__init__.py` is left empty so no target is generated for it.

--- a/gazelle/python/testdata/per_file/WORKSPACE
+++ b/gazelle/python/testdata/per_file/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/per_file/bar.py
+++ b/gazelle/python/testdata/per_file/bar.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For test purposes only.

--- a/gazelle/python/testdata/per_file/baz.py
+++ b/gazelle/python/testdata/per_file/baz.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For test purposes only.

--- a/gazelle/python/testdata/per_file/foo.py
+++ b/gazelle/python/testdata/per_file/foo.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For test purposes only.

--- a/gazelle/python/testdata/per_file/test.yaml
+++ b/gazelle/python/testdata/per_file/test.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---

--- a/gazelle/python/testdata/per_file_non_empty_init/BUILD.in
+++ b/gazelle/python/testdata/per_file_non_empty_init/BUILD.in
@@ -1,0 +1,3 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file

--- a/gazelle/python/testdata/per_file_non_empty_init/BUILD.out
+++ b/gazelle/python/testdata/per_file_non_empty_init/BUILD.out
@@ -1,0 +1,16 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file
+
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    visibility = ["//:__subpackages__"],
+    deps = [":foo"],
+)
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/per_file_non_empty_init/README.md
+++ b/gazelle/python/testdata/per_file_non_empty_init/README.md
@@ -1,0 +1,3 @@
+# Per-file generation
+
+This test case generates one `py_library` per file, including `__init__.py`.

--- a/gazelle/python/testdata/per_file_non_empty_init/WORKSPACE
+++ b/gazelle/python/testdata/per_file_non_empty_init/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/per_file_non_empty_init/__init__.py
+++ b/gazelle/python/testdata/per_file_non_empty_init/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bar
+import foo

--- a/gazelle/python/testdata/per_file_non_empty_init/foo.py
+++ b/gazelle/python/testdata/per_file_non_empty_init/foo.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bar
+# For test purposes only.

--- a/gazelle/python/testdata/per_file_non_empty_init/test.yaml
+++ b/gazelle/python/testdata/per_file_non_empty_init/test.yaml
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bar
+---

--- a/gazelle/python/testdata/per_file_subdirs/BUILD.in
+++ b/gazelle/python/testdata/per_file_subdirs/BUILD.in
@@ -1,0 +1,3 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file

--- a/gazelle/python/testdata/per_file_subdirs/BUILD.out
+++ b/gazelle/python/testdata/per_file_subdirs/BUILD.out
@@ -3,13 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 # gazelle:python_generation_mode file
 
 py_library(
-    name = "baz",
-    srcs = ["baz/baz.py"],
-    visibility = ["//:__subpackages__"],
-    deps = ["//bar:foo"],
-)
-
-py_library(
     name = "foo",
     srcs = ["foo.py"],
     visibility = ["//:__subpackages__"],

--- a/gazelle/python/testdata/per_file_subdirs/BUILD.out
+++ b/gazelle/python/testdata/per_file_subdirs/BUILD.out
@@ -1,0 +1,17 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+# gazelle:python_generation_mode file
+
+py_library(
+    name = "baz",
+    srcs = ["baz/baz.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["//bar:foo"],
+)
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["//bar:__init__"],
+)

--- a/gazelle/python/testdata/per_file_subdirs/README.md
+++ b/gazelle/python/testdata/per_file_subdirs/README.md
@@ -1,0 +1,3 @@
+# Per-file generation
+
+This test case generates one `py_library` per file in subdirectories.

--- a/gazelle/python/testdata/per_file_subdirs/WORKSPACE
+++ b/gazelle/python/testdata/per_file_subdirs/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/per_file_subdirs/bar/BUILD.out
+++ b/gazelle/python/testdata/per_file_subdirs/bar/BUILD.out
@@ -1,0 +1,13 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/per_file_subdirs/bar/__init__.py
+++ b/gazelle/python/testdata/per_file_subdirs/bar/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .foo import func

--- a/gazelle/python/testdata/per_file_subdirs/bar/foo.py
+++ b/gazelle/python/testdata/per_file_subdirs/bar/foo.py
@@ -1,0 +1,16 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def func():
+    pass

--- a/gazelle/python/testdata/per_file_subdirs/baz/baz.py
+++ b/gazelle/python/testdata/per_file_subdirs/baz/baz.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from bar.foo import func

--- a/gazelle/python/testdata/per_file_subdirs/foo.py
+++ b/gazelle/python/testdata/per_file_subdirs/foo.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from bar import func

--- a/gazelle/python/testdata/per_file_subdirs/test.yaml
+++ b/gazelle/python/testdata/per_file_subdirs/test.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---

--- a/gazelle/pythonconfig/pythonconfig.go
+++ b/gazelle/pythonconfig/pythonconfig.go
@@ -78,6 +78,7 @@ const (
 	// GenerationModeProject defines the mode in which a coarse-grained target will
 	// be generated englobing sub-directories containing Python files.
 	GenerationModeProject GenerationModeType = "project"
+	GenerationModeFile    GenerationModeType = "file"
 )
 
 const (
@@ -126,6 +127,7 @@ type Config struct {
 	ignoreDependencies       map[string]struct{}
 	validateImportStatements bool
 	coarseGrainedGeneration  bool
+	perFileGeneration        bool
 	libraryNamingConvention  string
 	binaryNamingConvention   string
 	testNamingConvention     string
@@ -145,6 +147,7 @@ func New(
 		ignoreDependencies:       make(map[string]struct{}),
 		validateImportStatements: true,
 		coarseGrainedGeneration:  false,
+		perFileGeneration:        false,
 		libraryNamingConvention:  packageNameNamingConventionSubstitution,
 		binaryNamingConvention:   fmt.Sprintf("%s_bin", packageNameNamingConventionSubstitution),
 		testNamingConvention:     fmt.Sprintf("%s_test", packageNameNamingConventionSubstitution),
@@ -169,6 +172,7 @@ func (c *Config) NewChild() *Config {
 		ignoreDependencies:       make(map[string]struct{}),
 		validateImportStatements: c.validateImportStatements,
 		coarseGrainedGeneration:  c.coarseGrainedGeneration,
+		perFileGeneration:        c.perFileGeneration,
 		libraryNamingConvention:  c.libraryNamingConvention,
 		binaryNamingConvention:   c.binaryNamingConvention,
 		testNamingConvention:     c.testNamingConvention,
@@ -325,6 +329,18 @@ func (c *Config) SetCoarseGrainedGeneration(coarseGrained bool) {
 // generated or not.
 func (c *Config) CoarseGrainedGeneration() bool {
 	return c.coarseGrainedGeneration
+}
+
+// SetPerFileGneration sets whether a separate py_library target should be
+// generated for each file.
+func (c *Config) SetPerFileGeneration(perFile bool) {
+	c.perFileGeneration = perFile
+}
+
+// PerFileGeneration returns whether a separate py_library target should be
+// generated for each file.
+func (c *Config) PerFileGeneration() bool {
+	return c.perFileGeneration
 }
 
 // SetLibraryNamingConvention sets the py_library target naming convention.


### PR DESCRIPTION
fixes #1150
fixes #1323

you can no longer pre-define the name of the target by creating an empty `py_library` (see 3c84655). I don't think this was being used and it's straightforward to rename the generated per-project or per-package target if you want