### PR TITLE
ci: pin pystar bazel version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -100,7 +100,7 @@ tasks:
     # TODO: Change to "rolling" once
     # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
     # is available in rolling.
-    bazel: "last_green"
+    bazel: "2b8219042c132483e0af39ef20d67dfd6442af01"
     environment:
       RULES_PYTHON_ENABLE_PYSTAR: "1"
     test_flags:
@@ -115,7 +115,7 @@ tasks:
     # TODO: Change to "rolling" once
     # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
     # is available in rolling.
-    bazel: "last_green"
+    bazel: "2b8219042c132483e0af39ef20d67dfd6442af01"
     environment:
       RULES_PYTHON_ENABLE_PYSTAR: "1"
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -100,6 +100,9 @@ tasks:
     # TODO: Change to "rolling" once
     # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
     # is available in rolling.
+    # NOTE @aignas 2023-10-17: as of https://github.com/bazelbuild/bazel/issues/19838
+    # this is the last known-to-work bazel version, use `last_green` or `rolling` once the
+    # issue is fixed.
     bazel: "2b8219042c132483e0af39ef20d67dfd6442af01"
     environment:
       RULES_PYTHON_ENABLE_PYSTAR: "1"
@@ -115,6 +118,9 @@ tasks:
     # TODO: Change to "rolling" once
     # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
     # is available in rolling.
+    # NOTE @aignas 2023-10-17: as of https://github.com/bazelbuild/bazel/issues/19838
+    # this is the last known-to-work bazel version, use `last_green` or `rolling` once the
+    # issue is fixed.
     bazel: "2b8219042c132483e0af39ef20d67dfd6442af01"
     environment:
       RULES_PYTHON_ENABLE_PYSTAR: "1"


### PR DESCRIPTION
This PR changes the specific version that is used to test starlark
rules_python rules implementation, which broke in recent bazelbuild/bazel
commits. Once the following issue is fixed, this can be reverted.


Towards #1496
Related bazelbuild/bazel#19838
