### PR TITLE
refactor: extract auth.bzl out of repositories.bzl

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -196,6 +196,7 @@ bzl_library(
     srcs = ["repositories.bzl"],
     deps = [
         ":versions_bzl",
+        "//python/private:auth_bzl",
         "//python/private:bazel_tools_bzl",
         "//python/private:bzlmod_enabled_bzl",
         "//python/private:coverage_deps_bzl",

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -49,6 +49,12 @@ filegroup(
 )
 
 bzl_library(
+    name = "auth_bzl",
+    srcs = ["auth.bzl"],
+    deps = [":bazel_tools_bzl"],
+)
+
+bzl_library(
     name = "autodetecting_toolchain_bzl",
     srcs = ["autodetecting_toolchain.bzl"],
     deps = [

--- a/python/private/auth.bzl
+++ b/python/private/auth.bzl
@@ -1,0 +1,42 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers copied from http_file source to be reused here.
+
+The implementation below is copied directly from Bazel's implementation of `http_archive`.
+Accordingly, the return value of this function should be used identically as the `auth` parameter of `http_archive`.
+Reference: https://github.com/bazelbuild/bazel/blob/6.3.2/tools/build_defs/repo/http.bzl#L109
+"""
+
+# TODO @aignas 2023-12-18: use the following instead when available.
+# load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_netrc", "use_netrc")
+
+def get_auth(rctx, urls):
+    """Utility for retrieving netrc-based authentication parameters for repository download rules used in python_repository.
+
+    Args:
+        rctx (repository_ctx): The repository rule's context object.
+        urls: A list of URLs from which assets will be downloaded.
+
+    Returns:
+        dict: A map of authentication parameters by URL.
+    """
+    if rctx.attr.netrc:
+        netrc = read_netrc(rctx, rctx.attr.netrc)
+    elif "NETRC" in rctx.os.environ:
+        netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
+    else:
+        netrc = read_user_netrc(rctx)
+    return use_netrc(netrc, urls, rctx.attr.auth_patterns)

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -18,8 +18,9 @@ For historic reasons, pip_repositories() is defined in //python:pip.bzl.
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe", "read_netrc", "read_user_netrc", "use_netrc")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//python/pip_install:repositories.bzl", "pip_install_dependencies")
+load("//python/private:auth.bzl", "get_auth")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load("//python/private:coverage_deps.bzl", "coverage_dep")
 load("//python/private:full_version.bzl", "full_version")
@@ -92,28 +93,6 @@ def is_standalone_interpreter(rctx, python_interpreter_path):
         ),
     ]).return_code == 0
 
-def _get_auth(rctx, urls):
-    """Utility for retrieving netrc-based authentication parameters for repository download rules used in python_repository.
-
-    The implementation below is copied directly from Bazel's implementation of `http_archive`.
-    Accordingly, the return value of this function should be used identically as the `auth` parameter of `http_archive`.
-    Reference: https://github.com/bazelbuild/bazel/blob/6.3.2/tools/build_defs/repo/http.bzl#L109
-
-    Args:
-        rctx (repository_ctx): The repository rule's context object.
-        urls: A list of URLs from which assets will be downloaded.
-
-    Returns:
-        dict: A map of authentication parameters by URL.
-    """
-    if rctx.attr.netrc:
-        netrc = read_netrc(rctx, rctx.attr.netrc)
-    elif "NETRC" in rctx.os.environ:
-        netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
-    else:
-        netrc = read_user_netrc(rctx)
-    return use_netrc(netrc, urls, rctx.attr.auth_patterns)
-
 def _python_repository_impl(rctx):
     if rctx.attr.distutils and rctx.attr.distutils_content:
         fail("Only one of (distutils, distutils_content) should be set.")
@@ -125,7 +104,7 @@ def _python_repository_impl(rctx):
     python_short_version = python_version.rpartition(".")[0]
     release_filename = rctx.attr.release_filename
     urls = rctx.attr.urls or [rctx.attr.url]
-    auth = _get_auth(rctx, urls)
+    auth = get_auth(rctx, urls)
 
     if release_filename.endswith(".zst"):
         rctx.download(


### PR DESCRIPTION
This is a simple change to make it possible to reuse the vendored
authentication code for easier reuse within the repository.

Split from #1625
