### PR TITLE
fix(pystar): Use py_internal for runfiles_enabled, declare_shareable_artifact, share_native_deps

### DIFF
--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -488,7 +488,7 @@ def _get_native_deps_details(ctx, *, semantics, cc_details, is_test):
         return struct(dso = None, runfiles = ctx.runfiles())
 
     dso = ctx.actions.declare_file(semantics.get_native_deps_dso_name(ctx))
-    share_native_deps = ctx.fragments.cpp.share_native_deps()
+    share_native_deps = py_internal.share_native_deps(ctx)
     cc_feature_config = cc_configure_features(
         ctx,
         cc_toolchain = cc_details.cc_toolchain,
@@ -571,7 +571,7 @@ def _create_shared_native_deps_dso(
         features = requested_features,
         is_test_target_partially_disabled_thin_lto = is_test and partially_disabled_thin_lto,
     )
-    return ctx.actions.declare_shareable_artifact("_nativedeps/%x.so" % dso_hash)
+    return py_internal.declare_shareable_artifact(ctx, "_nativedeps/%x.so" % dso_hash)
 
 # This is a minimal version of NativeDepsHelper.getSharedNativeDepsPath, see
 # com.google.devtools.build.lib.rules.nativedeps.NativeDepsHelper#getSharedNativeDepsPath

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -332,7 +332,7 @@ def _create_windows_exe_launcher(
     launch_info.add("binary_type=Python")
     launch_info.add(ctx.workspace_name, format = "workspace_name=%s")
     launch_info.add(
-        "1" if ctx.configuration.runfiles_enabled() else "0",
+        "1" if py_internal.runfiles_enabled(ctx) else "0",
         format = "symlink_runfiles_enabled=%s",
     )
     launch_info.add(python_binary_path, format = "python_bin_path=%s")


### PR DESCRIPTION
These are restricted use APIs, so they have to go through py_internal.

They aren't caught by CI because tests don't currently cover their code paths; fixing that will
be done in a separate change.

Work towards #1069