### PR TITLE
test(bzlmod): refactor tests to not depend on implementation details

### DIFF
--- a/examples/bzlmod/whl_mods/BUILD.bazel
+++ b/examples/bzlmod/whl_mods/BUILD.bazel
@@ -8,9 +8,13 @@ exports_files(
 py_test(
     name = "pip_whl_mods_test",
     srcs = ["pip_whl_mods_test.py"],
+    data = [
+        "@pip//requests:dist_info",
+        "@pip//wheel:dist_info",
+    ],
     env = {
-        "REQUESTS_PKG_DIR": "pip_39_requests",
-        "WHEEL_PKG_DIR": "pip_39_wheel",
+        "REQUESTS_DISTINFO": "$(rlocationpaths @pip//requests:dist_info)",
+        "WHEEL_DISTINFO": "$(rlocationpaths @pip//wheel:dist_info)",
     },
     main = "pip_whl_mods_test.py",
     deps = [

--- a/examples/bzlmod/whl_mods/BUILD.bazel
+++ b/examples/bzlmod/whl_mods/BUILD.bazel
@@ -8,13 +8,9 @@ exports_files(
 py_test(
     name = "pip_whl_mods_test",
     srcs = ["pip_whl_mods_test.py"],
-    data = [
-        "@pip//requests:dist_info",
-        "@pip//wheel:dist_info",
-    ],
     env = {
-        "REQUESTS_DISTINFO": "$(rlocationpaths @pip//requests:dist_info)",
-        "WHEEL_DISTINFO": "$(rlocationpaths @pip//wheel:dist_info)",
+        "REQUESTS_PKG": "$(rlocationpaths @pip//requests:pkg)",
+        "WHEEL_PKG": "$(rlocationpaths @pip//wheel:pkg)",
     },
     main = "pip_whl_mods_test.py",
     deps = [


### PR DESCRIPTION
This refactors the `whl_mods` tests to not rely on the layout of the
repositories, which I found to be needed whilst prototyping on #1625.
Whilst doing this I realized that in general it would be great to
support `Path` instances in the `runfiles` library, but that should be
done next time.
