### PR TITLE
fix(whl_library): actually apply patches and warn if RECORD file patch is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ A brief description of the categories of changes:
 * (bzlmod pip.parse) Requirements files with duplicate entries for the same
   package (e.g. one for the package, one for an extra) now work.
 * (whl_library) Actually use the provided patches to patch the whl_library.
+  On Windows the patching may result in files with CRLF line endings, as a result
+  the RECORD file consistency requirement is lifted and now a warning is emitted
+  instead with a location to the patch that could be used to silence the warning.
+  Copy the patch to your workspace and add it to the list if patches for the wheel
+  file if you decide to do so.
 
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ A brief description of the categories of changes:
   specifying a local system interpreter.
 * (bzlmod pip.parse) Requirements files with duplicate entries for the same
   package (e.g. one for the package, one for an extra) now work.
+* (whl_library) Actually use the provided patches to patch the whl_library.
 
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 

--- a/examples/bzlmod/whl_mods/pip_whl_mods_test.py
+++ b/examples/bzlmod/whl_mods/pip_whl_mods_test.py
@@ -130,6 +130,22 @@ class PipWhlModsTest(unittest.TestCase):
         content = generated_file.read_text().rstrip()
         self.assertEqual(content, "Hello world from requests")
 
+    def test_patches(self):
+        current_wheel_version = "2.25.1"
+
+        # This test verifies that the patches are applied to the wheel.
+        r = runfiles.Create()
+        metadata_path = "{}/site-packages/requests-{}.dist-info/METADATA".format(
+            self._requests_pkg_dir,
+            current_wheel_version,
+        )
+
+        metadata = Path(r.Rlocation(metadata_path))
+        self.assertIn(
+            "Summary: Python HTTP for Humans. Patched.",
+            metadata.read_text().splitlines(),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -729,7 +729,7 @@ def _whl_library_impl(rctx):
 
     if rctx.attr.whl_patches:
         patches = {}
-        for patch_file, json_args in patches.items():
+        for patch_file, json_args in rctx.attr.whl_patches.items():
             patch_dst = struct(**json.decode(json_args))
             if whl_path.basename in patch_dst.whls:
                 patches[patch_file] = patch_dst.patch_strip

--- a/python/private/repack_whl.py
+++ b/python/private/repack_whl.py
@@ -114,6 +114,11 @@ def main(sys_argv):
         help="The original wheel file that we have patched.",
     )
     parser.add_argument(
+        "--record-patch",
+        type=pathlib.Path,
+        help="The output path that we are going to write the RECORD file patch to.",
+    )
+    parser.add_argument(
         "output",
         type=pathlib.Path,
         help="The output path that we are going to write a new file to.",
@@ -163,8 +168,10 @@ def main(sys_argv):
         got_record,
         out.distinfo_path("RECORD"),
     )
-    logging.exception(f"Please also patch the RECORD file with:\n{record_diff}")
-    return 1
+    args.record_patch.write_text(record_diff)
+    logging.warning(
+        f"Please apply patch to the RECORD file ({args.record_patch}):\n{record_diff}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before this PR there was a typo, that was actually causing the
patching function to not use the provided patches. With this change
we are finally correctly doing it. After fixing this bug I noticed
that `repository_ctx.patch` results in files with `CRLF` on Windows,
which made me make the `RECORD` mismatch to be a warning rather than
a hard failure to make the CI happy and allow users on Windows to
patch wheels but see a warning if they have a multi-platform bazel
setup.

The `CRLF` endings on Windows issue is fixed in
bazelbuild/bazel@07e0d316a345a3cb2593f98525320590bbc56e30

Related #1631, #1639.
