### PR TITLE
test: make compile_pip_requirements work with bzlmod enabled

### DIFF
--- a/tests/compile_pip_requirements/MODULE.bazel
+++ b/tests/compile_pip_requirements/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "compile_pip_requirements")
+
+bazel_dep(name = "rules_python", version = "0.0.0")
+local_path_override(
+    module_name = "rules_python",
+    path = "../..",
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = "3.9",
+)


### PR DESCRIPTION
Bazel at head has bzlmod enabled by default, so the example needs to be updated to work with bzlmod enabled.

Work towards #1520