### PR TITLE
fix: use shutil.copyfile instead of shutil.copy

### DIFF
--- a/python/pip_install/tools/dependency_resolver/dependency_resolver.py
+++ b/python/pip_install/tools/dependency_resolver/dependency_resolver.py
@@ -29,7 +29,7 @@ from python.runfiles import runfiles
 
 # Replace the os.replace function with shutil.copy to work around os.replace not being able to
 # replace or move files across filesystems.
-os.replace = shutil.copy
+os.replace = shutil.copyfile
 
 # Next, we override the annotation_style_split and annotation_style_line functions to replace the
 # backslashes in the paths with forward slashes. This is so that we can have the same requirements


### PR DESCRIPTION
Encountering this error when running on a CI VM: https://stackoverflow.com/questions/11835833/why-would-shutil-copy-raise-a-permission-exception-when-cp-doesnt

Per the accepted solution, this solves the problem and doesn't seem to impact functionality. Is this consistent with the intent here?
