### PR TITLE
fix(pip.parse): allow absolute path for python_interpreter; skip hermetic toolchain lookup when used

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -76,7 +76,9 @@ def _resolve_python_interpreter(rctx):
 
     Args:
         rctx: Handle to the rule repository context.
-    Returns: Python interpreter path.
+
+    Returns:
+        `path` object, for the resolved path to the Python interpreter.
     """
     python_interpreter = _get_python_interpreter_attr(rctx)
 
@@ -91,10 +93,13 @@ def _resolve_python_interpreter(rctx):
             if os == WINDOWS_NAME:
                 python_interpreter = python_interpreter.realpath
     elif "/" not in python_interpreter:
+        # It's a plain command, e.g. "python3", to look up in the environment.
         found_python_interpreter = rctx.which(python_interpreter)
         if not found_python_interpreter:
             fail("python interpreter `{}` not found in PATH".format(python_interpreter))
         python_interpreter = found_python_interpreter
+    else:
+        python_interpreter = rctx.path(python_interpreter)
     return python_interpreter
 
 def _get_xcode_location_cflags(rctx):

--- a/python/private/bzlmod/pip.bzl
+++ b/python/private/bzlmod/pip.bzl
@@ -86,7 +86,7 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides):
     # if we do not have the python_interpreter set in the attributes
     # we programmatically find it.
     hub_name = pip_attr.hub_name
-    if python_interpreter_target == None:
+    if python_interpreter_target == None and not pip_attr.python_interpreter:
         python_name = "python_" + version_label(pip_attr.python_version, sep = "_")
         if python_name not in INTERPRETER_LABELS.keys():
             fail((
@@ -357,13 +357,14 @@ Targets from different hubs should not be used together.
         "python_version": attr.string(
             mandatory = True,
             doc = """
-The Python version to use for resolving the pip dependencies, in Major.Minor
-format (e.g. "3.11"). Patch level granularity (e.g. "3.11.1") is not supported.
+The Python version the dependencies are targetting, in Major.Minor format
+(e.g., "3.11"). Patch level granularity (e.g. "3.11.1") is not supported.
 If not specified, then the default Python version (as set by the root module or
 rules_python) will be used.
 
-The version specified here must have a corresponding `python.toolchain()`
-configured.
+If an interpreter isn't explicitly provided (using `python_interpreter` or
+`python_interpreter_target`), then the version specified here must have
+a corresponding `python.toolchain()` configured.
 """,
         ),
         "whl_modifications": attr.label_keyed_string_dict(


### PR DESCRIPTION
The `python_interpreter` arg wasn't being properly handled in the bzlmod code in two ways.

1. Lookup of a hermetic runtime wasn't being skipped when it was set. The net effect was a hermetic toolchain of a matching version had to be registered, even if it wasn't used. To fix, add a check for python_interpreter to the guard of the lookup.

2. Specifying an absolute path for the value wasn't being converted to a `path` object, which meant a plain string eventually made its way to some code expecting a `path` object. To fix, call `repository_ctx.path()` on the path to convert it to a path object.

Fixes https://github.com/bazelbuild/rules_python/issues/1618