### PR TITLE
test: remove usage of deprecated method `TestCase.assertEquals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ A brief description of the categories of changes:
   like `bazel query rdeps(...)`.
 
 * Python code generated from `proto_library` with `strip_import_prefix` can be imported now.
-* Removed usage of a deprecated method `TestCase.assertEquals` in tests.
 
 * (py_wheel) Produce deterministic wheel files and make `RECORD` file entries
   follow the order of files written to the `.whl` archive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ A brief description of the categories of changes:
   like `bazel query rdeps(...)`.
 
 * Python code generated from `proto_library` with `strip_import_prefix` can be imported now.
+* Removed usage of a deprecated method `TestCase.assertEquals` in tests.
 
 * (py_wheel) Produce deterministic wheel files and make `RECORD` file entries
   follow the order of files written to the `.whl` archive.

--- a/examples/bzlmod/test.py
+++ b/examples/bzlmod/test.py
@@ -76,7 +76,7 @@ class ExampleTest(unittest.TestCase):
             )
 
     def test_main(self):
-        self.assertEquals(
+        self.assertEqual(
             """\
 -  -
 A  1

--- a/examples/bzlmod_build_file_generation/__test__.py
+++ b/examples/bzlmod_build_file_generation/__test__.py
@@ -19,7 +19,7 @@ from lib import main
 
 class ExampleTest(unittest.TestCase):
     def test_main(self):
-        self.assertEquals(
+        self.assertEqual(
             """\
 -  -
 A  1

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -198,7 +198,7 @@ second = second.main:s""",
         )
         with zipfile.ZipFile(filename) as zf:
             self.assertAllEntriesHasReproducibleMetadata(zf)
-            self.assertEquals(
+            self.assertEqual(
                 zf.namelist(),
                 [
                     "examples/wheel/lib/data.txt",
@@ -216,7 +216,7 @@ second = second.main:s""",
             metadata_contents = zf.read(
                 "file_name_escaping-0.0.1_r7.dist-info/METADATA"
             )
-            self.assertEquals(
+            self.assertEqual(
                 metadata_contents,
                 b"""\
 Metadata-Version: 2.1


### PR DESCRIPTION
`TestCase.assertEquals` is an alias for `TestCase.assertEqual`.
[This method is deprecated since Python 3.2 and was removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#id3). 