### PR TITLE
internal(pystar): use rules_python PyCcLinkParamsProvider if pystar is enabled

### DIFF
--- a/python/py_cc_link_params_info.bzl
+++ b/python/py_cc_link_params_info.bzl
@@ -1,3 +1,6 @@
 """Public entry point for PyCcLinkParamsInfo."""
 
-PyCcLinkParamsInfo = PyCcLinkParamsProvider
+load("@rules_python_internal//:rules_python_config.bzl", "config")
+load("//python/private/common:providers.bzl", _starlark_PyCcLinkParamsProvider = "PyCcLinkParamsProvider")
+
+PyCcLinkParamsInfo = _starlark_PyCcLinkParamsProvider if config.enable_pystar else PyCcLinkParamsProvider


### PR DESCRIPTION
The PyCcLinkParamsInfo export wasn't respecting the `config.enable_pystar` setting. This
would cause the Starlark implementation to look up the wrong provider symbol and result
in an error later.

Work towards #1069