### PR TITLE
feat: Creating one py_binary per main module

### DIFF
--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:def.bzl", "gazelle_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load(":gazelle_test.bzl", "gazelle_test")
 
 go_library(
@@ -17,7 +17,7 @@ go_library(
         "std_modules.go",
         "target.go",
     ],
-    embedsrcs = [":helper.zip"],
+    embedsrcs = [":helper.zip"],  # keep
     importpath = "github.com/bazelbuild/rules_python/gazelle/python",
     visibility = ["//visibility:public"],
     deps = [
@@ -46,6 +46,14 @@ py_binary(
     ],
     main = "__main__.py",
     visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "parse_test",
+    srcs = [
+        "parse.py",
+        "parse_test.py",
+    ],
 )
 
 filegroup(

--- a/gazelle/python/parse_test.py
+++ b/gazelle/python/parse_test.py
@@ -1,0 +1,29 @@
+import unittest
+import parse
+
+class TestParse(unittest.TestCase):
+    def test_not_has_main(self):
+        content = "a = 1\nb = 2"
+        self.assertFalse(parse.parse_main(content))
+
+    def test_has_main_in_function(self):
+        content = """
+def foo():
+    if __name__ == "__main__":
+        a = 3
+"""
+        self.assertFalse(parse.parse_main(content))
+
+    def test_has_main(self):
+        content = """
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+"""
+        self.assertTrue(parse.parse_main(content))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gazelle/python/parser.go
+++ b/gazelle/python/parser.go
@@ -101,7 +101,7 @@ func newPython3Parser(
 
 // parseSingle parses a single Python file and returns the extracted modules
 // from the import statements as well as the parsed comments.
-func (p *python3Parser) parseSingle(pyFilename string) (*treeset.Set, error) {
+func (p *python3Parser) parseSingle(pyFilename string) (*treeset.Set, []string, error) {
 	pyFilenames := treeset.NewWith(godsutils.StringComparator)
 	pyFilenames.Add(pyFilename)
 	return p.parse(pyFilenames)
@@ -109,7 +109,7 @@ func (p *python3Parser) parseSingle(pyFilename string) (*treeset.Set, error) {
 
 // parse parses multiple Python files and returns the extracted modules from
 // the import statements as well as the parsed comments.
-func (p *python3Parser) parse(pyFilenames *treeset.Set) (*treeset.Set, error) {
+func (p *python3Parser) parse(pyFilenames *treeset.Set) (*treeset.Set, []string, error) {
 	parserMutex.Lock()
 	defer parserMutex.Unlock()
 
@@ -122,24 +122,28 @@ func (p *python3Parser) parse(pyFilenames *treeset.Set) (*treeset.Set, error) {
 	}
 	encoder := json.NewEncoder(parserStdin)
 	if err := encoder.Encode(&req); err != nil {
-		return nil, fmt.Errorf("failed to parse: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse: %w", err)
 	}
 
 	reader := bufio.NewReader(parserStdout)
 	data, err := reader.ReadBytes(0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse: %w", err)
 	}
 	data = data[:len(data)-1]
 	var allRes []parserResponse
 	if err := json.Unmarshal(data, &allRes); err != nil {
-		return nil, fmt.Errorf("failed to parse: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse: %w", err)
 	}
 
+	var mainModules []string
 	for _, res := range allRes {
+		if res.HasMain {
+			mainModules = append(mainModules, res.FileName)
+		}
 		annotations, err := annotationsFromComments(res.Comments)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse annotations: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse annotations: %w", err)
 		}
 
 		for _, m := range res.Modules {
@@ -159,17 +163,22 @@ func (p *python3Parser) parse(pyFilenames *treeset.Set) (*treeset.Set, error) {
 		}
 	}
 
-	return modules, nil
+	return modules, mainModules, nil
 }
 
 // parserResponse represents a response returned by the parser.py for a given
 // parsed Python module.
 type parserResponse struct {
+	// FileName of the parsed module
+	FileName string
 	// The modules depended by the parsed module.
 	Modules []module `json:"modules"`
 	// The comments contained in the parsed module. This contains the
 	// annotations as they are comments in the Python module.
 	Comments []comment `json:"comments"`
+	// HasMain indicates whether the Python module has `if __name == "__main__"`
+	// at the top level
+	HasMain bool `json:"has_main"`
 }
 
 // module represents a fully-qualified, dot-separated, Python module as seen on

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
@@ -1,0 +1,4 @@
+filegroup(
+    name = "collided_main",
+    srcs = ["collided_main.py"],
+)

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
@@ -1,0 +1,21 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+filegroup(
+    name = "collided_main",
+    srcs = ["collided_main.py"],
+)
+
+py_binary(
+    name = "main",
+    srcs = ["main.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "binary_without_entrypoint",
+    srcs = [
+        "__init__.py",
+        "collided_main.py",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/binary_without_entrypoint/README.md
+++ b/gazelle/python/testdata/binary_without_entrypoint/README.md
@@ -1,0 +1,4 @@
+# Binary without entrypoint
+
+This test case asserts that when there is no __main__.py, a py_binary is generated per main module, unless a main
+module main collides with existing target name.

--- a/gazelle/python/testdata/binary_without_entrypoint/WORKSPACE
+++ b/gazelle/python/testdata/binary_without_entrypoint/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/binary_without_entrypoint/__init__.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For test purposes only.

--- a/gazelle/python/testdata/binary_without_entrypoint/collided_main.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/collided_main.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+    run()

--- a/gazelle/python/testdata/binary_without_entrypoint/main.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/main.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+    run()

--- a/gazelle/python/testdata/binary_without_entrypoint/test.yaml
+++ b/gazelle/python/testdata/binary_without_entrypoint/test.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+expect:
+  stderr: |
+    gazelle: failed to generate target "//:binary_without_entrypoint" of kind "py_binary": a target of kind "filegroup" with the same name already exists.

--- a/gazelle/pythonconfig/BUILD.bazel
+++ b/gazelle/pythonconfig/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
 go_test(
     name = "pythonconfig_test",
     srcs = ["pythonconfig_test.go"],
-    deps = [":pythonconfig"],
+    embed = [":pythonconfig"],
 )
 
 filegroup(


### PR DESCRIPTION
Many existing Python repos don't use `__main__.py` to indicate the the main module. Instead, they put something below in any Python files:

```python
if __name__ == "__main__":
  main()
```

This PR makes the Gazelle extension able to recognize main modules like this, when `__main__.py` doesn't exist. This reduces the need to create `__main__.py` when enabling Gazelle extensions in existing Python repos.

The current behavior of creating single `py_binary` for `__main__.py` is preserved and takes precedence. So this is a backward-compatible change.