### PR TITLE
feat(py_runtime): Allow `py_runtime` to take an executable target as the interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ A brief description of the categories of changes:
 * (pip_install) the deprecated `pip_install` macro and related items have been
   removed.
 
-* (toolchains) `py_runtime` can now take an executable target. Note: runfiles from
-  the target are not supported yet.
+* (toolchains) `py_runtime` can now take an executable target. Note: runfiles
+  from the target are not supported yet.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ A brief description of the categories of changes:
 * (pip_install) the deprecated `pip_install` macro and related items have been
   removed.
 
+* (toolchains) `py_runtime` can now take an executable target. Note: runfiles from
+  the target are not supported yet.
+
 ### Fixed
 
 * (gazelle) The gazelle plugin helper was not working with Python toolchains 3.11

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -45,9 +45,7 @@ def _py_runtime_impl(ctx):
     else:
         interpreter_di = interpreter[DefaultInfo]
 
-        if _is_singleton_depset(interpreter_di.files):
-            interpreter = interpreter_di.files.to_list()[0]
-        elif interpreter_di.files_to_run and interpreter_di.files_to_run.executable:
+        if interpreter_di.files_to_run and interpreter_di.files_to_run.executable:
             interpreter = interpreter_di.files_to_run.executable
             runfiles = runfiles.merge(interpreter_di.default_runfiles)
 
@@ -56,6 +54,8 @@ def _py_runtime_impl(ctx):
                 interpreter_di.default_runfiles.files,
                 runtime_files,
             ])
+        elif _is_singleton_depset(interpreter_di.files):
+            interpreter = interpreter_di.files.to_list()[0]
         else:
             fail("interpreter must be an executable target or must produce exactly one file.")
 

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -57,7 +57,7 @@ def _py_runtime_impl(ctx):
                 runtime_files,
             ])
         else:
-            fail("interpreter must be an executable target or must product exactly one file.")
+            fail("interpreter must be an executable target or must produce exactly one file.")
 
     if ctx.attr.coverage_tool:
         coverage_di = ctx.attr.coverage_tool[DefaultInfo]
@@ -204,14 +204,28 @@ runtime. For a platform runtime this attribute must not be set.
 """,
         ),
         "interpreter": attr.label(
-            # We set `allow_files = True` because users should have
-            # the ability to set this attr to an executable target, such as
-            # a target created by `sh_binary`
+            # We set `allow_files = True` to allow specifying executable
+            # targets from rules that have more than one default output,
+            # e.g. sh_binary.
             allow_files = True,
             doc = """
-For an in-build runtime, this is the target to invoke as the interpreter. For a
-platform runtime this attribute must not be set. WIP: If the target is executable
-the runfiles may not be properly setup, see bazelbuild/rules_python/issues/1612
+For an in-build runtime, this is the target to invoke as the interpreter. It
+can be either of:
+
+* A single file, which will be the interpreter binary. It's assumed such
+  interpreters are either self-contained single-file executables or any
+  supporting files are specified in `files`.
+* An executable target. The target's executable will be the interpreter binary.
+  Any other default outputs (`target.files`) and plain files runfiles
+  (`runfiles.files`) will be automatically included as if specified in the
+  `files` attribute.
+
+  NOTE: the runfiles of the target may not yet be properly respected/propagated
+  to consumers of the toolchain/interpreter, see
+  bazelbuild/rules_python/issues/1612
+
+For a platform runtime (i.e. `interpreter_path` being set) this attribute must
+not be set.
 """,
         ),
         "interpreter_path": attr.string(doc = """

--- a/tests/py_runtime/pretend_binary
+++ b/tests/py_runtime/pretend_binary
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/tests/py_runtime/pretend_binary
+++ b/tests/py_runtime/pretend_binary
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-exit 0

--- a/tests/py_runtime/py_runtime_tests.bzl
+++ b/tests/py_runtime/py_runtime_tests.bzl
@@ -321,9 +321,10 @@ def _test_system_interpreter_must_be_absolute_impl(env, target):
 _tests.append(_test_system_interpreter_must_be_absolute)
 
 def _test_interpreter_sh_binary_target(name):
-    native.sh_binary(
+    rt_util.helper_target(
+        native.sh_binary,
         name = "built_interpreter",
-        srcs = [":pretend_binary"],
+        srcs = ["pretend_binary"],
     )
 
     rt_util.helper_target(

--- a/tests/py_runtime/py_runtime_tests.bzl
+++ b/tests/py_runtime/py_runtime_tests.bzl
@@ -320,6 +320,32 @@ def _test_system_interpreter_must_be_absolute_impl(env, target):
 
 _tests.append(_test_system_interpreter_must_be_absolute)
 
+def _test_interpreter_sh_binary_target(name):
+    native.sh_binary(
+        name = "built_interpreter",
+        srcs = [":pretend_binary"],
+    )
+
+    rt_util.helper_target(
+        py_runtime,
+        name = name + "_subject",
+        interpreter = ":built_interpreter",
+        python_version = "PY3",
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_interpreter_sh_binary_target_impl,
+    )
+
+def _test_interpreter_sh_binary_target_impl(env, target):
+    env.expect.that_target(target).provider(
+        PyRuntimeInfo,
+        factory = py_runtime_info_subject,
+    ).interpreter_path().equals(None)
+
+_tests.append(_test_interpreter_sh_binary_target)
+
 def py_runtime_test_suite(name):
     test_suite(
         name = name,

--- a/tests/py_runtime/py_runtime_tests.bzl
+++ b/tests/py_runtime/py_runtime_tests.bzl
@@ -41,8 +41,8 @@ def _simple_binary_impl(ctx):
 _simple_binary = rule(
     implementation = _simple_binary_impl,
     attrs = {
-        "extra_default_outputs": attr.label_list(allow_files = True),
         "data": attr.label_list(allow_files = True),
+        "extra_default_outputs": attr.label_list(allow_files = True),
     },
     executable = True,
 )

--- a/tests/py_runtime_info_subject.bzl
+++ b/tests/py_runtime_info_subject.bzl
@@ -31,6 +31,7 @@ def py_runtime_info_subject(info, *, meta):
     # buildifier: disable=uninitialized
     public = struct(
         # go/keep-sorted start
+        actual = info,
         bootstrap_template = lambda *a, **k: _py_runtime_info_subject_bootstrap_template(self, *a, **k),
         coverage_files = lambda *a, **k: _py_runtime_info_subject_coverage_files(self, *a, **k),
         coverage_tool = lambda *a, **k: _py_runtime_info_subject_coverage_tool(self, *a, **k),


### PR DESCRIPTION
This PR allows `py_runtime` to accept an executable (e.g. `sh_binary`).

This makes it easier to customize the interpreter binary used, as it allows
intercepting invocation of the interpreter. For example, it can be used to
change how the interpreter searches for dynamic libraries.

Related to https://github.com/bazelbuild/rules_python/issues/1612