### PR TITLE
internal: update native deps and linkstamp API updates to Bazel rolling APIs

### DIFF
--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -556,7 +556,8 @@ def _create_shared_native_deps_dso(
         cc_info,
         is_test,
         feature_configuration,
-        requested_features):
+        requested_features,
+        cc_toolchain):
     linkstamps = py_internal.linking_context_linkstamps(cc_info.linking_context)
 
     partially_disabled_thin_lto = (


### PR DESCRIPTION
This basically upstreams part of Google-internal patches for building native dep DSOs.

The APIs it uses are only available on Bazel rolling, but the code paths that activate them aren't enabled in rules_python.