### PR TITLE
fix: don't set distribs in version transitioning rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ A brief description of the categories of changes:
 
 ## Unreleased
 
+### Changed
+* (multi-version) The `distribs` attribute is no longer propagated. This
+  attribute has been long deprecated by Bazel and shouldn't be used.
+
 ### Added
 
 * (bzlmod, entry_point) Added

--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -152,7 +152,6 @@ def _py_rule(rule_impl, transition_rule, name, python_version, **kwargs):
     # https://bazel.build/reference/be/common-definitions#common-attributes
     compatible_with = kwargs.pop("compatible_with", None)
     deprecation = kwargs.pop("deprecation", None)
-    distribs = kwargs.pop("distribs", None)
     exec_compatible_with = kwargs.pop("exec_compatible_with", None)
     exec_properties = kwargs.pop("exec_properties", None)
     features = kwargs.pop("features", None)
@@ -166,7 +165,6 @@ def _py_rule(rule_impl, transition_rule, name, python_version, **kwargs):
     common_attrs = {
         "compatible_with": compatible_with,
         "deprecation": deprecation,
-        "distribs": distribs,
         "exec_compatible_with": exec_compatible_with,
         "exec_properties": exec_properties,
         "features": features,


### PR DESCRIPTION
This makes the version-aware transition rule compatible with an upcoming Bazel change that
disallows setting unknown attributes to None (the `distribs` attribute, in this case).

The `distribs` attribute was common to all rules, but it has been long deprecated and
it won't be part of every rule in upcoming Bazel versions. The previous implementation
resulted in setting `distribs = None` on the target. Bazel won't support setting
undefined attributes to None.

Addresses: https://github.com/bazelbuild/bazel/issues/19403
