### PR TITLE
feat(py_wheel): Added `requires_file` and `extra_requires_files` attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ A brief description of the categories of changes:
 
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 
+### Changed
+
+### Fixed
+
+### Added
+
+* (py_wheel) Added `requires_file` and `extra_requires_files` attributes.
+
 ## 0.29.0 - 2024-01-22
 
 [0.29.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.29.0

--- a/examples/wheel/BUILD.bazel
+++ b/examples/wheel/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//examples/wheel/private:wheel_utils.bzl", "directory_writer", "make_variable_tags")
 load("//python:defs.bzl", "py_library", "py_test")
 load("//python:packaging.bzl", "py_package", "py_wheel")
@@ -269,6 +270,47 @@ py_wheel(
     deps = [":example_pkg"],
 )
 
+write_file(
+    name = "requires_file",
+    out = "requires.txt",
+    content = """\
+# Requirements file
+--index-url https://pypi.com
+
+tomli>=2.0.0
+""".splitlines(),
+)
+
+write_file(
+    name = "extra_requires_file",
+    out = "extra_requires.txt",
+    content = """\
+# Extras Requirements file
+--index-url https://pypi.com
+
+pyyaml>=6.0.0,!=6.0.1
+toml; (python_version == "3.11" or python_version == "3.12") and python_version != "3.8"
+wheel; python_version == "3.11" or python_version == "3.12"
+""".splitlines(),
+)
+
+# py_wheel can use text files to specify their requirements. This
+# can be convenient for users of `compile_pip_requirements` who have
+# granular `requirements.in` files per package. This target shows
+# how to provide this file.
+py_wheel(
+    name = "requires_files",
+    distribution = "requires_files",
+    extra_requires_files = {":extra_requires.txt": "example"},
+    python_tag = "py3",
+    # py_wheel can use text files to specify their requirements. This
+    # can be convenient for users of `compile_pip_requirements` who have
+    # granular `requirements.in` files per package.
+    requires_file = ":requires.txt",
+    version = "0.0.1",
+    deps = [":example_pkg"],
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],
@@ -283,6 +325,7 @@ py_test(
         ":minimal_with_py_package",
         ":python_abi3_binary_wheel",
         ":python_requires_in_a_package",
+        ":requires_files",
         ":use_rule_with_dir_in_outs",
     ],
     deps = [

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -438,6 +438,34 @@ Tag: cp38-abi3-{os_string}_{arch}
             self.assertNotIn("{BUILD_TIMESTAMP}", version)
             self.assertNotIn("{BUILD_USER}", name)
 
+    def test_requires_file_and_extra_requires_files(self):
+        filename = self._get_path("requires_files-0.0.1-py3-none-any.whl")
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertAllEntriesHasReproducibleMetadata(zf)
+            metadata_file = None
+            for f in zf.namelist():
+                if os.path.basename(f) == "METADATA":
+                    metadata_file = f
+            self.assertIsNotNone(metadata_file)
+
+            requires = []
+            with zf.open(metadata_file) as fp:
+                for line in fp:
+                    if line.startswith(b"Requires-Dist:"):
+                        requires.append(line.decode("utf-8").strip())
+
+            print(requires)
+            self.assertEqual(
+                [
+                    "Requires-Dist: tomli>=2.0.0;",
+                    "Requires-Dist: pyyaml!=6.0.1,>=6.0.0; extra == 'example'",
+                    'Requires-Dist: toml; ((python_version == "3.11" or python_version == "3.12") and python_version != "3.8") and extra == \'example\'',
+                    'Requires-Dist: wheel; (python_version == "3.11" or python_version == "3.12") and extra == \'example\'',
+                ],
+                requires,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `compile_pip_requirements` rule promotes having `requirements.in` files describe python dependencies. This change aims to allow these files to be the source of truth for constraints by allowing the `py_wheel` rule to use them for adding requirements to a wheel. This reduces overhead in needing to maintain two lists of equal information (one as he `.in` and the other as starlark data).