### PR TITLE
cleanup(pystar): inline @bazel_tools and @platforms references

### DIFF
--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -19,9 +19,7 @@ load(":py_internal.bzl", "py_internal")
 load(
     ":semantics.bzl",
     "DEPS_ATTR_ALLOW_RULES",
-    "PLATFORMS_LOCATION",
     "SRCS_ATTR_ALLOW_FILES",
-    "TOOLS_REPO",
 )
 
 # TODO: Load CcInfo from rules_cc
@@ -72,7 +70,7 @@ def copy_common_test_kwargs(kwargs):
 CC_TOOLCHAIN = {
     # NOTE: The `cc_helper.find_cpp_toolchain()` function expects the attribute
     # name to be this name.
-    "_cc_toolchain": attr.label(default = "@" + TOOLS_REPO + "//tools/cpp:current_cc_toolchain"),
+    "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
 }
 
 # The common "data" attribute definition.
@@ -188,11 +186,11 @@ environment when the test is executed by bazel test.
         # TODO(b/176993122): Remove when Bazel automatically knows to run on darwin.
         "_apple_constraints": attr.label_list(
             default = [
-                PLATFORMS_LOCATION + "/os:ios",
-                PLATFORMS_LOCATION + "/os:macos",
-                PLATFORMS_LOCATION + "/os:tvos",
-                PLATFORMS_LOCATION + "/os:visionos",
-                PLATFORMS_LOCATION + "/os:watchos",
+                "@platforms//os:ios",
+                "@platforms//os:macos",
+                "@platforms//os:tvos",
+                "@platforms//os:visionos",
+                "@platforms//os:watchos",
             ],
         ),
     },

--- a/python/private/common/common.bzl
+++ b/python/private/common/common.bzl
@@ -20,7 +20,6 @@ load(
     ":semantics.bzl",
     "NATIVE_RULES_MIGRATION_FIX_CMD",
     "NATIVE_RULES_MIGRATION_HELP_URL",
-    "TOOLS_REPO",
 )
 
 _testing = testing
@@ -29,7 +28,7 @@ _coverage_common = coverage_common
 _py_builtins = py_internal
 PackageSpecificationInfo = getattr(py_internal, "PackageSpecificationInfo", None)
 
-TOOLCHAIN_TYPE = "@" + TOOLS_REPO + "//tools/python:toolchain_type"
+TOOLCHAIN_TYPE = "@bazel_tools//tools/python:toolchain_type"
 
 # Extensions without the dot
 _PYTHON_SOURCE_EXTENSIONS = ["py"]

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -14,14 +14,13 @@
 """Providers for Python rules."""
 
 load("@rules_python_internal//:rules_python_config.bzl", "config")
-load(":semantics.bzl", "TOOLS_REPO")
 
 # TODO: load CcInfo from rules_cc
 _CcInfo = CcInfo
 
 DEFAULT_STUB_SHEBANG = "#!/usr/bin/env python3"
 
-DEFAULT_BOOTSTRAP_TEMPLATE = "@" + TOOLS_REPO + "//tools/python:python_bootstrap_template.txt"
+DEFAULT_BOOTSTRAP_TEMPLATE = "@bazel_tools//tools/python:python_bootstrap_template.txt"
 _PYTHON_VERSION_VALUES = ["PY2", "PY3"]
 
 # Helper to make the provider definitions not crash under Bazel 5.4:

--- a/python/private/common/py_binary_rule_bazel.bzl
+++ b/python/private/common/py_binary_rule_bazel.bzl
@@ -20,11 +20,10 @@ load(
     "create_executable_rule",
     "py_executable_bazel_impl",
 )
