### PR TITLE
fix(gazelle): runfiles discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ A brief description of the categories of changes:
   dependencies improving initial build times involving external dependency
   fetching.
 
+* (gazelle) Improve runfiles lookup hermeticity.
+
 ## [0.25.0] - 2023-08-22
 
 ### Changed

--- a/gazelle/python/parser.go
+++ b/gazelle/python/parser.go
@@ -38,13 +38,20 @@ var (
 )
 
 func startParserProcess(ctx context.Context) {
-	parseScriptRunfile, err := runfiles.Rlocation("rules_python_gazelle_plugin/python/parse")
+	rfiles, err := runfiles.New()
+	if err != nil {
+		log.Printf("failed to create a runfiles object: %v\n", err)
+		os.Exit(1)
+	}
+
+	parseScriptRunfile, err := rfiles.Rlocation("rules_python_gazelle_plugin/python/parse")
 	if err != nil {
 		log.Printf("failed to initialize parser: %v\n", err)
 		os.Exit(1)
 	}
 
 	cmd := exec.CommandContext(ctx, parseScriptRunfile)
+	cmd.Env = rfiles.Env()
 
 	cmd.Stderr = os.Stderr
 

--- a/gazelle/python/parser.go
+++ b/gazelle/python/parser.go
@@ -51,7 +51,7 @@ func startParserProcess(ctx context.Context) {
 	}
 
 	cmd := exec.CommandContext(ctx, parseScriptRunfile)
-	cmd.Env = rfiles.Env()
+	cmd.Env = append(os.Environ(), rfiles.Env()...)
 
 	cmd.Stderr = os.Stderr
 

--- a/gazelle/python/std_modules.go
+++ b/gazelle/python/std_modules.go
@@ -39,7 +39,13 @@ var (
 func startStdModuleProcess(ctx context.Context) {
 	stdModulesSeen = make(map[string]struct{})
 
-	stdModulesScriptRunfile, err := runfiles.Rlocation("rules_python_gazelle_plugin/python/std_modules")
+	rfiles, err := runfiles.New()
+	if err != nil {
+		log.Printf("failed to create a runfiles object: %v\n", err)
+		os.Exit(1)
+	}
+
+	stdModulesScriptRunfile, err := rfiles.Rlocation("rules_python_gazelle_plugin/python/std_modules")
 	if err != nil {
 		log.Printf("failed to initialize std_modules: %v\n", err)
 		os.Exit(1)
@@ -49,7 +55,8 @@ func startStdModuleProcess(ctx context.Context) {
 
 	cmd.Stderr = os.Stderr
 	// All userland site-packages should be ignored.
-	cmd.Env = []string{"PYTHONNOUSERSITE=1"}
+	cmd.Env = append([]string{"PYTHONNOUSERSITE=1"}, rfiles.Env()...)
+
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Printf("failed to initialize std_modules: %v\n", err)


### PR DESCRIPTION
Pass the environment generated by the `runfiles` helper so that the
Python launcher can find the runfiles correctly as implemented in
bazelbuild/bazel#14740.

Fixes #1426
