### PR TITLE
tests: disable bzlmod for workspace-only build_file_generation example

### DIFF
--- a/examples/build_file_generation/.bazelrc
+++ b/examples/build_file_generation/.bazelrc
@@ -3,3 +3,7 @@ test --test_output=errors --enable_runfiles
 # Windows requires these for multi-python support:
 build --enable_runfiles
 startup --windows_enable_symlinks
+
+# The bzlmod version of this example is in examples/bzlmod_build_file_generation
+# Once WORKSPACE support is dropped, this example can be entirely deleted.
+build --experimental_enable_bzlmod=false


### PR DESCRIPTION
The build_file_generation example only supports workspace style builds. The bzlmod equivalent is in `examples/bzlmod_build_file_generation`

Work towards #1520