### PR TITLE
feat(whl_library): generate platform-specific dependency closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ A brief description of the categories of changes:
 * (gazelle) The gazelle plugin helper was not working with Python toolchains 3.11
   and above due to a bug in the helper components not being on PYTHONPATH.
 
+* (pip_parse) The repositories created by `whl_library` can now parse the `whl`
+  METADATA and generate dependency closures irrespective of the host platform
+  the generation is done. This can be turned on by supplying
+  `target_platforms = ["all"]` to the `pip_parse` or the `bzlmod` equivalent.
+  This may help in cases where fetching wheels for a different platform using
+  `download_only = True` feature.
+
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 
 ## [0.27.0] - 2023-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ A brief description of the categories of changes:
 
 * (pip_parse) The repositories created by `whl_library` can now parse the `whl`
   METADATA and generate dependency closures irrespective of the host platform
-  the generation is done. This can be turned on by supplying
+  the generation is executed on. This can be turned on by supplying
   `target_platforms = ["all"]` to the `pip_parse` or the `bzlmod` equivalent.
   This may help in cases where fetching wheels for a different platform using
   `download_only = True` feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ A brief description of the categories of changes:
 * (pip_parse) The repositories created by `whl_library` can now parse the `whl`
   METADATA and generate dependency closures irrespective of the host platform
   the generation is executed on. This can be turned on by supplying
