### PR TITLE
fix(toolchains): include tcl/** files in Windows interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Breaking changes:
 * (gazelle) Generate a single `py_test` target when `gazelle:python_generation_mode project`
   is used.
 
+* (python_register_toolchains) Keep tcl subdirectory in Windows build of hermetic interpreter.
+
 ### Added
 
 * (bzlmod) Added `.whl` patching support via `patches` and `patch_strip`

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -259,6 +259,7 @@ def _python_repository_impl(rctx):
             "libs/**",
             "Scripts/**",
             "share/**",
+            "tcl/**",
         ]
     else:
         glob_include += [


### PR DESCRIPTION
closes #1544 

The tcl subdirectory of the interpreter Windows build needs to be kept otherwise packages such as matplotlib will break.
