### PR TITLE
internal(pystar): make starlark impl (mostly) loadable

### DIFF
--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2022 The Bazel Authors. All rights reserved.
+# Copyright 2023 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of macro-half of py_library rule."""
-
-load(":common/python/py_library_bazel.bzl", py_library_rule = "py_library")
-
-def py_library(**kwargs):
-    py_library_rule(**kwargs)

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -13,18 +13,20 @@
 # limitations under the License.
 """Attributes for Python rules."""
 
-load(":common/cc/cc_info.bzl", _CcInfo = "CcInfo")
-load(":common/python/common.bzl", "union_attrs")
-load(":common/python/providers.bzl", "PyInfo")
+load(":common.bzl", "union_attrs")
+load(":providers.bzl", "PyInfo")
+load(":py_internal.bzl", "py_internal")
 load(
-    ":common/python/semantics.bzl",
+    ":semantics.bzl",
     "DEPS_ATTR_ALLOW_RULES",
     "PLATFORMS_LOCATION",
     "SRCS_ATTR_ALLOW_FILES",
     "TOOLS_REPO",
 )
 
-PackageSpecificationInfo = _builtins.toplevel.PackageSpecificationInfo
+# TODO: Load CcInfo from rules_cc
+_CcInfo = CcInfo
+_PackageSpecificationInfo = py_internal.PackageSpecificationInfo
 
 _STAMP_VALUES = [-1, 0, 1]
 
@@ -89,7 +91,7 @@ NATIVE_RULES_ALLOWLIST_ATTRS = {
             fragment = "py",
             name = "native_rules_allowlist",
         ),
-        providers = [PackageSpecificationInfo],
+        providers = [_PackageSpecificationInfo],
     ),
 }
 

--- a/python/private/common/cc_helper.bzl
+++ b/python/private/common/cc_helper.bzl
@@ -1,4 +1,4 @@
-# Copyright 2022 The Bazel Authors. All rights reserved.
+# Copyright 2023 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Macro to wrap the py_runtime rule."""
+"""PYTHON RULE IMPLEMENTATION ONLY: Do not use outside of the rule implementations and their tests.
 
-load(":py_runtime_rule.bzl", py_runtime_rule = "py_runtime")
+Adapter for accessing Bazel's internal cc_helper.
 
-# NOTE: The function name is purposefully selected to match the underlying
-# rule name so that e.g. 'generator_function' shows as the same name so
-# that it is less confusing to users.
-def py_runtime(**kwargs):
-    py_runtime_rule(**kwargs)
+These may change at any time and are closely coupled to the rule implementation.
+"""
+
+load(":py_internal.bzl", "py_internal")
+
+cc_helper = py_internal.cc_helper

--- a/python/private/common/common.bzl
+++ b/python/private/common/common.bzl
@@ -13,23 +13,21 @@
 # limitations under the License.
 """Various things common to Bazel and Google rule implementations."""
 
-load(":common/cc/cc_helper.bzl", "cc_helper")
+load(":cc_helper.bzl", "cc_helper")
+load(":providers.bzl", "PyInfo")
+load(":py_internal.bzl", "py_internal")
 load(
-    ":common/python/providers.bzl",
-    "PyInfo",
-)
-load(
-    ":common/python/semantics.bzl",
+    ":semantics.bzl",
     "NATIVE_RULES_MIGRATION_FIX_CMD",
     "NATIVE_RULES_MIGRATION_HELP_URL",
     "TOOLS_REPO",
 )
 
-_testing = _builtins.toplevel.testing
-_platform_common = _builtins.toplevel.platform_common
-_coverage_common = _builtins.toplevel.coverage_common
-_py_builtins = _builtins.internal.py_builtins
-PackageSpecificationInfo = _builtins.toplevel.PackageSpecificationInfo
+_testing = testing
+_platform_common = platform_common
+_coverage_common = coverage_common
+_py_builtins = py_internal
+PackageSpecificationInfo = py_internal.PackageSpecificationInfo
 
 TOOLCHAIN_TYPE = "@" + TOOLS_REPO + "//tools/python:toolchain_type"
 

