### PR TITLE
feat: Support netrc-based authentication for python_repository rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ A brief description of the categories of changes:
 * (gazelle) New `# gazelle:python_generation_mode file` directive to support
   generating one `py_library` per file.
 
+* (python_repository) Support `netrc` and `auth_patterns` attributes to enable
+  authentication against private HTTP hosts serving Python toolchain binaries.
+
 ### Removed
 
 * (bzlmod) The `entry_point` macro is no longer supported and has been removed
@@ -118,5 +121,3 @@ A brief description of the categories of changes:
 * Expose Python C headers through the toolchain.
 
 [0.24.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.24.0
-
-

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -103,10 +103,7 @@ def _python_repository_impl(rctx):
         netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
     else:
         netrc = read_user_netrc(rctx)
-
-    auth = None
-    if netrc:
-        auth = use_netrc(netrc, urls, rctx.attr.auth_patterns)
+    auth = use_netrc(netrc, urls, rctx.attr.auth_patterns)
 
     if release_filename.endswith(".zst"):
         rctx.download(
@@ -386,6 +383,9 @@ python_repository = repository_rule(
     _python_repository_impl,
     doc = "Fetches the external tools needed for the Python toolchain.",
     attrs = {
+        "auth_patterns": attr.string_dict(
+            doc = "Override mapping of hostnames to authorization patterns; mirrors the eponymous attribute from http_archive",
+        ),
         "coverage_tool": attr.string(
             # Mirrors the definition at
             # https://github.com/bazelbuild/bazel/blob/master/src/main/starlark/builtins_bzl/common/python/py_runtime_rule.bzl
@@ -426,6 +426,9 @@ For more information see the official bazel docs
             doc = "Whether the check for root should be ignored or not. This causes cache misses with .pyc files.",
             mandatory = False,
         ),
+        "netrc": attr.string(
+            doc = ".netrc file to use for authentication; mirrors the eponymous attribute from http_archive",
+        ),
         "patches": attr.label_list(
             doc = "A list of patch files to apply to the unpacked interpreter",
             mandatory = False,
@@ -455,12 +458,6 @@ For more information see the official bazel docs
         ),
         "urls": attr.string_list(
             doc = "The URL of the interpreter to download. Exactly one of url and urls must be set.",
-        ),
-        "netrc": attr.string(
-            doc = ".netrc file to use for authentication; mirrors the eponymous attribute from http_archive",
-        ),
-        "auth_patterns": attr.string_dict(
-            doc = "Override mapping of hostnames to authorization patterns; mirrors the eponymous attribute from http_archive",
         ),
         "zstd_sha256": attr.string(
             default = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -86,13 +86,10 @@ def is_standalone_interpreter(rctx, python_interpreter_path):
     ]).return_code == 0
 
 def _get_auth(rctx, urls):
-    """
-    Convenience utility for automatically retrieving netrc-based authentication parameters for
-    repository download rules used in python_repository.
+    """Utility for retrieving netrc-based authentication parameters for repository download rules used in python_repository.
 
     The implementation below is copied directly from Bazel's implementation of `http_archive`.
-    Accordingly, the return value of this function should be used identically as the `auth`
-    parameter of `http_archive`.
+    Accordingly, the return value of this function should be used identically as the `auth` parameter of `http_archive`.
     Reference: https://github.com/bazelbuild/bazel/blob/6.3.2/tools/build_defs/repo/http.bzl#L109
 
     Args:


### PR DESCRIPTION
This change introduces support for `netrc` and `auth_patterns` attributes in `python_repository` (and by extension, `python_register_toolchains`). This allows consuming projects to fetch custom Python toolchain binaries from a private/authenticated HTTP host when specified directly by URL in `python_register_toolchains`.

The implementation proposed here mirrors that of `http_archive`: https://github.com/bazelbuild/bazel/blob/1cf392ff3918386858b8c038f82c013b1e04be98/tools/build_defs/repo/http.bzl#L116

Fixes #1215.