-  `target_platforms = ["all"]` to the `pip_parse` or the `bzlmod` equivalent.
-  This may help in cases where fetching wheels for a different platform using
-  `download_only = True` feature.
+  `experimental_target_platforms = ["all"]` to the `pip_parse` or the `bzlmod`
+  equivalent. This may help in cases where fetching wheels for a different
+  platform using `download_only = True` feature.
 
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -102,7 +102,13 @@ pip.parse(
     python_version = "3.9",
     requirements_lock = "//:requirements_lock_3_9.txt",
     requirements_windows = "//:requirements_windows_3_9.txt",
-    target_platforms = ["all"],
+    # You can use one of the values below to specify the target platform
+    # to generate the dependency graph for.
+    target_platforms = [
+        "all",
+        "linux_*",
+        "host",
+    ],
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.
@@ -126,7 +132,13 @@ pip.parse(
     python_version = "3.10",
     requirements_lock = "//:requirements_lock_3_10.txt",
     requirements_windows = "//:requirements_windows_3_10.txt",
-    target_platforms = ["all"],
+    # You can use one of the values below to specify the target platform
+    # to generate the dependency graph for.
+    target_platforms = [
+        "all",
+        "linux_*",
+        "host",
+    ],
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -98,17 +98,17 @@ pip.parse(
             "sphinxcontrib-serializinghtml",
         ],
     },
-    hub_name = "pip",
-    python_version = "3.9",
-    requirements_lock = "//:requirements_lock_3_9.txt",
-    requirements_windows = "//:requirements_windows_3_9.txt",
     # You can use one of the values below to specify the target platform
     # to generate the dependency graph for.
-    target_platforms = [
+    experimental_target_platforms = [
         "all",
         "linux_*",
         "host",
     ],
+    hub_name = "pip",
+    python_version = "3.9",
+    requirements_lock = "//:requirements_lock_3_9.txt",
+    requirements_windows = "//:requirements_windows_3_9.txt",
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.
@@ -128,17 +128,17 @@ pip.parse(
             "sphinxcontrib-serializinghtml",
         ],
     },
-    hub_name = "pip",
-    python_version = "3.10",
-    requirements_lock = "//:requirements_lock_3_10.txt",
-    requirements_windows = "//:requirements_windows_3_10.txt",
     # You can use one of the values below to specify the target platform
     # to generate the dependency graph for.
-    target_platforms = [
+    experimental_target_platforms = [
         "all",
         "linux_*",
         "host",
     ],
+    hub_name = "pip",
+    python_version = "3.10",
+    requirements_lock = "//:requirements_lock_3_10.txt",
+    requirements_windows = "//:requirements_windows_3_10.txt",
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -102,6 +102,7 @@ pip.parse(
     python_version = "3.9",
     requirements_lock = "//:requirements_lock_3_9.txt",
     requirements_windows = "//:requirements_windows_3_9.txt",
+    target_platforms = ["all"],
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.
@@ -125,6 +126,7 @@ pip.parse(
     python_version = "3.10",
     requirements_lock = "//:requirements_lock_3_10.txt",
     requirements_windows = "//:requirements_windows_3_10.txt",
+    target_platforms = ["all"],
     # These modifications were created above and we
     # are providing pip.parse with the label of the mod
     # and the name of the wheel.

--- a/examples/pip_parse/MODULE.bazel
+++ b/examples/pip_parse/MODULE.bazel
@@ -26,5 +26,6 @@ pip.parse(
     hub_name = "pypi",
     python_version = "3.9",
     requirements_lock = "//:requirements_lock.txt",
+    requirements_windows = "//:requirements_windows.txt",
 )
 use_repo(pip, "pypi")

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -538,7 +538,7 @@ cross platform wheels by parsing the wheel metadata. This will generate the
 correct dependencies for packages like `sphinx` or `pylint`, which include
 `colorama` when installed and used on Windows platforms.
 
-An empty list means falling back to the legacy behaviour when we use the host
+An empty list means falling back to the legacy behaviour where the host
 platform is the target platform.
 
 WARNING: It may not work as expected in cases where the python interpreter

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -531,9 +531,6 @@ Prefix for the generated packages will be of the form `@<prefix><sanitized-packa
 """,
     ),
     "target_platforms": attr.string_list(
-        # TODO @aignas 2023-12-04: this is not the best way right now
-        # so if this approach is generally good, this can be refactored, by
-        # using the names of the config_setting labels.
         default = [],
         doc = """\
 A list of platforms that we will generate the conditional dependency graph for

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -25,6 +25,7 @@ load(
     "WHEEL_FILE_PUBLIC_LABEL",
 )
 load("//python/private:normalize_name.bzl", "normalize_name")
+load("//python/private:text_util.bzl", "render")
 
 _COPY_FILE_TEMPLATE = """\
 copy_file(
@@ -101,11 +102,36 @@ alias(
 )
 """
 
+def _render_list_and_select(deps, deps_by_platform, tmpl):
+    deps = render.list([tmpl.format(d) for d in deps])
+
+    if not deps_by_platform:
+        return deps
+
+    deps_by_platform = {
+        p if p.startswith("@") else ":is_" + p: [
+            tmpl.format(d)
+            for d in deps
+        ]
+        for p, deps in deps_by_platform.items()
+    }
+
+    # Add the default, which means that we will be just using the dependencies in
+    # `deps` for platforms that are not handled in a special way by the packages
+    deps_by_platform["//conditions:default"] = []
+    deps_by_platform = render.select(deps_by_platform, value_repr = render.list)
+
+    if deps == "[]":
+        return deps_by_platform
+    else:
+        return "{} + {}".format(deps, deps_by_platform)
+
 def generate_whl_library_build_bazel(
         *,
         repo_prefix,
         whl_name,
         dependencies,
+        dependencies_by_platform,
         data_exclude,
         tags,
         entry_points,
@@ -118,6 +144,7 @@ def generate_whl_library_build_bazel(
         repo_prefix: the repo prefix that should be used for dependency lists.
         whl_name: the whl_name that this is generated for.
         dependencies: a list of PyPI packages that are dependencies to the py_library.
+        dependencies_by_platform: a dict[str, list] of PyPI packages that may vary by platform.
         data_exclude: more patterns to exclude from the data attribute of generated py_library rules.
         tags: list of tags to apply to generated py_library rules.
         entry_points: A dict of entry points to add py_binary rules for.
@@ -138,6 +165,10 @@ def generate_whl_library_build_bazel(
     srcs_exclude = []
     data_exclude = [] + data_exclude
     dependencies = sorted([normalize_name(d) for d in dependencies])
+    dependencies_by_platform = {
+        platform: sorted([normalize_name(d) for d in deps])
+        for platform, deps in dependencies_by_platform.items()
+    }
     tags = sorted(tags)
 
     for entry_point, entry_point_script_name in entry_points.items():
@@ -185,22 +216,48 @@ def generate_whl_library_build_bazel(
         for d in group_deps
     }
 
-    # Filter out deps which are within the group to avoid cycles
-    non_group_deps = [
+    dependencies = [
         d
         for d in dependencies
         if d not in group_deps
     ]
+    dependencies_by_platform = {
+        p: deps
+        for p, deps in dependencies_by_platform.items()
+        for deps in [[d for d in deps if d not in group_deps]]
+        if deps
+    }
 
-    lib_dependencies = [
-        "@%s%s//:%s" % (repo_prefix, normalize_name(d), PY_LIBRARY_PUBLIC_LABEL)
-        for d in non_group_deps
-    ]
+    for p in dependencies_by_platform:
+        if p.startswith("@"):
+            continue
 
-    whl_file_deps = [
-        "@%s%s//:%s" % (repo_prefix, normalize_name(d), WHEEL_FILE_PUBLIC_LABEL)
-        for d in non_group_deps
-    ]
+        os, _, cpu = p.partition("_")
+
+        additional_content.append(
+            """\
+config_setting(
+    name = "is_{os}_{cpu}",
+    constraint_values = [
+        "@platforms//cpu:{cpu}",
+        "@platforms//os:{os}",
+    ],
+    visibility = ["//visibility:private"],
+)
+""".format(os = os, cpu = cpu),
+        )
+
+    lib_dependencies = _render_list_and_select(
+        deps = dependencies,
+        deps_by_platform = dependencies_by_platform,
+        tmpl = "@{}{{}}//:{}".format(repo_prefix, PY_LIBRARY_PUBLIC_LABEL),
+    )
+
+    whl_file_deps = _render_list_and_select(
+        deps = dependencies,
+        deps_by_platform = dependencies_by_platform,
+        tmpl = "@{}{{}}//:{}".format(repo_prefix, WHEEL_FILE_PUBLIC_LABEL),
+    )
 
     # If this library is a member of a group, its public label aliases need to
     # point to the group implementation rule not the implementation rules. We
@@ -223,13 +280,13 @@ def generate_whl_library_build_bazel(
                 py_library_public_label = PY_LIBRARY_PUBLIC_LABEL,
                 py_library_impl_label = PY_LIBRARY_IMPL_LABEL,
                 py_library_actual_label = library_impl_label,
-                dependencies = repr(lib_dependencies),
+                dependencies = render.indent(lib_dependencies, " " * 4).lstrip(),
+                whl_file_deps = render.indent(whl_file_deps, " " * 4).lstrip(),
                 data_exclude = repr(_data_exclude),
                 whl_name = whl_name,
                 whl_file_public_label = WHEEL_FILE_PUBLIC_LABEL,
                 whl_file_impl_label = WHEEL_FILE_IMPL_LABEL,
                 whl_file_actual_label = whl_impl_label,
-                whl_file_deps = repr(whl_file_deps),
                 tags = repr(tags),
                 data_label = DATA_LABEL,
                 dist_info_label = DIST_INFO_LABEL,

--- a/python/pip_install/tools/wheel_installer/BUILD.bazel
+++ b/python/pip_install/tools/wheel_installer/BUILD.bazel
@@ -13,6 +13,7 @@ py_library(
     deps = [
         requirement("installer"),
         requirement("pip"),
+        requirement("packaging"),
         requirement("setuptools"),
     ],
 )
@@ -42,6 +43,18 @@ py_test(
     srcs = [
         "namespace_pkgs_test.py",
     ],
+    deps = [
+        ":lib",
+    ],
+)
+
+py_test(
+    name = "wheel_test",
+    size = "small",
+    srcs = [
+        "wheel_test.py",
+    ],
+    data = ["//examples/wheel:minimal_with_py_package"],
     deps = [
         ":lib",
     ],

--- a/python/pip_install/tools/wheel_installer/arguments.py
+++ b/python/pip_install/tools/wheel_installer/arguments.py
@@ -101,10 +101,6 @@ def get_platforms(args: argparse.Namespace) -> Set:
     if args.platform is None:
         return platforms
 
-    for ps in args.platform:
-        if isinstance(ps, list):
-            platforms.update(ps)
-        else:
-            platforms.add(ps)
+    platforms.update(args.platform)
 
     return platforms

--- a/python/pip_install/tools/wheel_installer/arguments.py
+++ b/python/pip_install/tools/wheel_installer/arguments.py
@@ -17,6 +17,8 @@ import json
 import pathlib
 from typing import Any
 
+from python.pip_install.tools.wheel_installer import wheel
+
 
 def parser(**kwargs: Any) -> argparse.ArgumentParser:
     """Create a parser for the wheel_installer tool."""
@@ -38,6 +40,12 @@ def parser(**kwargs: Any) -> argparse.ArgumentParser:
         "--extra_pip_args",
         action="store",
         help="Extra arguments to pass down to pip.",
+    )
+    parser.add_argument(
+        "--platform",
+        action="append",
+        type=wheel.Platform.from_string,
+        help="Platforms to target dependencies. Can be used multiple times.",
     )
     parser.add_argument(
         "--pip_data_exclude",

--- a/python/pip_install/tools/wheel_installer/arguments.py
+++ b/python/pip_install/tools/wheel_installer/arguments.py
@@ -98,6 +98,9 @@ def get_platforms(args: argparse.Namespace) -> Set:
         args: dict of parsed command line arguments
     """
     platforms = set()
+    if args.platform is None:
+        return platforms
+
     for ps in args.platform:
         if isinstance(ps, list):
             for p in ps:

--- a/python/pip_install/tools/wheel_installer/arguments.py
+++ b/python/pip_install/tools/wheel_installer/arguments.py
@@ -15,7 +15,7 @@
 import argparse
 import json
 import pathlib
-from typing import Any
+from typing import Any, Dict, Set
 
 from python.pip_install.tools.wheel_installer import wheel
 
@@ -43,7 +43,7 @@ def parser(**kwargs: Any) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--platform",
-        action="append",
+        action="extend",
         type=wheel.Platform.from_string,
         help="Platforms to target dependencies. Can be used multiple times.",
     )
@@ -76,8 +76,9 @@ def parser(**kwargs: Any) -> argparse.ArgumentParser:
     return parser
 
 
-def deserialize_structured_args(args):
+def deserialize_structured_args(args: Dict[str, str]) -> Dict:
     """Deserialize structured arguments passed from the starlark rules.
+
     Args:
         args: dict of parsed command line arguments
     """
@@ -88,3 +89,20 @@ def deserialize_structured_args(args):
         else:
             args[arg_name] = []
     return args
+
+
+def get_platforms(args: argparse.Namespace) -> Set:
+    """Aggregate platforms into a single set.
+
+    Args:
+        args: dict of parsed command line arguments
+    """
+    platforms = set()
+    for ps in args.platform:
+        if isinstance(ps, list):
+            for p in ps:
+                platforms.add(p)
+        else:
+            platforms.add(ps)
+
+    return platforms

--- a/python/pip_install/tools/wheel_installer/arguments.py
+++ b/python/pip_install/tools/wheel_installer/arguments.py
@@ -103,8 +103,7 @@ def get_platforms(args: argparse.Namespace) -> Set:
 
     for ps in args.platform:
         if isinstance(ps, list):
-            for p in ps:
-                platforms.add(p)
+            platforms.update(ps)
         else:
             platforms.add(ps)
 

--- a/python/pip_install/tools/wheel_installer/arguments_test.py
+++ b/python/pip_install/tools/wheel_installer/arguments_test.py
@@ -16,7 +16,7 @@ import argparse
 import json
 import unittest
 
-from python.pip_install.tools.wheel_installer import arguments
+from python.pip_install.tools.wheel_installer import arguments, wheel
 
 
 class ArgumentsTestCase(unittest.TestCase):
@@ -51,6 +51,18 @@ class ArgumentsTestCase(unittest.TestCase):
         self.assertEqual(args["pip_data_exclude"], ["**.foo"])
         self.assertEqual(args["environment"], {"PIP_DO_SOMETHING": "True"})
         self.assertEqual(args["extra_pip_args"], [])
+
+    def test_platform_aggregation(self) -> None:
+        parser = arguments.parser()
+        args = parser.parse_args(
+            args=[
+                "--platform=host",
+                "--platform=linux_*",
+                "--platform=all",
+                "--requirement=foo",
+            ]
+        )
+        self.assertEqual(set(wheel.Platform.all()), arguments.get_platforms(args))
 
 
 if __name__ == "__main__":

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -316,7 +316,7 @@ class Deps:
             else:
                 self._add(req.name, Platform(plat.os))
 
-    def build(self, m=None) -> FrozenDeps:
+    def build(self) -> FrozenDeps:
         if not self._select:
             return FrozenDeps(
                 deps=sorted(self._deps),

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -15,7 +15,9 @@
 """Utility class to inspect an extracted wheel directory"""
 
 import email
+import platform
 import re
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
@@ -81,12 +83,16 @@ class Platform:
     arch: Optional[Arch] = None
 
     @classmethod
-    def all() -> List["Platform"]:
-        return [Platform(os=os, arch=arch) for os in OS for arch in Arch]
+    def all(cls) -> List["Platform"]:
+        return [cls(os=os, arch=arch) for os in OS for arch in Arch]
 
     @classmethod
-    def host() -> List["Platform"]:
-        return [Platform(os=os, arch=arch) for os in OS for arch in Arch]
+    def host(cls) -> "Platform":
+        return [
+            cls(os=OS[sys.platform.lower()], arch=Arch[platform.machine()])
+            for os in OS
+            for arch in Arch
+        ]
 
     def __lt__(self, other: Any) -> bool:
         """Add a comparison method, so that `sorted` returns the most specialized platforms first."""

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -100,13 +100,7 @@ class Platform:
         return [
             cls(
                 os=OS[sys.platform.lower()],
-                # NOTE @aignas 2023-12-13: we use `x86_64` as a fallback value as this
-                # is the observed behaviour on Windows. It seems that there are experiments
-                # to provide wheels for windows arm64, but for now it is uncommon to have
-                # Python running on something else than `x86_64`.
-                #
-                # For the win arm64 wheels: https://github.com/cgohlke/win_arm64-wheels/
-                arch=Arch[platform.machine() or "x86_64"],
+                arch=Arch[platform.machine().lower()],
             )
         ]
 

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -83,8 +83,13 @@ class Platform:
     arch: Optional[Arch] = None
 
     @classmethod
-    def all(cls) -> List["Platform"]:
-        return [cls(os=os, arch=arch) for os in OS for arch in Arch]
+    def all(cls, want_os: Optional[OS] = None) -> List["Platform"]:
+        return [
+            cls(os=os, arch=arch)
+            for os in OS
+            for arch in Arch
+            if not want_os or want_os == os
+        ]
 
     @classmethod
     def host(cls) -> "Platform":
@@ -124,13 +129,26 @@ class Platform:
         )
 
     @classmethod
-    def from_string(cls, platform: str) -> "Platform":
+    def from_string(cls, platform: str) -> List["Platform"]:
+        if platform == "host":
+            return [cls.host()]
+
+        if "*" in platform:
+            os, _, _ = platform.partition("_")
+
+            return cls.all(OS[os])
+
+        if platform == "all":
+            return cls.all()
+
         os, _, arch = platform.partition("_")
 
-        return cls(
-            os=OS[os],
-            arch=Arch[arch],
-        )
+        return [
+            cls(
+                os=OS[os],
+                arch=Arch[arch],
+            )
+        ]
 
     # NOTE @aignas 2023-12-05: below is the minimum number of accessors that are defined in
     # https://peps.python.org/pep-0496/ to make rules_python generate dependencies.

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -109,7 +109,7 @@ class Platform:
     def __lt__(self, other: Any) -> bool:
         """Add a comparison method, so that `sorted` returns the most specialized platforms first."""
         if not isinstance(other, Platform) or other is None:
-            return False
+            raise ValueError(f"cannot compare {other} with Platform")
 
         if self.arch is None and other.arch is not None:
             return True

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -100,7 +100,9 @@ class Platform:
         return [
             cls(
                 os=OS[sys.platform.lower()],
-                arch=Arch[platform.machine().lower()],
+                # FIXME @aignas 2023-12-13: Hermetic toolchain on Windows 3.11.6
+                # is returning an empty string here, so lets default to x86_64
+                arch=Arch[platform.machine().lower() or "x86_64"],
             )
         ]
 

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -93,10 +93,21 @@ class Platform:
 
     @classmethod
     def host(cls) -> "Platform":
+        """Use the Python interpreter to detect the platform.
+
+        We extract `os` from sys.platform and `arch` from platform.machine
+        """
         return [
-            cls(os=OS[sys.platform.lower()], arch=Arch[platform.machine()])
-            for os in OS
-            for arch in Arch
+            cls(
+                os=OS[sys.platform.lower()],
+                # NOTE @aignas 2023-12-13: we use `x86_64` as a fallback value as this
+                # is the observed behaviour on Windows. It seems that there are experiments
+                # to provide wheels for windows arm64, but for now it is uncommon to have
+                # Python running on something else than `x86_64`.
+                #
+                # For the win arm64 wheels: https://github.com/cgohlke/win_arm64-wheels/
+                arch=Arch[platform.machine() or "x86_64"],
+            )
         ]
 
     def __lt__(self, other: Any) -> bool:

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -241,8 +241,8 @@ class Platform:
 
 @dataclass(frozen=True)
 class FrozenDeps:
-    deps: list[str]
-    deps_select: dict[str, list[str]]
+    deps: List[str]
+    deps_select: Dict[str, List[str]]
 
 
 class Deps:

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -16,7 +16,7 @@
 
 import email
 import re
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -185,7 +185,10 @@ class Platform:
         }
 
 
-FrozenDeps = namedtuple("FrozenDeps", "deps deps_select")
+@dataclass(frozen=True)
+class FrozenDeps:
+    deps: list[str]
+    deps_select: dict[str, list[str]]
 
 
 class Deps:

--- a/python/pip_install/tools/wheel_installer/wheel_installer.py
+++ b/python/pip_install/tools/wheel_installer/wheel_installer.py
@@ -161,7 +161,7 @@ def main() -> None:
             wheel_file=whl,
             extras=extras,
             enable_implicit_namespace_pkgs=args.enable_implicit_namespace_pkgs,
-            platforms=set(args.platform or []),
+            platforms=arguments.get_platforms(args),
         )
         return
 

--- a/python/pip_install/tools/wheel_installer/wheel_installer.py
+++ b/python/pip_install/tools/wheel_installer/wheel_installer.py
@@ -14,19 +14,16 @@
 
 """Build and/or fetch a single wheel based on the requirement passed in"""
 
-import argparse
 import errno
 import glob
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -108,6 +105,7 @@ def _extract_wheel(
     wheel_file: str,
     extras: Dict[str, Set[str]],
     enable_implicit_namespace_pkgs: bool,
+    platforms: List[wheel.Platform],
     installation_dir: Path = Path("."),
 ) -> None:
     """Extracts wheel into given directory and creates py_library and filegroup targets.
@@ -126,16 +124,15 @@ def _extract_wheel(
         _setup_namespace_pkg_compatibility(installation_dir)
 
     extras_requested = extras[whl.name] if whl.name in extras else set()
-    # Packages may create dependency cycles when specifying optional-dependencies / 'extras'.
-    # Example: github.com/google/etils/blob/a0b71032095db14acf6b33516bca6d885fe09e35/pyproject.toml#L32.
-    self_edge_dep = set([whl.name])
-    whl_deps = sorted(whl.dependencies(extras_requested) - self_edge_dep)
+
+    dependencies = whl.dependencies(extras_requested, platforms)
 
     with open(os.path.join(installation_dir, "metadata.json"), "w") as f:
         metadata = {
             "name": whl.name,
             "version": whl.version,
-            "deps": whl_deps,
+            "deps": dependencies.deps,
+            "deps_by_platform": dependencies.deps_select,
             "entry_points": [
                 {
                     "name": name,
@@ -164,6 +161,7 @@ def main() -> None:
             wheel_file=whl,
             extras=extras,
             enable_implicit_namespace_pkgs=args.enable_implicit_namespace_pkgs,
+            platforms=set(args.platform or []),
         )
         return
 

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -58,7 +58,7 @@ class DepsTest(unittest.TestCase):
             "win_dep; os_name=='nt'",
         )
 
-        got = deps.build("foo")
+        got = deps.build()
 
         self.assertEqual(["bar"], got.deps)
         self.assertEqual(

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -1,0 +1,225 @@
+import unittest
+
+from python.pip_install.tools.wheel_installer import wheel
+
+
+class DepsTest(unittest.TestCase):
+    def test_simple(self):
+        deps = wheel.Deps("foo")
+        deps.add("bar")
+
+        got = deps.build()
+
+        self.assertIsInstance(got, wheel.FrozenDeps)
+        self.assertEqual(["bar"], got.deps)
+        self.assertEqual({}, got.deps_select)
+
+    def test_can_add_os_specific_deps(self):
+        platforms = {
+            "linux_x86_64",
+            "osx_x86_64",
+            "windows_x86_64",
+        }
+        deps = wheel.Deps(
+            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
+        )
+        deps.add(
+            "bar",
+            "posix_dep; os_name=='posix'",
+            "win_dep; os_name=='nt'",
+        )
+
+        got = deps.build()
+
+        self.assertEqual(["bar"], got.deps)
+        self.assertEqual(
+            {
+                "@platforms//os:linux": ["posix_dep"],
+                "@platforms//os:osx": ["posix_dep"],
+                "@platforms//os:windows": ["win_dep"],
+            },
+            got.deps_select,
+        )
+
+    def test_can_add_platform_specific_deps(self):
+        platforms = {
+            "linux_x86_64",
+            "osx_x86_64",
+            "osx_aarch64",
+            "windows_x86_64",
+        }
+        deps = wheel.Deps(
+            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
+        )
+        deps.add(
+            "bar",
+            "posix_dep; os_name=='posix'",
+            "m1_dep; sys_platform=='darwin' and platform_machine=='arm64'",
+            "win_dep; os_name=='nt'",
+        )
+
+        got = deps.build("foo")
+
+        self.assertEqual(["bar"], got.deps)
+        self.assertEqual(
+            {
+                "osx_aarch64": ["m1_dep", "posix_dep"],
+                "@platforms//os:linux": ["posix_dep"],
+                "@platforms//os:osx": ["posix_dep"],
+                "@platforms//os:windows": ["win_dep"],
+            },
+            got.deps_select,
+        )
+
+    def test_non_platform_markers_are_added_to_common_deps(self):
+        platforms = {
+            "linux_x86_64",
+            "osx_x86_64",
+            "osx_aarch64",
+            "windows_x86_64",
+        }
+        deps = wheel.Deps(
+            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
+        )
+        deps.add(
+            "bar",
+            "baz; implementation_name=='cpython'",
+            "m1_dep; sys_platform=='darwin' and platform_machine=='arm64'",
+        )
+
+        got = deps.build()
+
+        self.assertEqual(["bar", "baz"], got.deps)
+        self.assertEqual(
+            {
+                "osx_aarch64": ["m1_dep"],
+            },
+            got.deps_select,
+        )
+
+    def test_self_is_ignored(self):
+        deps = wheel.Deps("foo", extras={"ssl"})
+        deps.add(
+            "bar",
+            "req_dep; extra == 'requests'",
+            "foo[requests]; extra == 'ssl'",
+            "ssl_lib; extra == 'ssl'",
+        )
+
+        got = deps.build()
+
+        self.assertEqual(["bar", "req_dep", "ssl_lib"], got.deps)
+        self.assertEqual({}, got.deps_select)
+
+    def test_handle_etils(self):
+        deps = wheel.Deps("etils", extras={"all"})
+        requires = """
+etils[array-types] ; extra == "all"
+etils[eapp] ; extra == "all"
+etils[ecolab] ; extra == "all"
+etils[edc] ; extra == "all"
+etils[enp] ; extra == "all"
+etils[epath] ; extra == "all"
+etils[epath-gcs] ; extra == "all"
+etils[epath-s3] ; extra == "all"
+etils[epy] ; extra == "all"
+etils[etqdm] ; extra == "all"
+etils[etree] ; extra == "all"
+etils[etree-dm] ; extra == "all"
+etils[etree-jax] ; extra == "all"
+etils[etree-tf] ; extra == "all"
+etils[enp] ; extra == "array-types"
+pytest ; extra == "dev"
+pytest-subtests ; extra == "dev"
+pytest-xdist ; extra == "dev"
+pyink ; extra == "dev"
+pylint>=2.6.0 ; extra == "dev"
+chex ; extra == "dev"
+torch ; extra == "dev"
+optree ; extra == "dev"
+dataclass_array ; extra == "dev"
+sphinx-apitree[ext] ; extra == "docs"
+etils[dev,all] ; extra == "docs"
+absl-py ; extra == "eapp"
+simple_parsing ; extra == "eapp"
+etils[epy] ; extra == "eapp"
+jupyter ; extra == "ecolab"
+numpy ; extra == "ecolab"
+mediapy ; extra == "ecolab"
+packaging ; extra == "ecolab"
+etils[enp] ; extra == "ecolab"
+etils[epy] ; extra == "ecolab"
+etils[epy] ; extra == "edc"
+numpy ; extra == "enp"
+etils[epy] ; extra == "enp"
+fsspec ; extra == "epath"
+importlib_resources ; extra == "epath"
+typing_extensions ; extra == "epath"
+zipp ; extra == "epath"
+etils[epy] ; extra == "epath"
+gcsfs ; extra == "epath-gcs"
+etils[epath] ; extra == "epath-gcs"
+s3fs ; extra == "epath-s3"
+etils[epath] ; extra == "epath-s3"
+typing_extensions ; extra == "epy"
+absl-py ; extra == "etqdm"
+tqdm ; extra == "etqdm"
+etils[epy] ; extra == "etqdm"
+etils[array_types] ; extra == "etree"
+etils[epy] ; extra == "etree"
+etils[enp] ; extra == "etree"
+etils[etqdm] ; extra == "etree"
+dm-tree ; extra == "etree-dm"
+etils[etree] ; extra == "etree-dm"
+jax[cpu] ; extra == "etree-jax"
+etils[etree] ; extra == "etree-jax"
+tensorflow ; extra == "etree-tf"
+etils[etree] ; extra == "etree-tf"
+etils[ecolab] ; extra == "lazy-imports"
+"""
+
+        deps.add(*requires.strip().split("\n"))
+
+        got = deps.build()
+        want = [
+            "absl_py",
+            "dm_tree",
+            "fsspec",
+            "gcsfs",
+            "importlib_resources",
+            "jax",
+            "jupyter",
+            "mediapy",
+            "numpy",
+            "packaging",
+            "s3fs",
+            "simple_parsing",
+            "tensorflow",
+            "tqdm",
+            "typing_extensions",
+            "zipp",
+        ]
+
+        self.assertEqual(want, got.deps)
+        self.assertEqual({}, got.deps_select)
+
+
+class PlatformTest(unittest.TestCase):
+    def test_platform_from_string(self):
+        tests = {
+            "win_amd64": "windows_x86_64",
+            "macosx_10_9_arm64": "osx_aarch64",
+            "manylinux1_i686.manylinux_2_17_i686": "linux_x86_32",
+            "musllinux_1_1_ppc64le": "linux_ppc",
+        }
+
+        for give, want in tests.items():
+            with self.subTest(give=give, want=want):
+                self.assertEqual(
+                    wheel.Platform.from_string(want),
+                    wheel.Platform.from_tag(give),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -223,10 +223,17 @@ class PlatformTest(unittest.TestCase):
     def test_can_get_host(self):
         host = wheel.Platform.host()
         self.assertIsNotNone(host)
+        self.assertEqual(host, wheel.Platform.from_string("host"))
 
     def test_can_get_all(self):
         all_platforms = wheel.Platform.all()
-        self.assertTrue(len(all_platforms) != 0)
+        self.assertEqual(15, len(all_platforms))
+        self.assertEqual(all_platforms, wheel.Platform.from_string("all"))
+
+    def test_can_get_all_for_os(self):
+        linuxes = wheel.Platform.all(wheel.OS.linux)
+        self.assertEqual(5, len(linuxes))
+        self.assertEqual(linuxes, wheel.Platform.from_string("linux_*"))
 
 
 if __name__ == "__main__":

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -220,6 +220,14 @@ class PlatformTest(unittest.TestCase):
                     wheel.Platform.from_tag(give),
                 )
 
+    def test_can_get_host(self):
+        host = wheel.Platform.host()
+        self.assertIsNotNone(host)
+
+    def test_can_get_all(self):
+        all_platforms = wheel.Platform.all()
+        self.assertTrue(len(all_platforms) != 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -20,9 +20,7 @@ class DepsTest(unittest.TestCase):
             "osx_x86_64",
             "windows_x86_64",
         }
-        deps = wheel.Deps(
-            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
-        )
+        deps = wheel.Deps("foo", platforms=set(wheel.Platform.from_string(platforms)))
         deps.add(
             "bar",
             "posix_dep; os_name=='posix'",
@@ -48,9 +46,7 @@ class DepsTest(unittest.TestCase):
             "osx_aarch64",
             "windows_x86_64",
         }
-        deps = wheel.Deps(
-            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
-        )
+        deps = wheel.Deps("foo", platforms=set(wheel.Platform.from_string(platforms)))
         deps.add(
             "bar",
             "posix_dep; os_name=='posix'",
@@ -78,9 +74,7 @@ class DepsTest(unittest.TestCase):
             "osx_aarch64",
             "windows_x86_64",
         }
-        deps = wheel.Deps(
-            "foo", platforms={wheel.Platform.from_string(p) for p in platforms}
-        )
+        deps = wheel.Deps("foo", platforms=set(wheel.Platform.from_string(platforms)))
         deps.add(
             "bar",
             "baz; implementation_name=='cpython'",
@@ -216,14 +210,14 @@ class PlatformTest(unittest.TestCase):
         for give, want in tests.items():
             with self.subTest(give=give, want=want):
                 self.assertEqual(
-                    wheel.Platform.from_string(want),
+                    wheel.Platform.from_string(want)[0],
                     wheel.Platform.from_tag(give),
                 )
 
     def test_can_get_host(self):
         host = wheel.Platform.host()
         self.assertIsNotNone(host)
-        self.assertEqual(host, wheel.Platform.from_string("host"))
+        self.assertEqual(host, wheel.Platform.from_string("host")[0])
 
     def test_can_get_all(self):
         all_platforms = wheel.Platform.all()

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -218,7 +218,7 @@ class PlatformTest(unittest.TestCase):
         host = wheel.Platform.host()
         self.assertIsNotNone(host)
         self.assertEqual(1, len(wheel.Platform.from_string("host")))
-        self.assertEqual(host, wheel.Platform.from_string("host")[0])
+        self.assertEqual(host, wheel.Platform.from_string("host"))
 
     def test_can_get_all(self):
         all_platforms = wheel.Platform.all()

--- a/python/pip_install/tools/wheel_installer/wheel_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_test.py
@@ -217,6 +217,7 @@ class PlatformTest(unittest.TestCase):
     def test_can_get_host(self):
         host = wheel.Platform.host()
         self.assertIsNotNone(host)
+        self.assertEqual(1, len(wheel.Platform.from_string("host")))
         self.assertEqual(host, wheel.Platform.from_string("host")[0])
 
     def test_can_get_all(self):

--- a/python/private/bzlmod/pip.bzl
+++ b/python/private/bzlmod/pip.bzl
@@ -158,6 +158,7 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides):
                 p: json.encode(args)
                 for p, args in whl_overrides.get(whl_name, {}).items()
             },
+            target_platforms = pip_attr.target_platforms,
             python_interpreter = pip_attr.python_interpreter,
             python_interpreter_target = python_interpreter_target,
             quiet = pip_attr.quiet,

--- a/python/private/bzlmod/pip.bzl
+++ b/python/private/bzlmod/pip.bzl
@@ -158,7 +158,7 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides):
                 p: json.encode(args)
                 for p, args in whl_overrides.get(whl_name, {}).items()
             },
-            target_platforms = pip_attr.target_platforms,
+            experimental_target_platforms = pip_attr.experimental_target_platforms,
             python_interpreter = pip_attr.python_interpreter,
             python_interpreter_target = python_interpreter_target,
             quiet = pip_attr.quiet,

--- a/python/private/text_util.bzl
+++ b/python/private/text_util.bzl
@@ -28,18 +28,18 @@ def _render_alias(name, actual):
         ")",
     ])
 
-def _render_dict(d):
+def _render_dict(d, *, value_repr = repr):
     return "\n".join([
         "{",
         _indent("\n".join([
-            "{}: {},".format(repr(k), repr(v))
+            "{}: {},".format(repr(k), value_repr(v))
             for k, v in d.items()
         ])),
         "}",
     ])
 
-def _render_select(selects, *, no_match_error = None):
-    dict_str = _render_dict(selects) + ","
+def _render_select(selects, *, no_match_error = None, value_repr = repr):
+    dict_str = _render_dict(selects, value_repr = value_repr) + ","
 
     if no_match_error:
         args = "\n".join([

--- a/python/private/text_util.bzl
+++ b/python/private/text_util.bzl
@@ -58,6 +58,12 @@ def _render_select(selects, *, no_match_error = None):
     return "select({})".format(args)
 
 def _render_list(items):
+    if not items:
+        return "[]"
+
+    if len(items) == 1:
+        return "[{}]".format(repr(items[0]))
+
     return "\n".join([
         "[",
         _indent("\n".join([


### PR DESCRIPTION
Before this change, the dependency closures would be influenced by the
host-python interpreter, this removes the influence by detecting the
platforms against which the `Requires-Dist` wheel metadata is evaluated.
This functionality can be enabled via `experimental_target_platforms`
attribute to the `pip.parse` extension and is showcased in the `bzlmod`
example. The same attribute is also supported on the legacy `pip_parse`
repository rule.

The detection works in the following way:
- Check if the python wheel is platform specific or cross-platform
  (i.e., ends with `any.whl`), if it is then platform-specific
  dependencies are generated, which will go through a `select`
  statement.
- If it is platform specific, then parse the platform_tag and evaluate
  the `Requires-Dist` markers assuming the target platform rather than
  the host platform.

NOTE: The `whl` `METADATA` is now being parsed using the `packaging`
Python package instead of `pkg_resources` from `setuptools`.

Fixes #1591