--- a/python/private/common/common_bazel.bzl
+++ b/python/private/common/common_bazel.bzl
@@ -13,13 +13,18 @@
 # limitations under the License.
 """Common functions that are specific to Bazel rule implementation"""
 
-load(":common/cc/cc_common.bzl", _cc_common = "cc_common")
-load(":common/cc/cc_info.bzl", _CcInfo = "CcInfo")
-load(":common/paths.bzl", "paths")
-load(":common/python/common.bzl", "is_bool")
-load(":common/python/providers.bzl", "PyCcLinkParamsProvider")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":common.bzl", "is_bool")
+load(":providers.bzl", "PyCcLinkParamsProvider")
+load(":py_internal.bzl", "py_internal")
 
-_py_builtins = _builtins.internal.py_builtins
+# TODO: Load cc_common from rules_cc
+_cc_common = cc_common
+
+# TODO: Load CcInfo from rules_cc
+_CcInfo = CcInfo
+
+_py_builtins = py_internal
 
 def collect_cc_info(ctx, extra_deps = []):
     """Collect C++ information from dependencies for Bazel.

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Providers for Python rules."""
 
-load(":common/python/semantics.bzl", "TOOLS_REPO")
+load(":semantics.bzl", "TOOLS_REPO")
 
-_CcInfo = _builtins.toplevel.CcInfo
+# TODO: load CcInfo from rules_cc
+_CcInfo = CcInfo
 
-# NOTE: This is copied to PyRuntimeInfo.java
 DEFAULT_STUB_SHEBANG = "#!/usr/bin/env python3"
 
-# NOTE: This is copied to PyRuntimeInfo.java
 DEFAULT_BOOTSTRAP_TEMPLATE = "@" + TOOLS_REPO + "//tools/python:python_bootstrap_template.txt"
 _PYTHON_VERSION_VALUES = ["PY2", "PY3"]
 

