### PR TITLE
tests(pystar): CI configs that uses Starlark implementation of rules

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -93,6 +93,36 @@ tasks:
     <<: *reusable_config
     name: Default test on Ubuntu
     platform: ubuntu2004
+  ubuntu_bazel_rolling:
+    <<: *reusable_config
+    name: "Default test: Ubuntu, Pystar, workspace"
+    platform: ubuntu2004
+    # TODO: Change to "rolling" once
+    # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
+    # is available in rolling.
+    bazel: "last_green"
+    environment:
+      RULES_PYTHON_ENABLE_PYSTAR: "1"
+    test_flags:
+      # The doc check tests fail because the Starlark implementation makes the
+      # PyInfo and PyRuntimeInfo symbols become documented.
+      - "--test_tag_filters=-integration-test,-doc_check_test"
+  ubuntu_bazel_rolling_bzlmod:
+    <<: *reusable_config
+    <<: *common_bzlmod_flags
+    name: "Default test: Ubuntu, Pystar, bzlmod"
+    platform: ubuntu2004
+    # TODO: Change to "rolling" once
+    # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
+    # is available in rolling.
+    bazel: "last_green"
+    environment:
+      RULES_PYTHON_ENABLE_PYSTAR: "1"
+    test_flags:
+      # The doc check tests fail because the Starlark implementation makes the
+      # PyInfo and PyRuntimeInfo symbols become documented.
+      - "--test_tag_filters=-integration-test,-doc_check_test"
+
   debian:
     <<: *reusable_config
     name: Default test on Debian
@@ -107,7 +137,6 @@ tasks:
     platform: windows
     test_flags:
       - "--test_tag_filters=-integration-test,-fix-windows"
-
   rbe_min:
     <<: *minimum_supported_version
     <<: *reusable_config
@@ -262,34 +291,6 @@ tasks:
     name: multi_python_versions integration tests on Windows
     working_directory: examples/multi_python_versions
     platform: windows
-
-  integration_test_pip_install_ubuntu_min:
-    <<: *minimum_supported_version
-    <<: *reusable_build_test_all
-    name: pip_install integration tests on Ubuntu using minimum supported Bazel version
-    working_directory: examples/pip_install
-    platform: ubuntu2004
-  integration_test_pip_install_ubuntu:
-    <<: *reusable_build_test_all
-    name: pip_install integration tests on Ubuntu
-    working_directory: examples/pip_install
-    platform: ubuntu2004
-  integration_test_pip_install_debian:
-    <<: *reusable_build_test_all
-    name: pip_install integration tests on Debian
-    working_directory: examples/pip_install
-    platform: debian11
-  integration_test_pip_install_macos:
-    <<: *reusable_build_test_all
-    name: pip_install integration tests on macOS
-    working_directory: examples/pip_install
-    platform: macos
-  integration_test_pip_install_windows:
-    <<: *reusable_build_test_all
-    name: pip_install integration tests on Windows
-    working_directory: examples/pip_install
-    platform: windows
-
   integration_test_pip_parse_ubuntu_min:
     <<: *minimum_supported_version
     <<: *reusable_build_test_all

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -16,6 +16,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 
 package(default_visibility = ["//visibility:public"])
 
@@ -74,11 +75,16 @@ bzl_library(
     ],
 )
 
+# Empty list means "compatible with all".
+# Stardoc+bzlmod doesn't currently work with our docs, so disable trying to
+# build it for now.
+_COMPATIBLE_PLATFORM = [] if not BZLMOD_ENABLED else ["@platforms//:incompatible"]
+
 # TODO: Stardoc does not guarantee consistent outputs accross platforms (Unix/Windows).
 # As a result we do not build or test docs on Windows.
-_NOT_WINDOWS = select({
-    "@platforms//os:linux": [],
-    "@platforms//os:macos": [],
+_TARGET_COMPATIBLE_WITH = select({
+    "@platforms//os:linux": _COMPATIBLE_PLATFORM,
+    "@platforms//os:macos": _COMPATIBLE_PLATFORM,
     "//conditions:default": ["@platforms//:incompatible"],
 })
 
@@ -86,7 +92,7 @@ stardoc(
     name = "core-docs",
     out = "python.md_",
     input = "//python:defs.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = [":defs"],
 )
 
@@ -94,7 +100,7 @@ stardoc(
     name = "pip-docs",
     out = "pip.md_",
     input = "//python:pip.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = [
         ":bazel_repo_tools",
         ":pip_install_bzl",
@@ -106,7 +112,7 @@ stardoc(
     name = "pip-repository",
     out = "pip_repository.md_",
     input = "//python/pip_install:pip_repository.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = [
         ":bazel_repo_tools",
         ":pip_install_bzl",
@@ -119,7 +125,7 @@ stardoc(
     name = "py-console-script-binary",
     out = "py_console_script_binary.md_",
     input = "//python/entry_points:py_console_script_binary.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = [
         "//python/entry_points:py_console_script_binary_bzl",
     ],
@@ -129,7 +135,7 @@ stardoc(
     name = "packaging-docs",
     out = "packaging.md_",
     input = "//python:packaging.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = ["//python:packaging_bzl"],
 )
 
@@ -141,7 +147,7 @@ stardoc(
     # doesn't do anything interesting to users, so bypass it to avoid having to
     # copy/paste all the rule's doc in the macro.
     input = "//python/private:py_cc_toolchain_rule.bzl",
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = ["//python/private:py_cc_toolchain_bzl"],
 )
 
@@ -158,7 +164,8 @@ stardoc(
         failure_message = "Please run:   bazel run //docs:update",
         file1 = k + ".md",
         file2 = k + ".md_",
-        target_compatible_with = _NOT_WINDOWS,
+        tags = ["doc_check_test"],
+        target_compatible_with = _TARGET_COMPATIBLE_WITH,
     )
     for k in _DOCS.keys()
 ]
@@ -173,12 +180,12 @@ write_file(
         "cp -fv bazel-bin/docs/{0}.md_ docs/{0}.md".format(k)
         for k in _DOCS.keys()
     ],
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
 )
 
 sh_binary(
     name = "update",
     srcs = ["update.sh"],
     data = _DOCS.values(),
-    target_compatible_with = _NOT_WINDOWS,
+    target_compatible_with = _TARGET_COMPATIBLE_WITH,
 )


### PR DESCRIPTION
Since Bazel 7 isn't yet available, and we need a couple recent commits in Bazel, the
last_green release is used. This will eventually be changed to "rolling" once the
necessary commits are available in the next rolling release.

Because we're at the limit of 80 test jobs, some existing jobs have to be removed
and only a limited number of cases can be currently covered. I opted to remove
the pip_install tests, since they're redundant with the pip_parse tests, which
frees up 4 slots. Two test configs are added: one using workspace, the other using
bzlmod; both run the default tests on Ubuntu. This will provide some basic coverage;
more slots will free up when Bazel 5.4 support is dropped and Bazel 7 is released.

Work toward #1069