### PR TITLE
chore: add python 3.11.7, 3.12.1 toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ A brief description of the categories of changes:
   the default python version is not selected using
   `common --@rules_python//python/config_settings:python_version=X.Y.Z`.
 
+* New Python versions available: `3.11.7`, `3.12.1` using
+  https://github.com/indygreg/python-build-standalone/releases/tag/20240107.
+
 ## 0.29.0 - 2024-01-22
 
 [0.29.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.29.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,7 +85,7 @@ load("@rules_python_gazelle_plugin//:deps.bzl", _py_gazelle_deps = "gazelle_deps
 _py_gazelle_deps()
 
 # This interpreter is used for various rules_python dev-time tools
-load("@python//3.11.6:defs.bzl", "interpreter")
+load("@python//3.11.7:defs.bzl", "interpreter")
 
 #####################
 # Install twine for our own runfiles wheel publishing.

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -369,6 +369,19 @@ TOOL_VERSIONS = {
         },
         "strip_prefix": "python",
     },
+    "3.12.1": {
+        "url": "20240107/cpython-{python_version}+20240107-{platform}-{build}.tar.gz",
+        "sha256": {
+            "aarch64-apple-darwin": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af",
+            "aarch64-unknown-linux-gnu": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
+            "ppc64le-unknown-linux-gnu": "78051f0d1411ee62bc2af5edfccf6e8400ac4ef82887a2affc19a7ace6a05267",
+            "s390x-unknown-linux-gnu": "60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2",
+            "x86_64-apple-darwin": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8",
+            "x86_64-pc-windows-msvc": "fd5a9e0f41959d0341246d3643f2b8794f638adc0cec8dd5e1b6465198eae08a",
+            "x86_64-unknown-linux-gnu": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
+        },
+        "strip_prefix": "python",
+    },
 }
 
 # buildifier: disable=unsorted-dict-items
@@ -377,7 +390,7 @@ MINOR_MAPPING = {
     "3.9": "3.9.18",
     "3.10": "3.10.13",
     "3.11": "3.11.6",
-    "3.12": "3.12.0",
+    "3.12": "3.12.1",
 }
 
 PLATFORMS = {
@@ -455,7 +468,7 @@ def get_release_info(platform, python_version, base_url = DEFAULT_RELEASE_BASE_U
 
     Args:
         platform: The platform string for the interpreter
-        python_version: The version of the intterpreter to get
+        python_version: The version of the interpreter to get
         base_url: The URL to prepend to the 'url' attr in the tool_versions dict
         tool_versions: A dict listing the interpreter versions, their SHAs and URL
 

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -356,6 +356,19 @@ TOOL_VERSIONS = {
         },
         "strip_prefix": "python",
     },
+    "3.11.7": {
+        "url": "20240107/cpython-{python_version}+20240107-{platform}-{build}.tar.gz",
+        "sha256": {
+            "aarch64-apple-darwin": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883",
+            "aarch64-unknown-linux-gnu": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
+            "ppc64le-unknown-linux-gnu": "b44e1b74afe75c7b19143413632c4386708ae229117f8f950c2094e9681d34c7",
+            "s390x-unknown-linux-gnu": "49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22",
+            "x86_64-apple-darwin": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4",
+            "x86_64-pc-windows-msvc": "67077e6fa918e4f4fd60ba169820b00be7c390c497bf9bc9cab2c255ea8e6f3e",
+            "x86_64-unknown-linux-gnu": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
+        },
+        "strip_prefix": "python",
+    },
     "3.12.0": {
         "url": "20231002/cpython-{python_version}+20231002-{platform}-{build}.tar.gz",
         "sha256": {
@@ -389,7 +402,7 @@ MINOR_MAPPING = {
     "3.8": "3.8.18",
     "3.9": "3.9.18",
     "3.10": "3.10.13",
-    "3.11": "3.11.6",
+    "3.11": "3.11.7",
     "3.12": "3.12.1",
 }
 


### PR DESCRIPTION
Updates versions:
* 3.11.6 -> 3.11.7
* 3.12.0  -> 3.12.1

Adds versions: 3.11.7, 3.12.1
