### PR TITLE
tests: explicitly disable bzlmod for pip_repository_entry_points test

### DIFF
--- a/tests/pip_repository_entry_points/.bazelrc
+++ b/tests/pip_repository_entry_points/.bazelrc
@@ -5,3 +5,7 @@ startup --windows_enable_symlinks
 
 # https://docs.bazel.build/versions/main/best-practices.html#using-the-bazelrc-file
 try-import %workspace%/user.bazelrc
+
+# The requirements.bzl entry_point functions aren't supported under bzlmod.
+# They are replaced by py_console_script_binary, which already has tests
+build --noexperimental_enable_bzlmod


### PR DESCRIPTION
Bazel at head enables bzlmod by default, but the requirements.bzl entry_point functions aren't supported under bzlmod. Until workspace support is entirely dropped, explicitly disable bzlmod for the pip_repository_entry_points test.

Work towards #1590