### PR TITLE
test: workaround cyclic dependency bzlmod bug by disabling lockfiles

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,6 @@ common --enable_bzlmod
 build:rtd --stamp
 # Some bzl files contain repos only available under bzlmod
 build:rtd --enable_bzlmod
+
+# Disabled due to https://github.com/bazelbuild/bazel/issues/20942
+build --lockfile_mode=off


### PR DESCRIPTION
Bazel 7.0.1 has a bug where lockfiles can cause a bogus error about cyclic dependencies. Removing the lockfile or disabling the lockfiles prevents it from triggering. We aren't
using lockfiles anyways.

This should make CI happy, which uses 7.0.1 in some configurations. Local development
isn't impacted because .bazelversion specifies 7.0.0

See https://github.com/bazelbuild/bazel/issues/20942