### PR TITLE
feat: keep main module in py_library

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -248,7 +248,6 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 						fqTarget.String(), actualPyBinaryKind, err)
 					continue
 				}
-				srcs.Remove(filename)
 				pyBinary := newTargetBuilder(pyBinaryKind, pyBinaryTargetName, pythonProjectRoot, args.Rel, pyFileNames).
 					addVisibility(visibility).
 					addSrc(filename).

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
@@ -24,6 +24,8 @@ py_library(
     srcs = [
         "__init__.py",
         "collided_main.py",
+        "main.py",
+        "main2.py",
     ],
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
Unlike Go, the main module of Python can still be imported by other modules. We should keep them in the `py_library` target to allow such imports.
