### PR TITLE
ci: don't run minimum bazel version tests as part of bazel downstream…

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -22,6 +22,7 @@ buildifier:
   # For testing minimum supported version.
   # NOTE: Keep in sync with //:version.bzl
   bazel: 5.4.0
+  skip_in_bazel_downstream_pipeline: "Bazel 5 required"
 .minimum_supported_bzlmod_version: &minimum_supported_bzlmod_version
   bazel: 6.2.0 # test minimum supported version of bazel for bzlmod tests
 .reusable_config: &reusable_config


### PR DESCRIPTION
The Bazel downstream tests will use Bazel built at head, but the tests checking for support with the minimum Bazel version are specifically intended to only run with an older Bazel version.

Work towards #1520