### PR TITLE
fix: add missing `@bazel_tools` files to bzl_library dependencies.

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -157,9 +157,10 @@ bzl_library(
 bzl_library(
     name = "bazel_tools_bzl",
     srcs = [
-        "@bazel_tools//tools/python:srcs_version.bzl",
-        "@bazel_tools//tools/python:toolchain.bzl",
-        "@bazel_tools//tools/python:utils.bzl",
+        # This set of sources is overly broad, but it's the only public
+        # target available across Bazel versions that has all the necessary
+        # sources.
+        "@bazel_tools//tools:bzl_srcs",
     ],
     visibility = ["//python:__pkg__"],
 )


### PR DESCRIPTION
This allows depending on just e.g. `//python:defs_bzl` without having to also depend on our internal //docs targets or manually including the extra bazel_tools files.

The missing files were hidden by the doc tests because those tests manually include the extra files. Under the hood, it goes:
  * defs.bzl ->
  * py_runtime_pair.bzl -> 
  * @bazel_tools//tools/python:toolchain.bzl ->
  * @bazel_tools//tools/python:private/defs.bzl -> 

(Note the relationshps within @bazel_tools are Bazel-version specific)

Unfortunately, there isn't a public target for just the subset of files we need from @bazel_tools, so we have to use the larger glob of all of `@bazel_tools//tools`.