### PR TITLE
internal: support setting visibility when rendering aliases

### DIFF
--- a/python/private/text_util.bzl
+++ b/python/private/text_util.bzl
@@ -20,11 +20,18 @@ def _indent(text, indent = " " * 4):
 
     return "\n".join([indent + line for line in text.splitlines()])
 
-def _render_alias(name, actual):
+def _render_alias(name, actual, *, visibility = None):
+    args = [
+        "name = \"{}\",".format(name),
+        "actual = {},".format(actual),
+    ]
+
+    if visibility:
+        args.append("visibility = {},".format(render.list(visibility)))
+
     return "\n".join([
         "alias(",
-        _indent("name = \"{}\",".format(name)),
-        _indent("actual = {},".format(actual)),
+    ] + [_indent(arg) for arg in args] + [
         ")",
     ])
 

--- a/tests/private/text_util/BUILD.bazel
+++ b/tests/private/text_util/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load(":render_tests.bzl", "render_test_suite")
 
 render_test_suite(name = "render_tests")

--- a/tests/private/text_util/BUILD.bazel
+++ b/tests/private/text_util/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":render_tests.bzl", "render_test_suite")
+
+render_test_suite(name = "render_tests")

--- a/tests/private/text_util/render_tests.bzl
+++ b/tests/private/text_util/render_tests.bzl
@@ -1,0 +1,63 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""
+
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//python/private:text_util.bzl", "render")  # buildifier: disable=bzl-visibility
+
+_tests = []
+
+def _test_render_alias(env):
+    tests = [
+        struct(
+            args = dict(
+                name = "foo",
+                actual = repr("bar"),
+            ),
+            want = [
+                "alias(",
+                '    name = "foo",',
+                '    actual = "bar",',
+                ")",
+            ],
+        ),
+        struct(
+            args = dict(
+                name = "foo",
+                actual = repr("bar"),
+                visibility = ["//:__pkg__"],
+            ),
+            want = [
+                "alias(",
+                '    name = "foo",',
+                '    actual = "bar",',
+                '    visibility = ["//:__pkg__"],',
+                ")",
+            ],
+        ),
+    ]
+    for test in tests:
+        got = render.alias(**test.args)
+        env.expect.that_str(got).equals("\n".join(test.want).strip())
+
+_tests.append(_test_render_alias)
+
+def render_test_suite(name):
+    """Create the test suite.
+
+    Args:
+        name: the name of the test suite
+    """
+    test_suite(name = name, basic_tests = _tests)


### PR DESCRIPTION
Whilst prototyping for #1625, I realized that this feature would be useful
in general when rendering external repositories. This does not include a
CHANGELOG because it is not visible to the users.