--- a/python/private/common/py_binary_macro_bazel.bzl
+++ b/python/private/common/py_binary_macro_bazel.bzl
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of macro-half of py_test rule."""
+"""Implementation of macro-half of py_binary rule."""
 
-load(":common/python/common_bazel.bzl", "convert_legacy_create_init_to_int")
-load(":common/python/py_test_bazel.bzl", py_test_rule = "py_test")
+load(":common_bazel.bzl", "convert_legacy_create_init_to_int")
+load(":py_binary_rule_bazel.bzl", py_binary_rule = "py_binary")
 
-def py_test(**kwargs):
+def py_binary(**kwargs):
     convert_legacy_create_init_to_int(kwargs)
-    py_test_rule(**kwargs)
+    py_binary_rule(**kwargs)

--- a/python/private/common/py_binary_rule_bazel.bzl
+++ b/python/private/common/py_binary_rule_bazel.bzl
@@ -13,13 +13,13 @@
 # limitations under the License.
 """Rule implementation of py_binary for Bazel."""
 
-load(":common/python/attributes.bzl", "AGNOSTIC_BINARY_ATTRS")
+load(":attributes.bzl", "AGNOSTIC_BINARY_ATTRS")
 load(
-    ":common/python/py_executable_bazel.bzl",
+    ":py_executable_bazel.bzl",
     "create_executable_rule",
     "py_executable_bazel_impl",
 )
-load(":common/python/semantics.bzl", "TOOLS_REPO")
+load(":semantics.bzl", "TOOLS_REPO")
 
 _PY_TEST_ATTRS = {
     "_collect_cc_coverage": attr.label(

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -13,10 +13,8 @@
 # limitations under the License.
 """Common functionality between test/binary executables."""
 
-load(":common/cc/cc_common.bzl", _cc_common = "cc_common")
-load(":common/cc/cc_helper.bzl", "cc_helper")
 load(
-    ":common/python/attributes.bzl",
+    ":attributes.bzl",
     "AGNOSTIC_EXECUTABLE_ATTRS",
     "COMMON_ATTRS",
     "PY_SRCS_ATTRS",
@@ -24,8 +22,9 @@ load(
     "create_srcs_attr",
     "create_srcs_version_attr",
 )
+load(":cc_helper.bzl", "cc_helper")
 load(
-    ":common/python/common.bzl",
+    ":common.bzl",
     "TOOLCHAIN_TYPE",
     "check_native_allowed",
     "collect_imports",
@@ -38,19 +37,23 @@ load(
     "union_attrs",
 )
 load(
-    ":common/python/providers.bzl",
+    ":providers.bzl",
     "PyCcLinkParamsProvider",
     "PyRuntimeInfo",
 )
+load(":py_internal.bzl", "py_internal")
 load(
-    ":common/python/semantics.bzl",
+    ":semantics.bzl",
     "ALLOWED_MAIN_EXTENSIONS",
     "BUILD_DATA_SYMLINK_PATH",
     "IS_BAZEL",
     "PY_RUNTIME_ATTR_NAME",
 )
 
-_py_builtins = _builtins.internal.py_builtins
+# TODO: Load cc_common from rules_cc
+_cc_common = cc_common
+
+_py_builtins = py_internal
 
 # Non-Google-specific attributes for executables
 # These attributes are for rules that accept Python sources.
@@ -677,9 +680,8 @@ def is_stamping_enabled(ctx, semantics):
 def _is_tool_config(ctx):
     # NOTE: The is_tool_configuration() function is only usable by builtins.
     # See https://github.com/bazelbuild/bazel/issues/14444 for the FR for
-    # a more public API. Outside of builtins, ctx.bin_dir.path can be
-    # checked for `/host/` or `-exec-`.
-    return ctx.configuration.is_tool_configuration()
+    # a more public API. Until that's available, py_internal to the rescue.
+    return py_internal.is_tool_configuration(ctx)
 
 def _create_providers(
         *,

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -13,25 +13,26 @@
 # limitations under the License.
 """Implementation for Bazel Python executable."""
 
-load(":common/paths.bzl", "paths")
-load(":common/python/attributes_bazel.bzl", "IMPORTS_ATTRS")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":attributes_bazel.bzl", "IMPORTS_ATTRS")
 load(
-    ":common/python/common.bzl",
+    ":common.bzl",
     "create_binary_semantics_struct",
     "create_cc_details_struct",
     "create_executable_result_struct",
     "union_attrs",
 )
-load(":common/python/common_bazel.bzl", "collect_cc_info", "get_imports", "maybe_precompile")
-load(":common/python/providers.bzl", "DEFAULT_STUB_SHEBANG")
+load(":common_bazel.bzl", "collect_cc_info", "get_imports", "maybe_precompile")
+load(":providers.bzl", "DEFAULT_STUB_SHEBANG")
 load(
-    ":common/python/py_executable.bzl",
+    ":py_executable.bzl",
     "create_base_executable_rule",
     "py_executable_base_impl",
 )
-load(":common/python/semantics.bzl", "TOOLS_REPO")
+load(":py_internal.bzl", "py_internal")
+load(":semantics.bzl", "TOOLS_REPO")
 
-_py_builtins = _builtins.internal.py_builtins
+_py_builtins = py_internal
 _EXTERNAL_PATH_PREFIX = "external"
 _ZIP_RUNFILES_DIRECTORY_NAME = "runfiles"
 

--- a/python/private/common/py_internal.bzl
+++ b/python/private/common/py_internal.bzl
@@ -1,4 +1,4 @@
-# Copyright 2022 The Bazel Authors. All rights reserved.
+# Copyright 2023 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Macro to wrap the py_runtime rule."""
+"""PYTHON RULE IMPLEMENTATION ONLY: Do not use outside of the rule implementations and their tests.
 
-load(":py_runtime_rule.bzl", py_runtime_rule = "py_runtime")
+Re-exports the restricted-use py_internal helper under its original name.
 
-# NOTE: The function name is purposefully selected to match the underlying
-# rule name so that e.g. 'generator_function' shows as the same name so
-# that it is less confusing to users.
-def py_runtime(**kwargs):
-    py_runtime_rule(**kwargs)
+These may change at any time and are closely coupled to the rule implementation.
+"""
+
+# buildifier: disable=bzl-visibility
+load("//tools/build_defs/python/private:py_internal_renamed.bzl", "py_internal_renamed")
+
+py_internal = py_internal_renamed

