### PR TITLE
docs: update pip.parse example in release notes

### DIFF
--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -37,7 +37,8 @@ bazel_dep(name = "rules_python", version = "${TAG}")
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 
 pip.parse(
-    name = "pip",
+    hub_name = "pip",
+    python_version = "3.11",
     requirements_lock = "//:requirements_lock.txt",
 )
 


### PR DESCRIPTION
The release notes were using the old `pip.parse` api that used the `name` arg and
weren't mentioning the `python_version` arg.