### PR TITLE
chore!: remove incompatible_generate_aliases and related flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ A brief description of the categories of changes:
 
 ### Changed
 
+* **BREAKING** The deprecated `incompatible_generate_aliases` feature flags
+  from `pip_parse` and `gazelle` got removed. They have been flipped to `True`
+  in 0.27.0 release.
+
 ### Fixed
 
 * (bzlmod pip.parse) Use a platform-independent reference to the interpreter

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,7 +120,6 @@ pip_parse(
             "sphinxcontrib-applehelp",
         ],
     },
-    incompatible_generate_aliases = True,
     python_interpreter_target = interpreter,
     requirements_lock = "//docs/sphinx:requirements.txt",
 )

--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -25,7 +25,6 @@ def gazelle_python_manifest(
         pip_repository_name = "",
         pip_deps_repository_name = "",
         manifest = ":gazelle_python.yaml",
-        use_pip_repository_aliases = None,
         **kwargs):
     """A macro for defining the updating and testing targets for the Gazelle manifest file.
 
@@ -35,8 +34,6 @@ def gazelle_python_manifest(
             requirements files that will be concatenated before passing on to
             the manifest generator.
         pip_repository_name: the name of the pip_install or pip_repository target.
-        use_pip_repository_aliases: boolean flag to enable using user-friendly
-            python package aliases. Defaults to True.
         pip_deps_repository_name: deprecated - the old pip_install target name.
         modules_mapping: the target for the generated modules_mapping.json file.
         manifest: the target for the Gazelle manifest file.
@@ -84,24 +81,6 @@ def gazelle_python_manifest(
         "--update-target",
         update_target_label,
     ]
-
-    # TODO @aignas 2023-10-31: When removing this code, cleanup the
-    # code in gazelle to only work with aliased targets.
-    if use_pip_repository_aliases == None:
-        update_args += [
-            "--omit-pip-repository-aliases-setting",
-            "true",
-        ]
-    elif use_pip_repository_aliases:
-        update_args += [
-            "--use-pip-repository-aliases",
-            "true",
-        ]
-    else:
-        update_args += [
-            "--use-pip-repository-aliases",
-            "false",
-        ]
 
     go_binary(
         name = update_target,

--- a/gazelle/manifest/generate/generate.go
+++ b/gazelle/manifest/generate/generate.go
@@ -42,8 +42,6 @@ func main() {
 		manifestGeneratorHashPath string
 		requirementsPath          string
 		pipRepositoryName         string
-		usePipRepositoryAliases   bool
-		omitUsePipRepositoryAliases   bool
 		modulesMappingPath        string
 		outputPath                string
 		updateTarget              string
@@ -64,16 +62,6 @@ func main() {
 		"pip-repository-name",
 		"",
 		"The name of the pip_install or pip_repository target.")
-	flag.BoolVar(
-		&usePipRepositoryAliases,
-		"use-pip-repository-aliases",
-		true,
-		"Whether to use the pip-repository aliases, which are generated when passing 'incompatible_generate_aliases = True'.")
-	flag.BoolVar(
-		&omitUsePipRepositoryAliases,
-		"omit-pip-repository-aliases-setting",
-		false,
-		"Whether to omit use-pip-repository-aliases flag serialization into the manifest.")
 	flag.StringVar(
 		&modulesMappingPath,
 		"modules-mapping",
@@ -115,12 +103,6 @@ func main() {
 	header := generateHeader(updateTarget)
 	repository := manifest.PipRepository{
 		Name:                    pipRepositoryName,
-	}
-
-	if omitUsePipRepositoryAliases {
-		repository.UsePipRepositoryAliases = nil
-	} else {
-		repository.UsePipRepositoryAliases = &usePipRepositoryAliases
 	}
 
 	manifestFile := manifest.NewFile(&manifest.Manifest{

--- a/gazelle/manifest/manifest.go
+++ b/gazelle/manifest/manifest.go
@@ -144,7 +144,4 @@ type Manifest struct {
 type PipRepository struct {
 	// The name of the pip_parse or pip_repository target.
 	Name string
-	// UsePipRepositoryAliases allows to use aliases generated pip_repository
-	// when passing incompatible_generate_aliases = True.
-	UsePipRepositoryAliases *bool `yaml:"use_pip_repository_aliases,omitempty"`
 }

--- a/gazelle/pythonconfig/pythonconfig.go
+++ b/gazelle/pythonconfig/pythonconfig.go
@@ -239,13 +239,6 @@ func (c *Config) FindThirdPartyDependency(modName string) (string, bool) {
 				}
 				sanitizedDistribution := SanitizeDistribution(distributionName)
 
-				if repo := gazelleManifest.PipRepository; repo != nil && (repo.UsePipRepositoryAliases != nil && *repo.UsePipRepositoryAliases == false) {
-					// TODO @aignas 2023-10-31: to be removed later.
-					// @<repository_name>_<distribution_name>//:pkg
-					distributionRepositoryName = distributionRepositoryName + "_" + sanitizedDistribution
-					lbl := label.New(distributionRepositoryName, "", "pkg")
-					return lbl.String(), true
-				}
 
 				// @<repository_name>//<distribution_name>
 				lbl := label.New(distributionRepositoryName, sanitizedDistribution, sanitizedDistribution)

--- a/python/private/bzlmod/pip.bzl
+++ b/python/private/bzlmod/pip.bzl
@@ -394,9 +394,6 @@ The labels are JSON config files describing the modifications.
     # don't allow users to override it.
     attrs.pop("repo_prefix")
 
-    # incompatible_generate_aliases is always True in bzlmod
-    attrs.pop("incompatible_generate_aliases")
-
     return attrs
 
 def _whl_mod_attrs():
@@ -522,9 +519,8 @@ the BUILD files for wheels.
 This tag class is used to create a pip hub and all of the spokes that are part of that hub.
 This tag class reuses most of the pip attributes that are found in
 @rules_python//python/pip_install:pip_repository.bzl.
-The exceptions are it does not use the args 'repo_prefix',
-and 'incompatible_generate_aliases'.  We set the repository prefix
-for the user and the alias arg is always True in bzlmod.
+The exception is it does not use the arg 'repo_prefix'.  We set the repository
+prefix for the user and the alias arg is always True in bzlmod.
 """,
         ),
         "whl_mods": tag_class(

--- a/python/private/py_console_script_binary.bzl
+++ b/python/private/py_console_script_binary.bzl
@@ -27,9 +27,7 @@ def _dist_info(pkg):
     rules_python does not know anything about the hub repos that the user has
     available.
 
-    NOTE: Works with `incompatible_generate_aliases` and without by assuming the
-    following formats:
-        * @pypi_pylint//:pkg
+    NOTE: Works with assuming the following label formats:
         * @pypi//pylint
         * @pypi//pylint:pkg
         * Label("@pypi//pylint:pkg")
@@ -70,7 +68,6 @@ def py_console_script_binary(
 
     py_console_script_gen(
         name = "_{}_gen".format(name),
-        # NOTE @aignas 2023-08-05: Works with `incompatible_generate_aliases` and without.
         entry_points_txt = entry_points_txt or _dist_info(pkg),
         out = main,
         console_script = script,


### PR DESCRIPTION
According to our breaking change policy, we are removing the flag
since in the previous release it has been flipped by default and
enabled to all users in 0.27.0.
