### PR TITLE
test: use a custom rule instead of native.filegroup for testing that PyInfo is a required provider.

### DIFF
--- a/tests/base_rules/base_tests.bzl
+++ b/tests/base_rules/base_tests.bzl
@@ -30,6 +30,14 @@ _produces_py_info = rule(
     attrs = {"srcs": attr.label_list(allow_files = True)},
 )
 
+def _not_produces_py_info_impl(ctx):
+    _ = ctx  # @unused
+    return [DefaultInfo()]
+
+_not_produces_py_info = rule(
+    implementation = _not_produces_py_info_impl,
+)
+
 def _test_consumes_provider(name, config):
     rt_util.helper_target(
         config.base_test_rule,
@@ -62,7 +70,7 @@ def _test_requires_provider(name, config):
         deps = [name + "_nopyinfo"],
     )
     rt_util.helper_target(
-        native.filegroup,
+        _not_produces_py_info,
         name = name + "_nopyinfo",
     )
     analysis_test(


### PR DESCRIPTION
Within Google, for historical reasons, the filegroup rule type is allowed in deps, which means `test_requires_pyinfo` test fails. This can be easily worked around by using a custom rule that doesn't have the same name.