### PR TITLE
ci(example): provide a specific requirements.txt on windows

### DIFF
--- a/examples/pip_parse/MODULE.bazel
+++ b/examples/pip_parse/MODULE.bazel
@@ -26,5 +26,6 @@ pip.parse(
     hub_name = "pypi",
     python_version = "3.9",
     requirements_lock = "//:requirements_lock.txt",
+    requirements_windows = "//:requirements_windows.txt",
 )
 use_repo(pip, "pypi")


### PR DESCRIPTION
With bazel 7 released, this example started failing on regular PRs.
