### PR TITLE
fix(py_wheel): Fix parsing errors with `requires_file` attribute.

### DIFF
--- a/examples/wheel/BUILD.bazel
+++ b/examples/wheel/BUILD.bazel
@@ -278,6 +278,7 @@ write_file(
 --index-url https://pypi.com
 
 tomli>=2.0.0
+starlark  # Example comment
 """.splitlines(),
 )
 
@@ -290,7 +291,7 @@ write_file(
 
 pyyaml>=6.0.0,!=6.0.1
 toml; (python_version == "3.11" or python_version == "3.12") and python_version != "3.8"
-wheel; python_version == "3.11" or python_version == "3.12"
+wheel; python_version == "3.11" or python_version == "3.12"  # Example comment
 """.splitlines(),
 )
 

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -458,7 +458,8 @@ Tag: cp38-abi3-{os_string}_{arch}
             print(requires)
             self.assertEqual(
                 [
-                    "Requires-Dist: tomli>=2.0.0;",
+                    "Requires-Dist: tomli>=2.0.0",
+                    "Requires-Dist: starlark",
                     "Requires-Dist: pyyaml!=6.0.1,>=6.0.0; extra == 'example'",
                     'Requires-Dist: toml; ((python_version == "3.11" or python_version == "3.12") and python_version != "3.8") and extra == \'example\'',
                     'Requires-Dist: wheel; (python_version == "3.11" or python_version == "3.12") and extra == \'example\'',

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -531,13 +531,23 @@ def main() -> None:
                 if not reqs_text or reqs_text.startswith(("#", "-")):
                     continue
 
-                req = Requirement(reqs_text)
+                # Strip any comments
+                reqs_text, _, _ = reqs_text.partition("#")
+
+                req = Requirement(reqs_text.strip())
                 if req.marker:
-                    reqs.append(
-                        f"Requires-Dist: {req.name}{req.specifier}; ({req.marker}) and {extra}"
-                    )
+                    if extra:
+                        reqs.append(
+                            f"Requires-Dist: {req.name}{req.specifier}; ({req.marker}) and {extra}"
+                        )
+                    else:
+                        reqs.append(
+                            f"Requires-Dist: {req.name}{req.specifier}; {req.marker}"
+                        )
                 else:
-                    reqs.append(f"Requires-Dist: {req.name}{req.specifier}; {extra}")
+                    reqs.append(
+                        f"Requires-Dist: {req.name}{req.specifier}; {extra}".strip(" ;")
+                    )
 
             metadata = metadata.replace(meta_line, "\n".join(reqs))
 


### PR DESCRIPTION
The `requires_file` and `extra_requires_files` attributes added by https://github.com/bazelbuild/rules_python/pull/1710 break wheels by leaving trailing `;` and currently do not support `requirements.in` files with comments following a constraint on the same line. This PR fixes these issues.