### PR TITLE
test: make compile_pip_requirements_test_from_external_workspace work with bzlmod

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -570,34 +570,34 @@ tasks:
     working_directory: tests/compile_pip_requirements_test_from_external_workspace
     platform: ubuntu2004
     shell_commands:
-    # Assert that @external_repository//:requirements_test does the right thing.
-    - "bazel test @external_repository//..."
+    # Assert that @compile_pip_requirements//:requirements_test does the right thing.
+    - "bazel test @compile_pip_requirements//..."
   integration_compile_pip_requirements_test_from_external_repo_ubuntu:
     name: compile_pip_requirements test from external repo on Ubuntu
     working_directory: tests/compile_pip_requirements_test_from_external_workspace
     platform: ubuntu2004
     shell_commands:
-    # Assert that @external_repository//:requirements_test does the right thing.
-    - "bazel test @external_repository//..."
+    # Assert that @compile_pip_requirements//:requirements_test does the right thing.
+    - "bazel test @compile_pip_requirements//..."
   integration_compile_pip_requirements_test_from_external_repo_debian:
     name: compile_pip_requirements test from external repo on Debian
     working_directory: tests/compile_pip_requirements_test_from_external_workspace
     platform: debian11
     shell_commands:
-    # Assert that @external_repository//:requirements_test does the right thing.
-    - "bazel test @external_repository//..."
+    # Assert that @compile_pip_requirements//:requirements_test does the right thing.
+    - "bazel test @compile_pip_requirements//..."
   integration_compile_pip_requirements_test_from_external_repo_macos:
     name: compile_pip_requirements test from external repo on macOS
     working_directory: tests/compile_pip_requirements_test_from_external_workspace
     platform: macos
     shell_commands:
-    # Assert that @external_repository//:requirements_test does the right thing.
-    - "bazel test @external_repository//..."
+    # Assert that @compile_pip_requirements//:requirements_test does the right thing.
+    - "bazel test @compile_pip_requirements//..."
   integration_compile_pip_requirements_test_from_external_repo_windows:
     name: compile_pip_requirements test from external repo on Windows
     working_directory: tests/compile_pip_requirements_test_from_external_workspace
     platform: windows
     shell_commands:
-    # Assert that @external_repository//:requirements_test does the right thing.
-    - "bazel test @external_repository//..."
+    # Assert that @compile_pip_requirements//:requirements_test does the right thing.
+    - "bazel test @compile_pip_requirements//..."
 

--- a/tests/compile_pip_requirements/.bazelignore
+++ b/tests/compile_pip_requirements/.bazelignore
@@ -1,0 +1,4 @@
+# While normally ignored by default, it must be explicitly
+# specified so that compile_pip_requirements_test_from_external_workspace
+# properly ignores it
+bazel-compile_pip_requirements

--- a/tests/compile_pip_requirements_test_from_external_workspace/MODULE.bazel
+++ b/tests/compile_pip_requirements_test_from_external_workspace/MODULE.bazel
@@ -1,0 +1,25 @@
+module(name = "compile_pip_requirements_test_from_external_workspace")
+
+bazel_dep(name = "rules_python", version = "0.0.0")
+local_path_override(
+    module_name = "rules_python",
+    path = "../..",
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = "3.9",
+)
+
+bazel_dep(name = "compile_pip_requirements", version = "0.0.0")
+local_path_override(
+    module_name = "compile_pip_requirements",
+    path = "../compile_pip_requirements",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.9",
+    requirements_lock = "@compile_pip_requirements//:requirements_lock.txt",
+)

--- a/tests/compile_pip_requirements_test_from_external_workspace/WORKSPACE
+++ b/tests/compile_pip_requirements_test_from_external_workspace/WORKSPACE
@@ -20,14 +20,14 @@ load("@python39//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 local_repository(
-    name = "external_repository",
+    name = "compile_pip_requirements",
     path = "../compile_pip_requirements",
 )
 
 pip_parse(
     name = "pypi",
     python_interpreter_target = interpreter,
-    requirements_lock = "@external_repository//:requirements_lock.txt",
+    requirements_lock = "@compile_pip_requirements//:requirements_lock.txt",
 )
 
 load("@pypi//:requirements.bzl", "install_deps")


### PR DESCRIPTION
Bazel at head enables bzlmod by default, so the tests must also be
updated to be bzlmod compatible.

Also makes compile_pip_requirements ignore its convenience symlinks.
This allows locally running the "from external" workspace test even if
the compile_pip_requirements workspace previously had convenience
symlinks in it from other builds.

Work towards #1520