### PR TITLE
internal: add stub register_extension_name to make patching easier

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -111,6 +111,7 @@ bzl_library(
     name = "py_binary_bzl",
     srcs = ["py_binary.bzl"],
     deps = [
+        "//python/private:register_extension_info_bzl",
         "//python/private:util_bzl",
         "//python/private/common:py_binary_macro_bazel_bzl",
         "@rules_python_internal//:rules_python_config_bzl",
@@ -142,6 +143,7 @@ bzl_library(
     name = "py_library_bzl",
     srcs = ["py_library.bzl"],
     deps = [
+        "//python/private:register_extension_info_bzl",
         "//python/private:util_bzl",
         "//python/private/common:py_library_macro_bazel_bzl",
         "@rules_python_internal//:rules_python_config_bzl",
@@ -182,6 +184,7 @@ bzl_library(
     name = "py_test_bzl",
     srcs = ["py_test.bzl"],
     deps = [
+        "//python/private:register_extension_info_bzl",
         "//python/private:util_bzl",
         "//python/private/common:py_test_macro_bazel_bzl",
         "@rules_python_internal//:rules_python_config_bzl",

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -164,6 +164,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "register_extension_info_bzl",
+    srcs = ["register_extension_info.bzl"],
+)
+
+bzl_library(
     name = "render_pkg_aliases_bzl",
     srcs = ["render_pkg_aliases.bzl"],
     deps = [

--- a/python/private/register_extension_info.bzl
+++ b/python/private/register_extension_info.bzl
@@ -1,0 +1,18 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stub implementation to make patching easier."""
+
+# buildifier: disable=unused-variable
+def register_extension_info(**kwargs):
+    """A no-op stub to make Google patching easier."""

--- a/python/py_binary.bzl
+++ b/python/py_binary.bzl
@@ -15,6 +15,7 @@
 """Public entry point for py_binary."""
 
 load("@rules_python_internal//:rules_python_config.bzl", "config")
+load("//python/private:register_extension_info.bzl", "register_extension_info")
 load("//python/private:util.bzl", "add_migration_tag")
 load("//python/private/common:py_binary_macro_bazel.bzl", _starlark_py_binary = "py_binary")
 
@@ -33,3 +34,8 @@ def py_binary(**attrs):
         fail("Python 2 is no longer supported: https://github.com/bazelbuild/rules_python/issues/886")
 
     _py_binary_impl(**add_migration_tag(attrs))
+
+register_extension_info(
+    extension = py_binary,
+    label_regex_for_dep = "{extension_name}",
+)

--- a/python/py_library.bzl
+++ b/python/py_library.bzl
@@ -15,6 +15,7 @@
 """Public entry point for py_library."""
 
 load("@rules_python_internal//:rules_python_config.bzl", "config")
+load("//python/private:register_extension_info.bzl", "register_extension_info")
 load("//python/private:util.bzl", "add_migration_tag")
 load("//python/private/common:py_library_macro_bazel.bzl", _starlark_py_library = "py_library")
 
@@ -31,3 +32,8 @@ def py_library(**attrs):
         fail("Python 2 is no longer supported: https://github.com/bazelbuild/rules_python/issues/886")
 
     _py_library_impl(**add_migration_tag(attrs))
+
+register_extension_info(
+    extension = py_library,
+    label_regex_for_dep = "{extension_name}",
+)

--- a/python/py_test.bzl
+++ b/python/py_test.bzl
@@ -15,6 +15,7 @@
 """Public entry point for py_test."""
 
 load("@rules_python_internal//:rules_python_config.bzl", "config")
+load("//python/private:register_extension_info.bzl", "register_extension_info")
 load("//python/private:util.bzl", "add_migration_tag")
 load("//python/private/common:py_test_macro_bazel.bzl", _starlark_py_test = "py_test")
 
@@ -34,3 +35,8 @@ def py_test(**attrs):
 
     # buildifier: disable=native-python
     _py_test_impl(**add_migration_tag(attrs))
+
+register_extension_info(
+    extension = py_test,
+    label_regex_for_dep = "{extension_name}",
+)


### PR DESCRIPTION
Within Google, we have to patch some files so some additional tooling can capture some metadata. To make patching easier, call some no-opt stubs, which makes the patches smaller and more likely to apply without issues.