### PR TITLE
fix(bzlmod): allow modules to register the same toolchain as rules_python's default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ A brief description of the categories of changes:
   specifying a local system interpreter.
 * (bzlmod pip.parse) Requirements files with duplicate entries for the same
   package (e.g. one for the package, one for an extra) now work.
+* (bzlmod python.toolchain) Submodules can now (re)register the Python version
+  that rules_python has set as the default.
+  ([#1638](https://github.com/bazelbuild/rules_python/issues/1638))
 * (whl_library) Actually use the provided patches to patch the whl_library.
   On Windows the patching may result in files with CRLF line endings, as a result
   the RECORD file consistency requirement is lifted and now a warning is emitted


### PR DESCRIPTION
This fixes a bug where, if a module tries to register a non-default toolchain with the
same version as rules_python's default toolchain, an error would occur. This happened
because the earlier (non-default) toolchain caused the later (default) toolchain to
be entirely skipped, and then no default toolchain would be seen. This most affects
intermediary modules that need to register a toolchain, but can't specify a default one.

To fix, just skip creating and registering the duplicate toolchain, but still check
its default-ness to determine if it's the default toolchain.

Fixes https://github.com/bazelbuild/rules_python/issues/1638