### PR TITLE
test(pystar): run pystar under Windows and Mac

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -63,6 +63,17 @@ buildifier:
     - //tests:version_3_8_test
     - //tests:version_3_9_test
     - //tests:version_default_test
+.pystar_base: &pystar_base
+  # TODO: Change to "7.x" once Bazel 7 is available
+  # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
+  # is available in rolling.
+  bazel: "last_rc"
+  environment:
+    RULES_PYTHON_ENABLE_PYSTAR: "1"
+  test_flags:
+    # The doc check tests fail because the Starlark implementation makes the
+    # PyInfo and PyRuntimeInfo symbols become documented.
+    - "--test_tag_filters=-integration-test,-doc_check_test"
 tasks:
   gazelle_extension_min:
     <<: *minimum_supported_version
@@ -94,35 +105,27 @@ tasks:
     <<: *reusable_config
     name: Default test on Ubuntu
     platform: ubuntu2004
-  ubuntu_bazel_rolling:
+  ubuntu_pystar_workspace:
     <<: *reusable_config
+    <<: *pystar_base
     name: "Default test: Ubuntu, Pystar, workspace"
     platform: ubuntu2004
-    # TODO: Change to "rolling" once
-    # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
-    # is available in rolling.
-    bazel: "last_green"
-    environment:
-      RULES_PYTHON_ENABLE_PYSTAR: "1"
-    test_flags:
-      # The doc check tests fail because the Starlark implementation makes the
-      # PyInfo and PyRuntimeInfo symbols become documented.
-      - "--test_tag_filters=-integration-test,-doc_check_test"
-  ubuntu_bazel_rolling_bzlmod:
+  ubuntu_pystar_bzlmod:
     <<: *reusable_config
     <<: *common_bzlmod_flags
+    <<: *pystar_base
     name: "Default test: Ubuntu, Pystar, bzlmod"
     platform: ubuntu2004
-    # TODO: Change to "rolling" once
-    # https://github.com/bazelbuild/bazel/commit/f3aafea59ae021c6a12086cb2cd34c5fa782faf1
-    # is available in rolling.
-    bazel: "last_green"
-    environment:
-      RULES_PYTHON_ENABLE_PYSTAR: "1"
-    test_flags:
-      # The doc check tests fail because the Starlark implementation makes the
-      # PyInfo and PyRuntimeInfo symbols become documented.
-      - "--test_tag_filters=-integration-test,-doc_check_test"
+  mac_pystar_workspace:
+    <<: *reusable_config
+    <<: *pystar_base
+    name: "Default test: Mac, Pystar, workspace"
+    platform: macos
+  windows_pystar_workspace:
+    <<: *reusable_config
+    <<: *pystar_base
+    name: "Default test: Mac, Pystar, workspace"
+    platform: windows
 
   debian:
     <<: *reusable_config

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -43,6 +43,11 @@ def _test_basic_windows(name, config):
             "//command_line_option:crosstool_top": Label("//tests/cc:cc_toolchain_suite"),
             "//command_line_option:extra_toolchains": [str(Label("//tests/cc:all"))],
             "//command_line_option:platforms": [WINDOWS],
+            # NOTE: The default for this flag is based on the Bazel host OS, not
+            # the target platform. For windows, it defaults to true, so force
+            # it to that to match behavior when this test runs on other
+            # platforms.
+            "//command_line_option:build_python_zip": "true",
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )
@@ -51,7 +56,7 @@ def _test_basic_windows_impl(env, target):
     target = env.expect.that_target(target)
     target.executable().path().contains(".exe")
     target.runfiles().contains_predicate(matching.str_endswith(
-        target.meta.format_str("/{name}"),
+        target.meta.format_str("/{name}.zip"),
     ))
     target.runfiles().contains_predicate(matching.str_endswith(
         target.meta.format_str("/{name}.exe"),

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -39,15 +39,15 @@ def _test_basic_windows(name, config):
         impl = _test_basic_windows_impl,
         target = name + "_subject",
         config_settings = {
-            "//command_line_option:cpu": "windows_x86_64",
-            "//command_line_option:crosstool_top": Label("//tests/cc:cc_toolchain_suite"),
-            "//command_line_option:extra_toolchains": [str(Label("//tests/cc:all"))],
-            "//command_line_option:platforms": [WINDOWS],
             # NOTE: The default for this flag is based on the Bazel host OS, not
             # the target platform. For windows, it defaults to true, so force
             # it to that to match behavior when this test runs on other
             # platforms.
             "//command_line_option:build_python_zip": "true",
+            "//command_line_option:cpu": "windows_x86_64",
+            "//command_line_option:crosstool_top": Label("//tests/cc:cc_toolchain_suite"),
+            "//command_line_option:extra_toolchains": [str(Label("//tests/cc:all"))],
+            "//command_line_option:platforms": [WINDOWS],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )


### PR DESCRIPTION
This is to have better test coverage. Only workspace for them is used because of limited CI slots.

This also fixes the test_basic_windows test. The `--build_python_zip` flag built into Bazel has a different default depending on the host OS (not target platform): true for windows, and false otherwise. Updated the test to force the flag value for reliable behavior between platforms.

Work towards #1069