### PR TITLE
fix(whl_library): avoid unnecessary repository rule restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ A brief description of the categories of changes:
 * (bzlmod) The `entry_point` macro is no longer supported and has been removed
   in favour of the `py_console_script_binary` macro for `bzlmod` users.
 
+### Fixed
+
+* (whl_library) No longer restarts repository rule when fetching external
+  dependencies improving initial build times involving external dependency
+  fetching.
+
 ## [0.25.0] - 2023-08-22
 
 ### Changed

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -74,26 +74,26 @@ def get_interpreter_dirname(rctx, python_interpreter_target):
 
     return rctx.path(Label("{}//:WORKSPACE".format(str(python_interpreter_target).split("//")[0]))).dirname
 
-def is_standalone_interpreter(rctx, python_interpreter_target):
+def is_standalone_interpreter(rctx, python_interpreter_path):
     """Query a python interpreter target for whether or not it's a rules_rust provided toolchain
 
     Args:
         rctx (repository_ctx): The repository rule's context object.
-        python_interpreter_target (Target): A target representing a python interpreter.
+        python_interpreter_path (path): A path representing the interpreter.
 
     Returns:
         bool: Whether or not the target is from a rules_python generated toolchain.
     """
 
     # Only update the location when using a hermetic toolchain.
-    if not python_interpreter_target:
+    if not python_interpreter_path:
         return False
 
     # This is a rules_python provided toolchain.
     return rctx.execute([
         "ls",
         "{}/{}".format(
-            get_interpreter_dirname(rctx, python_interpreter_target),
+            python_interpreter_path.dirname,
             STANDALONE_INTERPRETER_FILENAME,
         ),
     ]).return_code == 0

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -61,19 +61,6 @@ def py_repositories():
 
 STANDALONE_INTERPRETER_FILENAME = "STANDALONE_INTERPRETER"
 
-def get_interpreter_dirname(rctx, python_interpreter_target):
-    """Get a python interpreter target dirname.
-
-    Args:
-        rctx (repository_ctx): The repository rule's context object.
-        python_interpreter_target (Target): A target representing a python interpreter.
-
-    Returns:
-        str: The Python interpreter directory.
-    """
-
-    return rctx.path(Label("{}//:WORKSPACE".format(str(python_interpreter_target).split("//")[0]))).dirname
-
 def is_standalone_interpreter(rctx, python_interpreter_path):
     """Query a python interpreter target for whether or not it's a rules_rust provided toolchain
 


### PR DESCRIPTION
Put the `PYTHONPATH` entries used in wheel building as a default value to a
private attribute of the `whl_library` repository rule and use resolved path of
the interpreter target in creating execution environment to avoid repository
rule restarts when fetching external dependencies.

The extra private attribute on the `whl_library` removes all but one restart
and the extra refactor removes the last restart observed when running, which
also reduces the total execution time from around 50s to 43s on my machine:
```console
$ cd examples/bzlmod
$ bazel clean --expunge --async && bazel build //entry_points:yamllint
```

Fixes #1399
