### PR TITLE
feat, refactor(pystar): bzl_library for packaging.bzl; fix pystar doc building and py_wheel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -8,8 +8,11 @@ bazel-out
 bazel-testlogs
 # Prevent the convenience symlinks within the examples from being
 # treated as directories with valid BUILD files for the main repo.
+# Any directory with a WORKSPACE in it should be added here, with
+# an entry like `bazel-{workspacename}`
 examples/bzlmod/bazel-bzlmod
 examples/bzlmod/other_module/bazel-other_module
 examples/bzlmod_build_file_generation/bazel-bzlmod_build_file_generation
 examples/pip_parse/bazel-pip_parse
 examples/py_proto_library/bazel-py_proto_library
+tests/ignore_root_user_error/bazel-ignore_root_user_error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,10 @@ A brief description of the categories of changes:
   https://github.com/indygreg/python-build-standalone/releases/tag/20230826.
 * (gazelle) New `# gazelle:python_generation_mode file` directive to support
   generating one `py_library` per file.
-
 * (python_repository) Support `netrc` and `auth_patterns` attributes to enable
   authentication against private HTTP hosts serving Python toolchain binaries.
+* `//python:packaging_bzl` added, a `bzl_library` for the Starlark
+  files `//python:packaging.bzl` requires.
 
 ### Removed
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -74,20 +74,6 @@ bzl_library(
     ],
 )
 
-bzl_library(
-    name = "packaging_bzl",
-    srcs = [
-        "//python:packaging.bzl",
-        "//python/private:py_package.bzl",
-        "//python/private:py_wheel.bzl",
-        "//python/private:stamp.bzl",
-        "//python/private:util.bzl",
-    ],
-    deps = [
-        "//python/private:util_bzl",
-    ],
-)
-
 # TODO: Stardoc does not guarantee consistent outputs accross platforms (Unix/Windows).
 # As a result we do not build or test docs on Windows.
 _NOT_WINDOWS = select({
@@ -144,7 +130,7 @@ stardoc(
     out = "packaging.md_",
     input = "//python:packaging.bzl",
     target_compatible_with = _NOT_WINDOWS,
-    deps = [":packaging_bzl"],
+    deps = ["//python:packaging_bzl"],
 )
 
 stardoc(

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -71,6 +71,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "packaging_bzl",
+    srcs = ["packaging.bzl"],
+    deps = [
+        ":py_binary_bzl",
+        "//python/private:py_package.bzl",
+        "//python/private:py_wheel_bzl",
+        "//python/private:stamp_bzl",
+        "//python/private:util_bzl",
+    ],
+)
+
+bzl_library(
     name = "proto_bzl",
     srcs = [
         "proto.bzl",

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -14,6 +14,7 @@
 
 """Public API for for building wheels."""
 
+load("//python:py_binary.bzl", "py_binary")
 load("//python/private:py_package.bzl", "py_package_lib")
 load("//python/private:py_wheel.bzl", _PyWheelInfo = "PyWheelInfo", _py_wheel = "py_wheel")
 load("//python/private:util.bzl", "copy_propagating_kwargs")
@@ -167,7 +168,7 @@ def py_wheel(name, twine = None, publish_args = [], **kwargs):
 
         # TODO: use py_binary from //python:defs.bzl after our stardoc setup is less brittle
         # buildifier: disable=native-py
-        native.py_binary(
+        py_binary(
             name = "{}.publish".format(name),
             srcs = [twine_main],
             args = twine_args,

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -106,6 +106,28 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "py_package_bzl",
+    srcs = ["py_package.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "py_wheel_bzl",
+    srcs = ["py_wheel.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":py_package_bzl",
+        ":stamp_bzl",
+    ],
+)
+
+bzl_library(
+    name = "stamp_bzl",
+    srcs = ["stamp.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
 # @bazel_tools can't define bzl_library itself, so we just put a wrapper around it.
 bzl_library(
     name = "bazel_tools_bzl",
@@ -130,7 +152,7 @@ exports_files(
         "util.bzl",
         "py_cc_toolchain_rule.bzl",
     ],
-    visibility = ["//docs:__pkg__"],
+    visibility = ["//:__subpackages__"],
 )
 
 # Used to determine the use of `--stamp` in Starlark rules

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -49,12 +49,19 @@ load(
     "BUILD_DATA_SYMLINK_PATH",
     "IS_BAZEL",
     "PY_RUNTIME_ATTR_NAME",
+    "TOOLS_REPO",
 )
 
 # TODO: Load cc_common from rules_cc
 _cc_common = cc_common
 
 _py_builtins = py_internal
+
+# Bazel 5.4 doesn't have config_common.toolchain_type
+_CC_TOOLCHAINS = [config_common.toolchain_type(
+    "@" + TOOLS_REPO + "//tools/cpp:toolchain_type",
+    mandatory = False,
+)] if hasattr(config_common, "toolchain_type") else []
 
 # Non-Google-specific attributes for executables
 # These attributes are for rules that accept Python sources.
@@ -810,7 +817,7 @@ def create_base_executable_rule(*, attrs, fragments = [], **kwargs):
     return rule(
         # TODO: add ability to remove attrs, i.e. for imports attr
         attrs = dicts.add(EXECUTABLE_ATTRS, attrs),
-        toolchains = [TOOLCHAIN_TYPE] + (cc_helper.use_cpp_toolchain() if cc_helper else []),
+        toolchains = [TOOLCHAIN_TYPE] + _CC_TOOLCHAINS,
         fragments = fragments,
         **kwargs
     )


### PR DESCRIPTION
Changed `py_wheel` to load `py_binary` instead of using `native.py_binary`. This caused the doc generation to fail because of the additional loads(), so the doc libraries were refactored to represent the additional loads. This adds `//python:packaging_bzl`
as a public target.

Docs were failing to build because Stardoc wasn't able to process the value `cc_helper.use_cpp_toolchains()` returned. For some reason, under Stardoc, the value is some mocked out value that it can't handle. This is easily fixed by just using the regular way for referencing an optional toolchain; the labels the two use are the same.

Work towards #1069