### PR TITLE
tests: disable bzlmod for workspace-only pip_repository_annotations example

### DIFF
--- a/examples/pip_repository_annotations/.bazelrc
+++ b/examples/pip_repository_annotations/.bazelrc
@@ -1,2 +1,6 @@
 # https://docs.bazel.build/versions/main/best-practices.html#using-the-bazelrc-file
 try-import %workspace%/user.bazelrc
+
+# This example is WORKSPACE specific. The equivalent functionality
+# is in examples/bzlmod as the `whl_mods` feature.
+build --experimental_enable_bzlmod=false


### PR DESCRIPTION
The pip_repository_annoations example is workspace-only. Its equivalent functionality is demonstrated in examples/bzlmod with the whl_mods feature.

Work towards #1520 