### PR TITLE
feat(gazelle): use relative paths for resolved imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ A brief description of the categories of changes:
   or `requirements_in` attributes are unspecified, matching the upstream
   `pip-compile` behaviour more closely.
 
+* Make Gazelle use relative paths if possible for dependencies added through
+  the use of the `resolve` directive.
+
 Breaking changes:
 
 * (pip) `pip_install` repository rule in this release has been disabled and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ A brief description of the categories of changes:
   or `requirements_in` attributes are unspecified, matching the upstream
   `pip-compile` behaviour more closely.
 
-* Make Gazelle use relative paths if possible for dependencies added through
+* (gazelle) Use relative paths if possible for dependencies added through
   the use of the `resolve` directive.
 
 Breaking changes:

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -172,7 +172,7 @@ func (py *Resolver) Resolve(
 						if override.Repo == from.Repo {
 							override.Repo = ""
 						}
-						dep := override.String()
+						dep := override.Rel(from.Repo, from.Pkg).String()
 						deps.Add(dep)
 						if explainDependency == dep {
 							log.Printf("Explaining dependency (%s): "+

--- a/gazelle/python/testdata/relative_imports/BUILD.in
+++ b/gazelle/python/testdata/relative_imports/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:resolve py resolved_package //package2:resolved_package

--- a/gazelle/python/testdata/relative_imports/BUILD.out
+++ b/gazelle/python/testdata/relative_imports/BUILD.out
@@ -1,5 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
+# gazelle:resolve py resolved_package //package2:resolved_package
+
 py_library(
     name = "relative_imports",
     srcs = [

--- a/gazelle/python/testdata/relative_imports/package2/BUILD.out
+++ b/gazelle/python/testdata/relative_imports/package2/BUILD.out
@@ -9,4 +9,5 @@ py_library(
         "subpackage1/module5.py",
     ],
     visibility = ["//:__subpackages__"],
+    deps = ["//package2:resolved_package"],
 )

--- a/gazelle/python/testdata/relative_imports/package2/BUILD.out
+++ b/gazelle/python/testdata/relative_imports/package2/BUILD.out
@@ -9,5 +9,5 @@ py_library(
         "subpackage1/module5.py",
     ],
     visibility = ["//:__subpackages__"],
-    deps = ["//package2:resolved_package"],
+    deps = [":resolved_package"],
 )

--- a/gazelle/python/testdata/relative_imports/package2/module3.py
+++ b/gazelle/python/testdata/relative_imports/package2/module3.py
@@ -15,6 +15,7 @@
 from . import Class1
 from .subpackage1.module5 import function5
 
+import resolved_package
 
 def function3():
     c1 = Class1()


### PR DESCRIPTION
Modify the Gazelle plugin so that when it adds a `dep` because of a `resolve` directive it makes it a relative import if possible.

The first commit adds a test for the existing behavior, where inside of `//package2` the dependency `//package2:resolved_package` is added. The second commit updates the test and the behavior so inside of `//package2` we add `: resolved_package` instead.