### PR TITLE
cleanup: delete commented out line forgottenly left in

### DIFF
--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -28,7 +28,6 @@ class PipInstallTest(unittest.TestCase):
     def _remove_leading_dirs(self, paths):
         # Removes the first two directories (external/<reponame>)
         # to normalize what workspace and bzlmod produce.
-        #return [str(Path(*Path(v).parts[2:])) for v in paths]
         return [
             '/'.join(v.split('/')[2:])
             for v in paths


### PR DESCRIPTION
I forget to remove a commented out line before merging a PR; just cleaning that up.
