### PR TITLE
refactor: add missing `//python/config_settings/private:distribution` target

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
     name = "distribution",
     srcs = glob(["*.bzl"]) + [
         "BUILD.bazel",
+        "//python/config_settings/private:distribution",
     ],
     visibility = ["//python:__pkg__"],
 )

--- a/python/config_settings/private/BUILD.bazel
+++ b/python/config_settings/private/BUILD.bazel
@@ -1,0 +1,7 @@
+filegroup(
+    name = "distribution",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//python/config_settings:__pkg__"],
+)


### PR DESCRIPTION
I'm working on adding a new pip package download rule to the repo
called `pypi_install`. For that, I set up a new
`examples/pypi_install` directory. When I imported `rules_python` via
a `local_repository`, however, the build complained about missing
files. This patch aims to fix that issue by making the missing files
available.

I tried copying the other `distribution` targets when creating this
one.