### PR TITLE
feat: use rules_python implemented py_runtime, py_runtime_pair, PyRuntimeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ A brief description of the categories of changes:
 
 ## Unreleased
 
+### Changed
+
+* (toolchains) `py_runtime`, `py_runtime_pair`, and `PyRuntimeInfo` now use the
+  rules_python Starlark implementation, not the one built into Bazel. NOTE: This
+  only applies to Bazel 6+; Bazel 5 still uses the builtin implementation.
+
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 
 ## [0.27.0] - 2023-11-16

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -157,7 +157,6 @@ bzl_library(
     deps = [
         "//python/private:util_bzl",
         "//python/private/common:py_runtime_macro_bzl",
-        "@rules_python_internal//:rules_python_config_bzl",
     ],
 )
 
@@ -167,7 +166,7 @@ bzl_library(
     deps = [
         "//python/private:bazel_tools_bzl",
         "//python/private:py_runtime_pair_macro_bzl",
-        "@rules_python_internal//:rules_python_config_bzl",
+        "//python/private:util_bzl",
     ],
 )
 
@@ -176,8 +175,8 @@ bzl_library(
     srcs = ["py_runtime_info.bzl"],
     deps = [
         "//python/private:reexports_bzl",
+        "//python/private:util_bzl",
         "//python/private/common:providers_bzl",
-        "@rules_python_internal//:rules_python_config_bzl",
     ],
 )
 

--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -74,7 +74,7 @@ bzl_library(
     srcs = ["providers.bzl"],
     deps = [
         ":semantics_bzl",
-        "@rules_python_internal//:rules_python_config_bzl",
+        "//python/private:util_bzl",
     ],
 )
 
@@ -171,9 +171,10 @@ bzl_library(
     srcs = ["py_runtime_rule.bzl"],
     deps = [
         ":attributes_bzl",
-        ":common_bzl",
         ":providers_bzl",
         ":py_internal_bzl",
+        "//python/private:reexports_bzl",
+        "//python/private:util_bzl",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
     ],

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -13,14 +13,15 @@
 # limitations under the License.
 """Providers for Python rules."""
 
-load("@rules_python_internal//:rules_python_config.bzl", "config")
+load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")
 
 # TODO: load CcInfo from rules_cc
 _CcInfo = CcInfo
 
 DEFAULT_STUB_SHEBANG = "#!/usr/bin/env python3"
 
-DEFAULT_BOOTSTRAP_TEMPLATE = "@bazel_tools//tools/python:python_bootstrap_template.txt"
+DEFAULT_BOOTSTRAP_TEMPLATE = Label("//python/private:python_bootstrap_template.txt")
+
 _PYTHON_VERSION_VALUES = ["PY2", "PY3"]
 
 # Helper to make the provider definitions not crash under Bazel 5.4:
@@ -31,7 +32,7 @@ _PYTHON_VERSION_VALUES = ["PY2", "PY3"]
 # This isn't actually used under Bazel 5.4, so just stub out the values
 # to get past the loading phase.
 def _define_provider(doc, fields, **kwargs):
-    if not config.enable_pystar:
+    if not IS_BAZEL_6_OR_HIGHER:
         return provider("Stub, not used", fields = []), None
     return provider(doc = doc, fields = fields, **kwargs)
 

--- a/python/private/py_runtime_pair_rule.bzl
+++ b/python/private/py_runtime_pair_rule.bzl
@@ -15,10 +15,11 @@
 """Implementation of py_runtime_pair."""
 
 load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
+load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")
 
 def _py_runtime_pair_impl(ctx):
     if ctx.attr.py2_runtime != None:
-        py2_runtime = ctx.attr.py2_runtime[PyRuntimeInfo]
+        py2_runtime = _get_py_runtime_info(ctx.attr.py2_runtime)
         if py2_runtime.python_version != "PY2":
             fail("The Python runtime in the 'py2_runtime' attribute did not have " +
                  "version 'PY2'")
@@ -26,7 +27,7 @@ def _py_runtime_pair_impl(ctx):
         py2_runtime = None
 
     if ctx.attr.py3_runtime != None:
-        py3_runtime = ctx.attr.py3_runtime[PyRuntimeInfo]
+        py3_runtime = _get_py_runtime_info(ctx.attr.py3_runtime)
         if py3_runtime.python_version != "PY3":
             fail("The Python runtime in the 'py3_runtime' attribute did not have " +
                  "version 'PY3'")
@@ -43,6 +44,12 @@ def _py_runtime_pair_impl(ctx):
         py3_runtime = py3_runtime,
     )]
 