--- a/python/private/common/py_library.bzl
+++ b/python/private/common/py_library.bzl
@@ -14,7 +14,7 @@
 """Implementation of py_library rule."""
 
 load(
-    ":common/python/attributes.bzl",
+    ":attributes.bzl",
     "COMMON_ATTRS",
     "PY_SRCS_ATTRS",
     "SRCS_VERSION_ALL_VALUES",
@@ -22,7 +22,7 @@ load(
     "create_srcs_version_attr",
 )
 load(
-    ":common/python/common.bzl",
+    ":common.bzl",
     "check_native_allowed",
     "collect_imports",
     "collect_runfiles",
@@ -32,9 +32,10 @@ load(
     "filter_to_py_srcs",
     "union_attrs",
 )
-load(":common/python/providers.bzl", "PyCcLinkParamsProvider")
+load(":providers.bzl", "PyCcLinkParamsProvider")
+load(":py_internal.bzl", "py_internal")
 
-_py_builtins = _builtins.internal.py_builtins
+_py_builtins = py_internal
 
 LIBRARY_ATTRS = union_attrs(
     COMMON_ATTRS,

--- a/python/private/common/py_library_macro_bazel.bzl
+++ b/python/private/common/py_library_macro_bazel.bzl
@@ -11,12 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Macro to wrap the py_runtime rule."""
+"""Implementation of macro-half of py_library rule."""
 
-load(":py_runtime_rule.bzl", py_runtime_rule = "py_runtime")
+load(":py_library_rule_bazel.bzl", py_library_rule = "py_library")
 
-# NOTE: The function name is purposefully selected to match the underlying
-# rule name so that e.g. 'generator_function' shows as the same name so
-# that it is less confusing to users.
-def py_runtime(**kwargs):
-    py_runtime_rule(**kwargs)
+def py_library(**kwargs):
+    py_library_rule(**kwargs)

--- a/python/private/common/py_library_rule_bazel.bzl
+++ b/python/private/common/py_library_rule_bazel.bzl
@@ -13,23 +13,11 @@
 # limitations under the License.
 """Implementation of py_library for Bazel."""
 
+load(":attributes_bazel.bzl", "IMPORTS_ATTRS")
+load(":common.bzl", "create_library_semantics_struct", "union_attrs")
+load(":common_bazel.bzl", "collect_cc_info", "get_imports", "maybe_precompile")
 load(
-    ":common/python/attributes_bazel.bzl",
-    "IMPORTS_ATTRS",
-)
-load(
-    ":common/python/common.bzl",
-    "create_library_semantics_struct",
-    "union_attrs",
-)
-load(
-    ":common/python/common_bazel.bzl",
-    "collect_cc_info",
-    "get_imports",
-    "maybe_precompile",
-)
-load(
-    ":common/python/py_library.bzl",
+    ":py_library.bzl",
     "LIBRARY_ATTRS",
     "create_py_library_rule",
     bazel_py_library_impl = "py_library_impl",

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -13,12 +13,13 @@
 # limitations under the License.
 """Implementation of py_runtime rule."""
 
-load(":common/paths.bzl", "paths")
-load(":common/python/attributes.bzl", "NATIVE_RULES_ALLOWLIST_ATTRS")
-load(":common/python/common.bzl", "check_native_allowed")
-load(":common/python/providers.bzl", "DEFAULT_BOOTSTRAP_TEMPLATE", "DEFAULT_STUB_SHEBANG", _PyRuntimeInfo = "PyRuntimeInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":attributes.bzl", "NATIVE_RULES_ALLOWLIST_ATTRS")
+load(":common.bzl", "check_native_allowed")
+load(":providers.bzl", "DEFAULT_BOOTSTRAP_TEMPLATE", "DEFAULT_STUB_SHEBANG", _PyRuntimeInfo = "PyRuntimeInfo")
+load(":py_internal.bzl", "py_internal")
 
-_py_builtins = _builtins.internal.py_builtins
+_py_builtins = py_internal
 
 def _py_runtime_impl(ctx):
     check_native_allowed(ctx)

--- a/python/private/common/py_test_macro_bazel.bzl
+++ b/python/private/common/py_test_macro_bazel.bzl
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of macro-half of py_binary rule."""
+"""Implementation of macro-half of py_test rule."""
 
-load(":common/python/common_bazel.bzl", "convert_legacy_create_init_to_int")
-load(":common/python/py_binary_bazel.bzl", py_binary_rule = "py_binary")
+load(":common_bazel.bzl", "convert_legacy_create_init_to_int")
+load(":py_test_rule_bazel.bzl", py_test_rule = "py_test")
 
-def py_binary(**kwargs):
+def py_test(**kwargs):
     convert_legacy_create_init_to_int(kwargs)
-    py_binary_rule(**kwargs)
+    py_test_rule(**kwargs)

--- a/python/private/common/py_test_rule_bazel.bzl
+++ b/python/private/common/py_test_rule_bazel.bzl
@@ -13,14 +13,14 @@
 # limitations under the License.
 """Rule implementation of py_test for Bazel."""
 
-load(":common/python/attributes.bzl", "AGNOSTIC_TEST_ATTRS")
-load(":common/python/common.bzl", "maybe_add_test_execution_info")
+load(":attributes.bzl", "AGNOSTIC_TEST_ATTRS")
+load(":common.bzl", "maybe_add_test_execution_info")
 load(
-    ":common/python/py_executable_bazel.bzl",
+    ":py_executable_bazel.bzl",
     "create_executable_rule",
     "py_executable_bazel_impl",
 )
-load(":common/python/semantics.bzl", "TOOLS_REPO")
+load(":semantics.bzl", "TOOLS_REPO")
 
 _BAZEL_PY_TEST_ATTRS = {
     # This *might* be a magic attribute to help C++ coverage work. There's no

--- a/tools/build_defs/python/private/BUILD.bazel
+++ b/tools/build_defs/python/private/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2022 The Bazel Authors. All rights reserved.
+# Copyright 2023 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,12 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Macro to wrap the py_runtime rule."""
-
-load(":py_runtime_rule.bzl", py_runtime_rule = "py_runtime")
-
-# NOTE: The function name is purposefully selected to match the underlying
-# rule name so that e.g. 'generator_function' shows as the same name so
-# that it is less confusing to users.
-def py_runtime(**kwargs):
-    py_runtime_rule(**kwargs)

--- a/tools/build_defs/python/private/py_internal_renamed.bzl
+++ b/tools/build_defs/python/private/py_internal_renamed.bzl
@@ -1,0 +1,25 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PYTHON RULE IMPLEMENTATION ONLY: Do not use outside of the rule implementations and their tests.
+
+Re-exports the restricted-use py_internal helper under another name. This is
+necessary because `py_internal = py_internal` results in an error (trying
+to bind a local symbol to itself before its defined).
+
+This is to allow the rule implementation in the //python directory to access
+the internal helpers only rules_python is allowed to use.
+
+These may change at any time and are closely coupled to the rule implementation.
+"""
+py_internal_renamed = py_internal


### PR DESCRIPTION
This just makes the files able to get passed the loading stage under Bazel 7+.

This mostly involves fixing load statements, but also exposed a couple places where
py_internal needs some small changes.

* Also renames files to better distinguish rule vs macro vs Bazel-specific. This makes it easier to patch them within Google and more clear about which file is doing what.

Work towards #1069