### PR TITLE
doc: add a py_proto_library example with well-known-types

### DIFF
--- a/examples/py_proto_library/MODULE.bazel
+++ b/examples/py_proto_library/MODULE.bazel
@@ -21,3 +21,6 @@ use_repo(python, "python_3_9")
 
 # We are using rules_proto to define rules_proto targets to be consumed by py_proto_library.
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+
+# Add the protobuf library for well-known types (e.g. `Any`, `Timestamp`, etc)
+bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")

--- a/examples/py_proto_library/example.com/proto/BUILD.bazel
+++ b/examples/py_proto_library/example.com/proto/BUILD.bazel
@@ -13,4 +13,5 @@ proto_library(
     # https://bazel.build/reference/be/protocol-buffer#proto_library.strip_import_prefix
     strip_import_prefix = "/example.com",
     visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:any_proto"],
 )

--- a/examples/py_proto_library/example.com/proto/pricetag.proto
+++ b/examples/py_proto_library/example.com/proto/pricetag.proto
@@ -1,8 +1,11 @@
 syntax = "proto3";
 
+import "google/protobuf/any.proto";
+
 package rules_python;
 
 message PriceTag {
   string name = 2;
   double cost = 1;
+  google.protobuf.Any metadata = 3;
 }

--- a/examples/py_proto_library/test.py
+++ b/examples/py_proto_library/test.py
@@ -1,4 +1,4 @@
-import sys
+import json
 import unittest
 
 from proto import pricetag_pb2
@@ -10,6 +10,10 @@ class TestCase(unittest.TestCase):
             name="dollar",
             cost=5.00,
         )
+
+        metadata = {"description": "some text..."}
+        got.metadata.value = json.dumps(metadata).encode("utf-8")
+
         self.assertIsNotNone(got)
 
 


### PR DESCRIPTION
This behaviour should be in the latest release (0.27.0), so just
documenting it for the future.

Fixes #1005