+def _get_py_runtime_info(target):
+    if PyRuntimeInfo in target:
+        return target[PyRuntimeInfo]
+    else:
+        return target[BuiltinPyRuntimeInfo]
+
 # buildifier: disable=unused-variable
 def _is_py2_disabled(ctx):
     # Because this file isn't bundled with Bazel, so we have to conditionally
@@ -58,7 +65,7 @@ py_runtime_pair = rule(
         # The two runtimes are used by the py_binary at runtime, and so need to
         # be built for the target platform.
         "py2_runtime": attr.label(
-            providers = [PyRuntimeInfo],
+            providers = [[PyRuntimeInfo], [BuiltinPyRuntimeInfo]],
             cfg = "target",
             doc = """\
 The runtime to use for Python 2 targets. Must have `python_version` set to
@@ -66,7 +73,7 @@ The runtime to use for Python 2 targets. Must have `python_version` set to
 """,
         ),
         "py3_runtime": attr.label(
-            providers = [PyRuntimeInfo],
+            providers = [[PyRuntimeInfo], [BuiltinPyRuntimeInfo]],
             cfg = "target",
             doc = """\
 The runtime to use for Python 3 targets. Must have `python_version` set to

--- a/python/private/reexports.bzl
+++ b/python/private/reexports.bzl
@@ -37,4 +37,4 @@ different name. Then we can load it from elsewhere.
 BuiltinPyInfo = PyInfo
 
 # buildifier: disable=name-conventions
-internal_PyRuntimeInfo = PyRuntimeInfo
+BuiltinPyRuntimeInfo = PyRuntimeInfo

--- a/python/private/util.bzl
+++ b/python/private/util.bzl
@@ -83,3 +83,9 @@ def add_tag(attrs, tag):
             attrs["tags"] = tags + [tag]
     else:
         attrs["tags"] = [tag]
+
+IS_BAZEL_7_OR_HIGHER = hasattr(native, "starlark_doc_extract")
+
+# Bazel 5.4 has a bug where every access of testing.ExecutionInfo is a
+# different object that isn't equal to any other. This is fixed in bazel 6+.
+IS_BAZEL_6_OR_HIGHER = testing.ExecutionInfo == testing.ExecutionInfo

--- a/python/py_runtime.bzl
+++ b/python/py_runtime.bzl
@@ -14,12 +14,11 @@
 
 """Public entry point for py_runtime."""
 
-load("@rules_python_internal//:rules_python_config.bzl", "config")
-load("//python/private:util.bzl", "add_migration_tag")
+load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER", "add_migration_tag")
 load("//python/private/common:py_runtime_macro.bzl", _starlark_py_runtime = "py_runtime")
 
 # buildifier: disable=native-python
-_py_runtime_impl = _starlark_py_runtime if config.enable_pystar else native.py_runtime
+_py_runtime_impl = _starlark_py_runtime if IS_BAZEL_6_OR_HIGHER else native.py_runtime
 
 def py_runtime(**attrs):
     """See the Bazel core [py_runtime](https://docs.bazel.build/versions/master/be/python.html#py_runtime) documentation.

--- a/python/py_runtime_info.bzl
+++ b/python/py_runtime_info.bzl
@@ -14,8 +14,8 @@
 
 """Public entry point for PyRuntimeInfo."""
 
-load("@rules_python_internal//:rules_python_config.bzl", "config")
-load("//python/private:reexports.bzl", "internal_PyRuntimeInfo")
+load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")
+load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")
 load("//python/private/common:providers.bzl", _starlark_PyRuntimeInfo = "PyRuntimeInfo")
 
-PyRuntimeInfo = _starlark_PyRuntimeInfo if config.enable_pystar else internal_PyRuntimeInfo
+PyRuntimeInfo = _starlark_PyRuntimeInfo if IS_BAZEL_6_OR_HIGHER else BuiltinPyRuntimeInfo

--- a/python/py_runtime_pair.bzl
+++ b/python/py_runtime_pair.bzl
@@ -15,10 +15,10 @@
 """Public entry point for py_runtime_pair."""
 
 load("@bazel_tools//tools/python:toolchain.bzl", _bazel_tools_impl = "py_runtime_pair")
-load("@rules_python_internal//:rules_python_config.bzl", "config")
 load("//python/private:py_runtime_pair_macro.bzl", _starlark_impl = "py_runtime_pair")
+load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")
 
-_py_runtime_pair = _bazel_tools_impl if not config.enable_pystar else _starlark_impl
+_py_runtime_pair = _starlark_impl if IS_BAZEL_6_OR_HIGHER else _bazel_tools_impl
 
 # NOTE: This doc is copy/pasted from the builtin py_runtime_pair rule so our
 # doc generator gives useful API docs.

--- a/tests/base_rules/util.bzl
+++ b/tests/base_rules/util.bzl
@@ -14,6 +14,7 @@
 """Helpers and utilities multiple tests re-use."""
 
 load("@bazel_skylib//lib:structs.bzl", "structs")
+load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")  # buildifier: disable=bzl-visibility
 
 # Use this with is_windows()
 WINDOWS_ATTR = {"windows": attr.label(default = "@platforms//os:windows")}
@@ -53,9 +54,7 @@ def _struct_with(s, **kwargs):
     return struct(**struct_dict)
 
 def _is_bazel_6_or_higher():
-    # Bazel 5.4 has a bug where every access of testing.ExecutionInfo is a
-    # different object that isn't equal to any other. This is fixed in bazel 6+.
-    return testing.ExecutionInfo == testing.ExecutionInfo
+    return IS_BAZEL_6_OR_HIGHER
 
 def _is_windows(env):
     """Tell if the target platform is windows.

--- a/tests/py_runtime_pair/py_runtime_pair_tests.bzl
+++ b/tests/py_runtime_pair/py_runtime_pair_tests.bzl
@@ -19,7 +19,27 @@ load("@rules_testing//lib:truth.bzl", "matching", "subjects")
 load("@rules_testing//lib:util.bzl", rt_util = "util")
 load("//python:py_runtime.bzl", "py_runtime")
 load("//python:py_runtime_pair.bzl", "py_runtime_pair")
+load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")  # buildifier: disable=bzl-visibility
 load("//tests:py_runtime_info_subject.bzl", "py_runtime_info_subject")
+
+def _toolchain_factory(value, meta):
+    return subjects.struct(
+        value,
+        meta = meta,
+        attrs = {
+            "py3_runtime": py_runtime_info_subject,
+        },
+    )
+
+def _provides_builtin_py_runtime_info_impl(ctx):  # @unused
+    return [BuiltinPyRuntimeInfo(
+        python_version = "PY3",
+        interpreter_path = "builtin",
+    )]
+
+_provides_builtin_py_runtime_info = rule(
+    implementation = _provides_builtin_py_runtime_info_impl,
+)
 
 _tests = []
 
@@ -45,19 +65,39 @@ def _test_basic(name):
 def _test_basic_impl(env, target):
     toolchain = env.expect.that_target(target).provider(
         platform_common.ToolchainInfo,
-        factory = lambda value, meta: subjects.struct(
-            value,
-            meta = meta,
-            attrs = {
-                "py3_runtime": py_runtime_info_subject,
-            },
-        ),
+        factory = _toolchain_factory,
     )
     toolchain.py3_runtime().python_version().equals("PY3")
     toolchain.py3_runtime().files().contains_predicate(matching.file_basename_equals("file1.txt"))
     toolchain.py3_runtime().interpreter().path().contains("fake_interpreter")
 
 _tests.append(_test_basic)
+
+def _test_builtin_py_info_accepted(name):
+    rt_util.helper_target(
+        _provides_builtin_py_runtime_info,
+        name = name + "_runtime",
+    )
+    rt_util.helper_target(
+        py_runtime_pair,
+        name = name + "_subject",
+        py3_runtime = name + "_runtime",
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_builtin_py_info_accepted_impl,
+    )
+
+def _test_builtin_py_info_accepted_impl(env, target):
+    toolchain = env.expect.that_target(target).provider(
+        platform_common.ToolchainInfo,
+        factory = _toolchain_factory,
+    )
+    toolchain.py3_runtime().python_version().equals("PY3")
+    toolchain.py3_runtime().interpreter_path().equals("builtin")
+
+_tests.append(_test_builtin_py_info_accepted)
 
 def py_runtime_pair_test_suite(name):
     test_suite(


### PR DESCRIPTION
This switches over to using the rules_python implementation of `py_runtime`,
`py_runtime_pair`, and `PyRuntimeInfo` for Bazel 6 and higher. Bazel 5 lacks features
(specifically provider ctors) to allow enabling it on that version.

This is possible because the rules don't directly use the PyRuntimeInfo provider
(mostly, see below), they only care about the structure of it as exposed from the
ToolchainInfo provider.

Switching the toolchain providers and rules over early allows some development of
the toolchain prior to Bazel 7 and the rest of the rules_python Starlark implementation
being enabled.

The builtin PyRuntimeInfo is still returned and accepted for two reasons:
* Better compatibility with the builtin rules to make transitioning easier
* `py_binary` has an old, possibly defunct (not sure) code path that will look up the
  the PyRuntimeInfo from a flag/implicit attribute.