-load(":semantics.bzl", "TOOLS_REPO")
 
 _PY_TEST_ATTRS = {
     "_collect_cc_coverage": attr.label(
-        default = "@" + TOOLS_REPO + "//tools/test:collect_cc_coverage",
+        default = "@bazel_tools//tools/test:collect_cc_coverage",
         executable = True,
         cfg = "exec",
     ),

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -49,9 +49,7 @@ load(
     "ALLOWED_MAIN_EXTENSIONS",
     "BUILD_DATA_SYMLINK_PATH",
     "IS_BAZEL",
-    "PLATFORMS_LOCATION",
     "PY_RUNTIME_ATTR_NAME",
-    "TOOLS_REPO",
 )
 
 # TODO: Load cc_common from rules_cc
@@ -61,7 +59,7 @@ _py_builtins = py_internal
 
 # Bazel 5.4 doesn't have config_common.toolchain_type
 _CC_TOOLCHAINS = [config_common.toolchain_type(
-    "@" + TOOLS_REPO + "//tools/cpp:toolchain_type",
+    "@bazel_tools//tools/cpp:toolchain_type",
     mandatory = False,
 )] if hasattr(config_common, "toolchain_type") else []
 
@@ -97,7 +95,7 @@ filename in `srcs`, `main` must be specified.
         ),
         "_windows_constraints": attr.label_list(
             default = [
-                PLATFORMS_LOCATION + "/os:windows",
+                "@platforms//os:windows",
             ],
         ),
     },

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -32,7 +32,6 @@ load(
     "py_executable_base_impl",
 )
 load(":py_internal.bzl", "py_internal")
-load(":semantics.bzl", "TOOLS_REPO")
 
 _py_builtins = py_internal
 _EXTERNAL_PATH_PREFIX = "external"
@@ -56,11 +55,11 @@ the `srcs` of Python targets as required.
         ),
         "_bootstrap_template": attr.label(
             allow_single_file = True,
-            default = "@" + TOOLS_REPO + "//tools/python:python_bootstrap_template.txt",
+            default = "@bazel_tools//tools/python:python_bootstrap_template.txt",
         ),
         "_launcher": attr.label(
             cfg = "target",
-            default = "@" + TOOLS_REPO + "//tools/launcher:launcher",
+            default = "@bazel_tools//tools/launcher:launcher",
             executable = True,
         ),
         "_py_interpreter": attr.label(
@@ -76,17 +75,17 @@ the `srcs` of Python targets as required.
         # GraphlessQueryTest.testLabelsOperator relies on it to test for
         # query behavior of implicit dependencies.
         "_py_toolchain_type": attr.label(
-            default = "@" + TOOLS_REPO + "//tools/python:toolchain_type",
+            default = "@bazel_tools//tools/python:toolchain_type",
         ),
         "_windows_launcher_maker": attr.label(
-            default = "@" + TOOLS_REPO + "//tools/launcher:launcher_maker",
+            default = "@bazel_tools//tools/launcher:launcher_maker",
             cfg = "exec",
             executable = True,
         ),
         "_zipper": attr.label(
             cfg = "exec",
             executable = True,
-            default = "@" + TOOLS_REPO + "//tools/zip:zipper",
+            default = "@bazel_tools//tools/zip:zipper",
         ),
     },
 )

--- a/python/private/common/py_test_rule_bazel.bzl
+++ b/python/private/common/py_test_rule_bazel.bzl
@@ -21,13 +21,12 @@ load(
     "create_executable_rule",
     "py_executable_bazel_impl",
 )
-load(":semantics.bzl", "TOOLS_REPO")
 
 _BAZEL_PY_TEST_ATTRS = {
     # This *might* be a magic attribute to help C++ coverage work. There's no
     # docs about this; see TestActionBuilder.java
     "_collect_cc_coverage": attr.label(
-        default = "@" + TOOLS_REPO + "//tools/test:collect_cc_coverage",
+        default = "@bazel_tools//tools/test:collect_cc_coverage",
         executable = True,
         cfg = "exec",
     ),

--- a/python/private/common/semantics.bzl
+++ b/python/private/common/semantics.bzl
@@ -15,9 +15,6 @@
 
 IMPORTS_ATTR_SUPPORTED = True
 
-TOOLS_REPO = "bazel_tools"
-PLATFORMS_LOCATION = "@platforms/"
-
 SRCS_ATTR_ALLOW_FILES = [".py", ".py3"]
 
 DEPS_ATTR_ALLOW_RULES = None


### PR DESCRIPTION
The location of the `@bazel_tools` and `@platforms` repositories were originally part of the semantics.bzl config because performing rewrites on the code as part of the Bazel code export process was too difficult.

With the direction being reversed (imported instead of exported), and the scope of the codebase being reduced (just rules_python instead of the entire Bazel codebase), it's easier to perform copybara rewrites.

In particular, the `"//` strings are problematic to rewrite because they look like intra-repo references instead of parts of a larger expression.