### PR TITLE
fix: trimming deps in py_binary

### DIFF
--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
@@ -1,4 +1,6 @@
 # gazelle:python_library_naming_convention py_default_library
+# gazelle:resolve py numpy @pip//:numpy
+# gazelle:resolve py pandas @pip//:pandas
 
 filegroup(
     name = "collided_main",

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
@@ -1,6 +1,8 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 # gazelle:python_library_naming_convention py_default_library
+# gazelle:resolve py numpy @pip//:numpy
+# gazelle:resolve py pandas @pip//:pandas
 
 filegroup(
     name = "collided_main",
@@ -11,12 +13,14 @@ py_binary(
     name = "main",
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],
+    deps = ["@pip//:pandas"],
 )
 
 py_binary(
     name = "main2",
     srcs = ["main2.py"],
     visibility = ["//:__subpackages__"],
+    deps = [":py_default_library"],
 )
 
 py_library(
@@ -28,6 +32,10 @@ py_library(
         "main2.py",
     ],
     visibility = ["//:__subpackages__"],
+    deps = [
+        "@pip//:numpy",
+        "@pip//:pandas",
+    ],
 )
 
 py_test(

--- a/gazelle/python/testdata/binary_without_entrypoint/collided_main.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/collided_main.py
@@ -1,2 +1,4 @@
+import numpy
+
 if __name__ == "__main__":
     run()

--- a/gazelle/python/testdata/binary_without_entrypoint/main.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/main.py
@@ -1,2 +1,4 @@
+import pandas
+
 if __name__ == "__main__":
     run()

--- a/gazelle/python/testdata/binary_without_entrypoint/main2.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/main2.py
@@ -1,2 +1,4 @@
+import collided_main
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
The `py_binary` targets for main modules should only depend on the modules that it imports, not blindly inheriting from the py_library.