### PR TITLE
docs: document a breaking changes policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ PR Instructions/requirements
   * Update `CHANGELOG.md` as applicable
 * Breaking changes include "!" after the type and a "BREAKING CHANGES:"
   section at the bottom.
+  See CONTRIBUTING.md for our breaking changes process.
 * Body text describes:
   * Why this change is being made, briefly.
   * Before and after behavior, as applicable


### PR DESCRIPTION
This largely covers how to introduce a breaking change.

It also attempts to clarify what is or isn't a breaking change.

Closes #1424
Work towards #1361