### PR TITLE
fix(gazelle): Cease write narrow visibilities

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -212,7 +212,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	}
 
 	parser := newPython3Parser(args.Config.RepoRoot, args.Rel, cfg.IgnoresDependency)
-	visibility := fmt.Sprintf("//%s:__subpackages__", pythonProjectRoot)
+	visibility := "//visibility:public"
 
 	var result language.GenerateResult
 	result.Gen = make([]*rule.Rule, 0)


### PR DESCRIPTION
This PR causes Gazelle to not write `visibility` lines for generated rules.

# Context

This is necessary in monorepo situations where there are multiple `# gazelle:python_root` directives used, e.g. in the structure below:

```
ROOT
    proj_1
        src  # is a python root and depends on proj_2
            foo
    pro_2
        src  # is a python root
            bar  ← The visibility here will be incorrect; proj_1 cannot see this.
```

As it stands, we write a narrowly scoped `visibility` attribute for every generated rule; the visibility is `//{python-root-package}:__subpackages__`. Let's not!

---

# Alternatives

Two considered alternatives were:
* Have the Gazelle Python extension respect the `# gazelle:default_visibility` directive. This is probably correct in the long run, but I'm not Go-literate.
* Set all visibilities to `//visibility:public`. This achieves correct behavior but gives less control than the current PR. Instead of respecting any default visibility stanzas, it forces the entirety to be public.

---

# Preserving current behavior

If someone wants the current behavior, it can still be achieved by setting the following in Python root's BUILD file:
```python
package(
    default_visibility = ["//" + package_name() + ":__subpackages__"],
)
```

