### PR TITLE
fix: missing dependencies of py_binary

### DIFF
--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
@@ -13,7 +13,10 @@ py_binary(
     name = "main",
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//:pandas"],
+    deps = [
+        ":py_default_library",
+        "@pip//:pandas",
+    ],
 )
 
 py_binary(

--- a/gazelle/python/testdata/binary_without_entrypoint/main.py
+++ b/gazelle/python/testdata/binary_without_entrypoint/main.py
@@ -1,3 +1,4 @@
+import collided_main
 import pandas
 
 if __name__ == "__main__":


### PR DESCRIPTION
When multiple main modules import the same package, the package is only added to one of the main module's deps, this is because the `allDeps` set returned from `parse` removed the duplicates based on the import's name.

This PR have every main module maintains a list of deps it imports to avoid this issue.