### PR TITLE
fix: always ignore `.pyc.NNNN` files from the hermetic runtime tree

### DIFF
--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -234,6 +234,7 @@ def _python_repository_impl(rctx):
         # tests for the standard libraries.
         "lib/python{python_version}/**/test/**".format(python_version = python_short_version),
         "lib/python{python_version}/**/tests/**".format(python_version = python_short_version),
+        "**/__pycache__/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNN are created
     ]
 
     if rctx.attr.ignore_root_user_error:
@@ -243,7 +244,6 @@ def _python_repository_impl(rctx):
             # the definition of this filegroup will change, and depending rules will get invalidated."
             # See https://github.com/bazelbuild/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them."
             "**/__pycache__/*.pyc",
-            "**/__pycache__/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNN are created
             "**/__pycache__/*.pyo",
         ]
 


### PR DESCRIPTION
Part of the pyc compilation process is to create a temporary file named `<name>.pyc.NNNN`, where `NNNN` is a timestamp. Once the pyc is entirely written, this file is renamed to the regular pyc file name. These files only exist for brief periods of time, but its possible for different threads/processes to see the temporary files when computing the glob() values. Later, since the file is gone, an error is raised about the file missing.

PR #1266 mostly fixed this issue, except that the exclude for the `.pyc.NNNN` files for an
interpreter runtime's files was behind the `ignore_root_user_error` flag, which meant it
wasn't always applied. This changes it to always be applied, which should eliminate the
failures due to the missing NNNN files.

Fixes #1261

Work towards #1520
