### PR TITLE
examples(pip_parse): fix circular deps with sphinx by breaking cycles

### DIFF
--- a/examples/pip_parse/MODULE.bazel
+++ b/examples/pip_parse/MODULE.bazel
@@ -13,6 +13,16 @@ python.toolchain(
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
+    experimental_requirement_cycles = {
+        "sphinx": [
+            "sphinx",
+            "sphinxcontrib-serializinghtml",
+            "sphinxcontrib-qthelp",
+            "sphinxcontrib-htmlhelp",
+            "sphinxcontrib-devhelp",
+            "sphinxcontrib-applehelp",
+        ],
+    },
     hub_name = "pypi",
     python_version = "3.9",
     requirements_lock = "//:requirements_lock.txt",


### PR DESCRIPTION
When the pip_parse example was updated to use sphinx to demonstrate circular deps, its MODULE.bazel config was forgotten to also be updated to use the requirement_cycles feature to break the circular deps.

Fixes #1595