### PR TITLE
cleanup: delete defunct load of bzlmod pip_repository

### DIFF
--- a/python/pip_install/BUILD.bazel
+++ b/python/pip_install/BUILD.bazel
@@ -34,7 +34,6 @@ bzl_library(
         "//python/private:render_pkg_aliases_bzl",
         "//python/private:toolchains_repo_bzl",
         "//python/private:which_bzl",
-        "//python/private/bzlmod:pip_repository_bzl",
     ],
 )
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -26,16 +26,12 @@ load("//python/private:patch_whl.bzl", "patch_whl")
 load("//python/private:render_pkg_aliases.bzl", "render_pkg_aliases")
 load("//python/private:toolchains_repo.bzl", "get_host_os_arch")
 load("//python/private:which.bzl", "which_with_fail")
-load("//python/private/bzlmod:pip_repository.bzl", _pip_hub_repository_bzlmod = "pip_repository")
 
 CPPFLAGS = "CPPFLAGS"
 
 COMMAND_LINE_TOOLS_PATH_SLUG = "commandlinetools"
 
 _WHEEL_ENTRY_POINT_PREFIX = "rules_python_wheel_entry_point"
-
-# Kept for not creating merge conflicts with PR#1476, can be removed later.
-pip_hub_repository_bzlmod = _pip_hub_repository_bzlmod
 
 def _construct_pypath(rctx):
     """Helper function to construct a PYTHONPATH.


### PR DESCRIPTION
The non-bzlmod pip_repository code loads the bzlmod pip_repository code for some reason,
but nothing else uses that reference. A comment indicates it was only done to make
merge conflicts easier to manage for PR #1476.