### PR TITLE
doc: switch to pypi.org

### DIFF
--- a/examples/bzlmod/requirements.in
+++ b/examples/bzlmod/requirements.in
@@ -1,4 +1,4 @@
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 wheel
 websockets

--- a/examples/bzlmod/requirements_lock_3_10.txt
+++ b/examples/bzlmod/requirements_lock_3_10.txt
@@ -4,7 +4,7 @@
 #
 #    bazel run //:requirements_3_10.update
 #
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \

--- a/examples/bzlmod/requirements_lock_3_9.txt
+++ b/examples/bzlmod/requirements_lock_3_9.txt
@@ -4,7 +4,7 @@
 #
 #    bazel run //:requirements_3_9.update
 #
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \

--- a/examples/bzlmod/requirements_windows_3_10.txt
+++ b/examples/bzlmod/requirements_windows_3_10.txt
@@ -4,7 +4,7 @@
 #
 #    bazel run //:requirements_3_10.update
 #
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \

--- a/examples/bzlmod/requirements_windows_3_9.txt
+++ b/examples/bzlmod/requirements_windows_3_9.txt
@@ -4,7 +4,7 @@
 #
 #    bazel run //:requirements_3_9.update
 #
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \

--- a/examples/pip_repository_annotations/requirements.in
+++ b/examples/pip_repository_annotations/requirements.in
@@ -1,6 +1,6 @@
 # This flag allows for regression testing requirements arguments in 
 # `pip_repository` rules.
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 certifi>=2023.7.22  # https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047
 wheel

--- a/examples/pip_repository_annotations/requirements.txt
+++ b/examples/pip_repository_annotations/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    bazel run //:requirements.update
 #
---extra-index-url https://pypi.python.org/simple/
+--extra-index-url https://pypi.org/simple/
 
 certifi==2023.7.22 \
     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -105,10 +105,10 @@ def rules_python_internal_deps():
         name = "futures_2_2_0_whl",
         downloaded_file_path = "futures-2.2.0-py2.py3-none-any.whl",
         sha256 = "9fd22b354a4c4755ad8c7d161d93f5026aca4cfe999bd2e53168f14765c02cd6",
-        # From https://pypi.python.org/pypi/futures/2.2.0
+        # From https://pypi.org/pypi/futures/2.2.0
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
-            "https://pypi.python.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
+            "https://mirror.bazel.build/pypi.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
+            "https://pypi.org/packages/d7/1d/68874943aa37cf1c483fc61def813188473596043158faa6511c04a038b4/futures-2.2.0-py2.py3-none-any.whl",
         ],
     )
 
@@ -116,10 +116,10 @@ def rules_python_internal_deps():
         name = "futures_3_1_1_whl",
         downloaded_file_path = "futures-3.1.1-py2-none-any.whl",
         sha256 = "c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
-        # From https://pypi.python.org/pypi/futures
+        # From https://pypi.org/pypi/futures
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
-            "https://pypi.python.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
+            "https://mirror.bazel.build/pypi.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
+            "https://pypi.org/packages/a6/1c/72a18c8c7502ee1b38a604a5c5243aa8c2a64f4bba4e6631b1b8972235dd/futures-3.1.1-py2-none-any.whl",
         ],
     )
 
@@ -127,10 +127,10 @@ def rules_python_internal_deps():
         name = "google_cloud_language_whl",
         downloaded_file_path = "google_cloud_language-0.29.0-py2.py3-none-any.whl",
         sha256 = "a2dd34f0a0ebf5705dcbe34bd41199b1d0a55c4597d38ed045bd183361a561e9",
-        # From https://pypi.python.org/pypi/google-cloud-language
+        # From https://pypi.org/pypi/google-cloud-language
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
-            "https://pypi.python.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
+            "https://mirror.bazel.build/pypi.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
+            "https://pypi.org/packages/6e/86/cae57e4802e72d9e626ee5828ed5a646cf4016b473a4a022f1038dba3460/google_cloud_language-0.29.0-py2.py3-none-any.whl",
         ],
     )
 
@@ -138,10 +138,10 @@ def rules_python_internal_deps():
         name = "grpc_whl",
         downloaded_file_path = "grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
         sha256 = "c232d6d168cb582e5eba8e1c0da8d64b54b041dd5ea194895a2fe76050916561",
-        # From https://pypi.python.org/pypi/grpcio/1.6.0
+        # From https://pypi.org/pypi/grpcio/1.6.0
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
-            "https://pypi.python.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
+            "https://mirror.bazel.build/pypi.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
+            "https://pypi.org/packages/c6/28/67651b4eabe616b27472c5518f9b2aa3f63beab8f62100b26f05ac428639/grpcio-1.6.0-cp27-cp27m-manylinux1_i686.whl",
         ],
     )
 
@@ -149,10 +149,10 @@ def rules_python_internal_deps():
         name = "mock_whl",
         downloaded_file_path = "mock-2.0.0-py2.py3-none-any.whl",
         sha256 = "5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
-        # From https://pypi.python.org/pypi/mock
+        # From https://pypi.org/pypi/mock
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
-            "https://pypi.python.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
+            "https://mirror.bazel.build/pypi.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
+            "https://pypi.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl",
         ],
     )
 

--- a/tools/private/update_deps/update_coverage_deps.py
+++ b/tools/private/update_deps/update_coverage_deps.py
@@ -151,7 +151,7 @@ def _parse_args() -> argparse.Namespace:
 def main():
     args = _parse_args()
 
-    api_url = f"https://pypi.python.org/pypi/{args.name}/{args.version}/json"
+    api_url = f"https://pypi.org/pypi/{args.name}/{args.version}/json"
     req = request.Request(api_url)
     with request.urlopen(req) as response:
         data = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
Before this PR all of our examples are referring to the default PyPI by its
legacy URL. This PR just makes things more consistent by updating URLs to point
to the pypi.org as pypi.python.org does not have any guarantees to be up.

See https://packaging.python.org/en/latest/guides/migrating-to-pypi-org/
