### PR TITLE
tests: make multi_python_verions example bzlmod compatible

### DIFF
--- a/examples/multi_python_versions/MODULE.bazel
+++ b/examples/multi_python_versions/MODULE.bazel
@@ -1,0 +1,57 @@
+module(
+    name = "multi_python_versions",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.0")
+bazel_dep(name = "rules_python", version = "0.0.0")
+local_path_override(
+    module_name = "rules_python",
+    path = "../..",
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.8",
+)
+python.toolchain(
+    configure_coverage_tool = True,
+    # Only set when you have mulitple toolchain versions.
+    is_default = True,
+    python_version = "3.9",
+)
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.10",
+)
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.11",
+)
+use_repo(
+    python,
+    python = "python_versions",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+use_repo(pip, "pypi")
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.8",
+    requirements_lock = "//requirements:requirements_lock_3_8.txt",
+)
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.9",
+    requirements_lock = "//requirements:requirements_lock_3_9.txt",
+)
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.10",
+    requirements_lock = "//requirements:requirements_lock_3_10.txt",
+)
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.11",
+    requirements_lock = "//requirements:requirements_lock_3_11.txt",
+)

--- a/examples/multi_python_versions/tests/my_lib_test.py
+++ b/examples/multi_python_versions/tests/my_lib_test.py
@@ -17,8 +17,11 @@ import sys
 
 import libs.my_lib as my_lib
 
-sanitized_version_check = f"{sys.version_info.major}_{sys.version_info.minor}"
+workspace_version = f"{sys.version_info.major}_{sys.version_info.minor}"
+bzlmod_version = f"{sys.version_info.major}{sys.version_info.minor}"
 
-if not my_lib.websockets_is_for_python_version(sanitized_version_check):
+if not my_lib.websockets_is_for_python_version(
+    workspace_version
+) and not my_lib.websockets_is_for_python_version(bzlmod_version):
     print("expected package for Python version is different than returned")
     sys.exit(1)


### PR DESCRIPTION
Bazel is enabling bzlmod by default, which means the examples need to be updated to be bzlmod compatible.

Work towards #1520