### PR TITLE
refactor: broaden visibility and use list() instead of keys()

### DIFF
--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(
-    default_visibility = ["//python:__subpackages__"],
+    default_visibility = ["//:__subpackages__"],
 )
 
 bzl_library(

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -226,7 +226,7 @@ COMMON_ATTR_NAMES = [
     "testonly",
     "toolchains",
     "visibility",
-] + COMMON_ATTRS.keys()
+] + list(COMMON_ATTRS)  # Use list() instead .keys() so it's valid Python
 
 # Attribute names common to all test=True rules
 TEST_ATTR_NAMES = COMMON_ATTR_NAMES + [
@@ -236,10 +236,10 @@ TEST_ATTR_NAMES = COMMON_ATTR_NAMES + [
     "flaky",
     "shard_count",
     "local",
-] + AGNOSTIC_TEST_ATTRS.keys()
+] + list(AGNOSTIC_TEST_ATTRS)  # Use list() instead .keys() so it's valid Python
 
 # Attribute names common to all executable=True rules
 BINARY_ATTR_NAMES = COMMON_ATTR_NAMES + [
     "args",
     "output_licenses",  # NOTE: Common to all rules, but slated for removal
-] + AGNOSTIC_BINARY_ATTRS.keys()
+] + list(AGNOSTIC_BINARY_ATTRS)  # Use list() instead .keys() so it's valid Python


### PR DESCRIPTION
This upstreams a couple trivial Google patches to make rules_python more compatible with some Google-internal changes.

* Use list(dict) instead of dict.keys(). This is because some bzl files are run through a Python-based testing framework, and dict.keys() can't be concatenated to a list in Python 3.
* Expand visibility to all of rules_python instead of just the python subdirectory. This makes some patches that use internals easier to maintain, but also makes the visiblity more in line with the rest of the project (where `//:__subpackages__` is used for convenience, as it avoids having to change visibility frequently, but still prevents public dependencies).