### PR TITLE
feat(bzlmod): mark pip extension as os/arch dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ A brief description of the categories of changes:
   cases. An error about `@rules_python_internal` means the `py_repositories()`
   call is missing in `WORKSPACE`.
 
-* (bzlmod): the `pip.parse` extension will generate os/arch specific lock
+* (bzlmod) The `pip.parse` extension will generate os/arch specific lock
   file entries on `bazel>=6.4`.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ A brief description of the categories of changes:
   cases. An error about `@rules_python_internal` means the `py_repositories()`
   call is missing in `WORKSPACE`.
 
+* (bzlmod): the `pip.parse` extension will generate os/arch specific lock
+  file entries on `bazel>=6.4`.
+
 
 ### Added
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,9 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "bazel_features", version = "1.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/python/extensions/pip.bzl
+++ b/python/extensions/pip.bzl
@@ -14,6 +14,7 @@
 
 "pip module extension for use with bzlmod"
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@pythons_hub//:interpreters.bzl", "DEFAULT_PYTHON_VERSION", "INTERPRETER_LABELS")
 load(
     "//python/pip_install:pip_repository.bzl",
@@ -380,6 +381,17 @@ cannot have a child module that uses the same `hub_name`.
     }
     return attrs
 
+def _extension_extra_args():
+    args = {}
+
+    if bazel_features.external_deps.module_extension_has_os_arch_dependent:
+        args = args | {
+            "arch_dependent": True,
+            "os_dependent": True,
+        }
+
+    return args
+
 pip = module_extension(
     doc = """\
 This extension is used to make dependencies from pip available.
@@ -422,6 +434,7 @@ extension.
 """,
         ),
     },
+    **_extension_extra_args()
 )
 
 def _whl_mods_repo_impl(rctx):


### PR DESCRIPTION
This ensures that under bzlmod with `--lockfile-mode=update` we
would generate an entry per os/arch, which is needed because the
hermetic toolchain interpreter path is os/arch dependent.

Summary:
- add bazel_features dep
- mark the pip extension as arch/os dependent

Related: bazelbuild/bazel#19154
