### PR TITLE
docs: include changelog and contributing page in generated docs.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,11 @@ exports_files([
     "version.bzl",
 ])
 
+exports_files(
+    glob(["*.md"]),
+    visibility = ["//docs:__subpackages__"],
+)
+
 filegroup(
     name = "distribution",
     srcs = [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,6 @@ and setup. Subsequent runs will be faster, but there are many tests, and some of
 them are slow. If you're working on a particular area of code, you can run just
 the tests in those directories instead, which can speed up your edit-run cycle.
 
-Note that there are tests to verify generated documentation is correct -- if
-you're modifying the signature of a public function, these tests will likely
-fail and you'll need to [regenerate the api docs](#documentation).
-
 ## Formatting
 
 Starlark files should be formatted by
@@ -149,17 +145,6 @@ For the full details of types, see
 
 Some checked-in files are generated and need to be updated when a new PR is
 merged.
-
-### Documentation
-
-To regenerate the content under the `docs/` directory, run this command:
-
-```shell
-bazel run //docs:update
-```
-
-This needs to be done whenever the docstrings in the corresponding .bzl files
-are changed; a test failure will remind you to run this command when needed.
 
 ## Core rules
 

--- a/docs/sphinx/BUILD.bazel
+++ b/docs/sphinx/BUILD.bazel
@@ -55,6 +55,10 @@ sphinx_docs(
     formats = [
         "html",
     ],
+    renamed_srcs = {
+        "//:CHANGELOG.md": "changelog.md",
+        "//:CONTRIBUTING.md": "contributing.md",
+    },
     sphinx = ":sphinx-build",
     strip_prefix = package_name() + "/",
     tags = ["docs"],

--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -60,6 +60,8 @@ pypi-dependencies
 pip
 coverage
 gazelle
+Contributing <contributing>
+Changelog <changelog>
 api/index
 glossary
 genindex


### PR DESCRIPTION
This better unifies where docs can be viewed.

Also deletes some mentions of having to generate the docs manually.