### PR TITLE
refactor: toolchainize py_proto_library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
-bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+bazel_dep(name = "rules_proto", version = "6.0.0-rc1")
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 
 internal_deps = use_extension("@rules_python//python/private/bzlmod:internal_deps.bzl", "internal_deps")

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -22,7 +22,6 @@ python_register_toolchains(
 # Then we need to setup dependencies in order to use py_proto_library
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-
 http_archive(
     name = "rules_proto",
     sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
@@ -31,15 +30,18 @@ http_archive(
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-26.1",
     sha256 = "4fc5ff1b2c339fb86cd3a25f0b5311478ab081e65ad258c6789359cd84d421f8",
+    strip_prefix = "protobuf-26.1",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v26.1.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -1,3 +1,5 @@
+# NB: short workspace name is required to workaround PATH length limitation, see
+# https://github.com/bazelbuild/bazel/issues/18683#issuecomment-1843857373
 workspace(name = "p")
 
 # The following local_path_override is only needed to run this example as part of our CI.

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -22,6 +22,7 @@ python_register_toolchains(
 # Then we need to setup dependencies in order to use py_proto_library
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+
 http_archive(
     name = "rules_proto",
     sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
@@ -30,17 +31,15 @@ http_archive(
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
 rules_proto_dependencies()
-
 rules_proto_toolchains()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-25.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v25.3.tar.gz"],
+    strip_prefix = "protobuf-26.1",
+    sha256 = "4fc5ff1b2c339fb86cd3a25f0b5311478ab081e65ad258c6789359cd84d421f8",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v26.1.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
 protobuf_deps()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -22,27 +22,28 @@ python_register_toolchains(
 # Then we need to setup dependencies in order to use py_proto_library
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+
 http_archive(
     name = "rules_proto",
-    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-    strip_prefix = "rules_proto-5.3.0-21.7",
-    urls = [
-        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-    ],
+    sha256 = "903af49528dc37ad2adbb744b317da520f133bc1cbbecbdd2a6c546c9ead080b",
+    strip_prefix = "rules_proto-6.0.0-rc0",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc0/rules_proto-6.0.0-rc0.tar.gz",
 )
+
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
-    urls = [
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-    ],
+    # sha256 = "8632d7e8a6cbbd7e58f40e3f62fed77bff3df6e4dcac73498f0a68ba5a38d892",
+    strip_prefix = "protobuf-d1c5e885b7b7d3ac888e89cf4d45cb0c9fa6b4ed",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/d1c5e885b7b7d3ac888e89cf4d45cb0c9fa6b4ed.tar.gz"],
 )
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps", "protobuf_register_toolchains")
+protobuf_deps()
+protobuf_register_toolchains()
 
-rules_proto_dependencies()
-
-rules_proto_toolchains()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -22,7 +22,6 @@ python_register_toolchains(
 # Then we need to setup dependencies in order to use py_proto_library
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-
 http_archive(
     name = "rules_proto",
     sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
@@ -31,18 +30,17 @@ http_archive(
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-rules_proto_dependencies()
-rules_proto_toolchains()
 
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 http_archive(
     name = "com_google_protobuf",
-    # sha256 = "8632d7e8a6cbbd7e58f40e3f62fed77bff3df6e4dcac73498f0a68ba5a38d892",
-    strip_prefix = "protobuf-d1c5e885b7b7d3ac888e89cf4d45cb0c9fa6b4ed",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/d1c5e885b7b7d3ac888e89cf4d45cb0c9fa6b4ed.tar.gz"],
+    strip_prefix = "protobuf-25.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v25.3.tar.gz"],
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps", "protobuf_register_toolchains")
-protobuf_deps()
-protobuf_register_toolchains()
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
+protobuf_deps()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -25,11 +25,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_proto",
-    sha256 = "903af49528dc37ad2adbb744b317da520f133bc1cbbecbdd2a6c546c9ead080b",
-    strip_prefix = "rules_proto-6.0.0-rc0",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc0/rules_proto-6.0.0-rc0.tar.gz",
+    sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
+    strip_prefix = "rules_proto-6.0.0-rc1",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz",
 )
-
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "rules_python_py_proto_library_example")
+workspace(name = "p")
 
 # The following local_path_override is only needed to run this example as part of our CI.
 local_repository(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -173,14 +173,14 @@ def rules_python_internal_deps():
         ],
     )
 
+
     http_archive(
         name = "rules_proto",
-        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-        strip_prefix = "rules_proto-5.3.0-21.7",
-        urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-        ],
+        sha256 = "903af49528dc37ad2adbb744b317da520f133bc1cbbecbdd2a6c546c9ead080b",
+        strip_prefix = "rules_proto-6.0.0-rc0",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc0/rules_proto-6.0.0-rc0.tar.gz",
     )
+
 
     http_archive(
         name = "com_google_protobuf",

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -173,14 +173,12 @@ def rules_python_internal_deps():
         ],
     )
 
-
     http_archive(
         name = "rules_proto",
-        sha256 = "903af49528dc37ad2adbb744b317da520f133bc1cbbecbdd2a6c546c9ead080b",
-        strip_prefix = "rules_proto-6.0.0-rc0",
-        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc0/rules_proto-6.0.0-rc0.tar.gz",
+        sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
+        strip_prefix = "rules_proto-6.0.0-rc1",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz",
     )
-
 
     http_archive(
         name = "com_google_protobuf",

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -17,8 +17,6 @@
 load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
 load("//python:defs.bzl", "PyInfo")
 
-ProtoLangToolchainInfo = proto_common.ProtoLangToolchainInfo
-
 _PyProtoInfo = provider(
     doc = "Encapsulates information needed by the Python proto rules.",
     fields = {
@@ -51,7 +49,6 @@ def _py_proto_aspect_impl(target, ctx):
       ([_PyProtoInfo]) Providers collecting transitive information about
       generated files.
     """
-
     _proto_library = ctx.rule.attr
 
     # Check Proto file names
@@ -61,7 +58,7 @@ def _py_proto_aspect_impl(target, ctx):
                 proto.path,
             ))
 
-    proto_lang_toolchain_info = ctx.attr._aspect_proto_toolchain[ProtoLangToolchainInfo]
+    proto_lang_toolchain_info = ctx.toolchains["@rules_python//python/proto:toolchain_type"].proto
     api_deps = [proto_lang_toolchain_info.runtime]
 
     generated_sources = []
@@ -123,14 +120,10 @@ def _py_proto_aspect_impl(target, ctx):
 
 _py_proto_aspect = aspect(
     implementation = _py_proto_aspect_impl,
-    attrs = {
-        "_aspect_proto_toolchain": attr.label(
-            default = ":python_toolchain",
-        ),
-    },
     attr_aspects = ["deps"],
     required_providers = [ProtoInfo],
     provides = [_PyProtoInfo],
+    toolchains = ["@rules_python//python/proto:toolchain_type"]
 )
 
 def _py_proto_library_rule(ctx):

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -14,8 +14,7 @@
 
 """The implementation of the `py_proto_library` rule and its aspect."""
 
-load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
-load("@rules_proto//proto:proto_common.bzl", "toolchains")
+load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common", "toolchains")
 load("//python:defs.bzl", "PyInfo")
 
 PY_PROTO_TOOLCHAIN = "@rules_python//python/proto:toolchain_type"


### PR DESCRIPTION
Enables use of `--incompatible_enable_proto_toolchain_resolution` flag that launched in Bazel 7. This allows users to choose a pre-built `protoc` or use the runtime from https://pypi.org/project/protobuf/ rather than be forced to use hard-coded values in Bazel core.

This change is also happening in other language rulesets that provide first-class protobuf support, e.g.
https://github.com/bazelbuild/rules_go/issues/3895

No update to CHANGELOG.md in this PR as the feature is not yet documented for end-users, this just makes it possible to enable the flag. A follow-up PR will provide user instructions.