### PR TITLE
docs(pip_parse): Update docs about `experimental_requirement_cycles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ A brief description of the categories of changes:
   rules_python Starlark implementation, not the one built into Bazel. NOTE: This
   only applies to Bazel 6+; Bazel 5 still uses the builtin implementation.
 
+* (pip_parse) The parameter `experimental_requirement_cycles` may be provided a
+  map of names to lists of requirements which form a dependency
+  cycle. `pip_parse` will break the cycle for you transparently. This behavior
+  is also available under bzlmod as
+  `pip.parse(experimental_requirement_cycles={})`.
+
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 
 ## [0.27.0] - 2023-11-16
@@ -58,11 +64,6 @@ A brief description of the categories of changes:
   labels that are present in the `foo` package are `dist_info`, `whl` and
   `data`. Note, that the `@pypi_foo//:pkg` labels are still present for
   backwards compatibility.
-
-* (pip_parse) The parameter `requirement_cycles` may be provided a map of names
-  to lists of requirements which form a dependency cycle. `pip_parse` will break
-  the cycle for you transparently. This behavior is also available under bzlmod
-  as `pip.parse(requirement_cycles={})`.
 
 * (gazelle) The flag `use_pip_repository_aliases` is now set to `True` by
   default, which will cause `gazelle` to change third-party dependency labels

--- a/docs/sphinx/pypi-dependencies.md
+++ b/docs/sphinx/pypi-dependencies.md
@@ -159,14 +159,15 @@ ERROR: .../external/pypi_sphinxcontrib_serializinghtml/BUILD.bazel:44:6: in alia
 `-- @pypi_sphinxcontrib_serializinghtml//:pkg (...)
 ```
 
-The `requirement_cycles` argument allows you to work around these issues by
-specifying groups of packages which form cycles. `pip_parse` will transparently
-fix the cycles for you and provide the cyclic dependencies simultaneously.
+The `experimental_requirement_cycles` argument allows you to work around these
+issues by specifying groups of packages which form cycles. `pip_parse` will
+transparently fix the cycles for you and provide the cyclic dependencies
+simultaneously.
 
 ```
 pip_parse(
   ...
-  requirement_cycles = {
+  experimental_requirement_cycles = {
     "sphinx": [
       "sphinx",
       "sphinxcontrib-serializinghtml",
@@ -183,7 +184,7 @@ be a part of the `airflow` cycle. For instance --
 ```
 pip_parse(
   ...
-  requirement_cycles = {
+  experimental_requirement_cycles = {
     "airflow": [
       "apache-airflow",
       "apache-airflow-providers-common-sql",


### PR DESCRIPTION
This PR updates the docs for https://github.com/bazelbuild/rules_python/pull/1166 since there were some inconsistencies about the naming (`experimental_requirement_cycles` vs `requirement_cycles`). Also moved the entry in the changelog from `0.27` to `Unreleased` since it missed `0.27`. Can't wait for this feature to land!