### PR TITLE
tests: make pip_parse example work with bzlmod enabled

### DIFF
--- a/examples/pip_parse/BUILD.bazel
+++ b/examples/pip_parse/BUILD.bazel
@@ -47,7 +47,7 @@ py_test(
 
 py_console_script_binary(
     name = "yamllint",
-    pkg = "@pypi//yamllint:pkg",
+    pkg = "@pypi//yamllint",
 )
 
 # This rule adds a convenient way to update the requirements file.

--- a/examples/pip_parse/BUILD.bazel
+++ b/examples/pip_parse/BUILD.bazel
@@ -1,11 +1,6 @@
-load(
-    "@pypi//:requirements.bzl",
-    "data_requirement",
-    "dist_info_requirement",
-    "entry_point",
-)
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 
 # Toolchain setup, this is optional.
 # Demonstrate that we can use the same python interpreter for the toolchain and executing pip in pip install (see WORKSPACE).
@@ -37,7 +32,7 @@ py_binary(
     name = "main",
     srcs = ["main.py"],
     deps = [
-        "@pypi_requests//:pkg",
+        "@pypi//requests:pkg",
     ],
 )
 
@@ -50,9 +45,9 @@ py_test(
 # For pip dependencies which have entry points, the `entry_point` macro can be
 # used from the generated `pip_parse` repository to access a runnable binary.
 
-alias(
+py_console_script_binary(
     name = "yamllint",
-    actual = entry_point("yamllint"),
+    pkg = "@pypi//yamllint:pkg",
 )
 
 # This rule adds a convenient way to update the requirements file.
@@ -68,13 +63,13 @@ py_test(
     srcs = ["pip_parse_test.py"],
     data = [
         ":yamllint",
-        data_requirement("s3cmd"),
-        dist_info_requirement("requests"),
+        "@pypi//requests:dist_info",
+        "@pypi//s3cmd:data",
     ],
     env = {
-        "WHEEL_DATA_CONTENTS": "$(rootpaths {})".format(data_requirement("s3cmd")),
-        "WHEEL_DIST_INFO_CONTENTS": "$(rootpaths {})".format(dist_info_requirement("requests")),
-        "YAMLLINT_ENTRY_POINT": "$(rootpath :yamllint)",
+        "WHEEL_DATA_CONTENTS": "$(rootpaths @pypi//s3cmd:data)",
+        "WHEEL_DIST_INFO_CONTENTS": "$(rootpaths @pypi//requests:dist_info)",
+        "YAMLLINT_ENTRY_POINT": "$(rlocationpath :yamllint)",
     },
     deps = ["@rules_python//python/runfiles"],
 )

--- a/examples/pip_parse/MODULE.bazel
+++ b/examples/pip_parse/MODULE.bazel
@@ -1,0 +1,20 @@
+module(name = "rules_python_pip_parse_example")
+
+bazel_dep(name = "rules_python", version = "0.0.0")
+local_path_override(
+    module_name = "rules_python",
+    path = "../..",
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = "3.9",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.9",
+    requirements_lock = "//:requirements_lock.txt",
+)
+use_repo(pip, "pypi")

--- a/examples/pip_parse/WORKSPACE
+++ b/examples/pip_parse/WORKSPACE
@@ -24,7 +24,6 @@ pip_parse(
     # can be passed
     # environment = {"HTTPS_PROXY": "http://my.proxy.fun/"},
     name = "pypi",
-    incompatible_generate_aliases = True,
     # (Optional) You can provide extra parameters to pip.
     # Here, make pip output verbose (this is usable with `quiet = False`).
     # extra_pip_args = ["-v"],

--- a/examples/pip_parse/WORKSPACE
+++ b/examples/pip_parse/WORKSPACE
@@ -24,6 +24,7 @@ pip_parse(
     # can be passed
     # environment = {"HTTPS_PROXY": "http://my.proxy.fun/"},
     name = "pypi",
+    incompatible_generate_aliases = True,
     # (Optional) You can provide extra parameters to pip.
     # Here, make pip output verbose (this is usable with `quiet = False`).
     # extra_pip_args = ["-v"],

--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -19,20 +19,24 @@ import subprocess
 import unittest
 from pathlib import Path
 
-from rules_python.python.runfiles import runfiles
+from python.runfiles import runfiles
 
 
 class PipInstallTest(unittest.TestCase):
     maxDiff = None
 
+    def _remove_leading_dirs(self, paths):
+        # Removes the first two directories (external/<reponame>)
+        # to normalize what workspace and bzlmod produce.
+        return [str(Path(*Path(v).parts[2:])) for v in paths]
+
     def test_entry_point(self):
-        env = os.environ.get("YAMLLINT_ENTRY_POINT")
-        self.assertIsNotNone(env)
+        entry_point_path = os.environ.get("YAMLLINT_ENTRY_POINT")
+        self.assertIsNotNone(entry_point_path)
 
         r = runfiles.Create()
 
-        # To find an external target, this must use `{workspace_name}/$(rootpath @external_repo//:target)`
-        entry_point = Path(r.Rlocation("rules_python_pip_parse_example/{}".format(env)))
+        entry_point = Path(r.Rlocation(entry_point_path))
         self.assertTrue(entry_point.exists())
 
         proc = subprocess.run(
@@ -44,31 +48,34 @@ class PipInstallTest(unittest.TestCase):
         self.assertEqual(proc.stdout.decode("utf-8").strip(), "yamllint 1.28.0")
 
     def test_data(self):
-        env = os.environ.get("WHEEL_DATA_CONTENTS")
-        self.assertIsNotNone(env)
+        actual = os.environ.get("WHEEL_DATA_CONTENTS")
+        self.assertIsNotNone(actual)
+        actual = self._remove_leading_dirs(actual.split(" "))
+
         self.assertListEqual(
-            env.split(" "),
+            actual,
             [
-                "external/pypi_s3cmd/data/share/doc/packages/s3cmd/INSTALL.md",
-                "external/pypi_s3cmd/data/share/doc/packages/s3cmd/LICENSE",
-                "external/pypi_s3cmd/data/share/doc/packages/s3cmd/NEWS",
-                "external/pypi_s3cmd/data/share/doc/packages/s3cmd/README.md",
-                "external/pypi_s3cmd/data/share/man/man1/s3cmd.1",
+                "data/share/doc/packages/s3cmd/INSTALL.md",
+                "data/share/doc/packages/s3cmd/LICENSE",
+                "data/share/doc/packages/s3cmd/NEWS",
+                "data/share/doc/packages/s3cmd/README.md",
+                "data/share/man/man1/s3cmd.1",
             ],
         )
 
     def test_dist_info(self):
-        env = os.environ.get("WHEEL_DIST_INFO_CONTENTS")
-        self.assertIsNotNone(env)
+        actual = os.environ.get("WHEEL_DIST_INFO_CONTENTS")
+        self.assertIsNotNone(actual)
+        actual = self._remove_leading_dirs(actual.split(" "))
         self.assertListEqual(
-            env.split(" "),
+            actual,
             [
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/INSTALLER",
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/LICENSE",
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/METADATA",
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/RECORD",
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/WHEEL",
-                "external/pypi_requests/site-packages/requests-2.25.1.dist-info/top_level.txt",
+                "site-packages/requests-2.25.1.dist-info/INSTALLER",
+                "site-packages/requests-2.25.1.dist-info/LICENSE",
+                "site-packages/requests-2.25.1.dist-info/METADATA",
+                "site-packages/requests-2.25.1.dist-info/RECORD",
+                "site-packages/requests-2.25.1.dist-info/WHEEL",
+                "site-packages/requests-2.25.1.dist-info/top_level.txt",
             ],
         )
 

--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -28,7 +28,11 @@ class PipInstallTest(unittest.TestCase):
     def _remove_leading_dirs(self, paths):
         # Removes the first two directories (external/<reponame>)
         # to normalize what workspace and bzlmod produce.
-        return [str(Path(*Path(v).parts[2:])) for v in paths]
+        #return [str(Path(*Path(v).parts[2:])) for v in paths]
+        return [
+            '/'.join(v.split('/')[2:])
+            for v in paths
+        ]
 
     def test_entry_point(self):
         entry_point_path = os.environ.get("YAMLLINT_ENTRY_POINT")


### PR DESCRIPTION
Bazel is enabling bzlmod by default, which means the examples need to be updated to be bzlmod compatible.

Work towards #1520