### PR TITLE
tweak(whl_library): capture arbitrary files as data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ A brief description of the categories of changes:
 * (deps): Bumped bazel_features to 1.9.1 to detect optional support
   non-blocking downloads.
 * (deps): Updated `pip_tools` to >= 7.4.0
+* (whl_library) A new `filegroup` rule named `:data` has been added to
+  `whl_library` which captures any non-source resources emplaced outside of the
+  `site-packages` tree by installing a wheel. For instance this captures `/bin`
+  files such as compiled binaries distributed in wheels along with `/etc` or
+  other data files.
 
 ### Fixed
 

--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -55,6 +55,7 @@ class PipInstallTest(unittest.TestCase):
         self.assertListEqual(
             actual,
             [
+                "bin/s3cmd",
                 "data/share/doc/packages/s3cmd/INSTALL.md",
                 "data/share/doc/packages/s3cmd/LICENSE",
                 "data/share/doc/packages/s3cmd/NEWS",

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -54,14 +54,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "{dist_info_label}",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "{data_label}",
-    srcs = glob(["**/*"],
-                exclude = ["{whl_name}", "site-packages/**"],
-                allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["{whl_name}", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -66,6 +66,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "{whl_name}",
             "site-packages/**",

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -259,7 +259,7 @@ def generate_whl_library_build_bazel(
     """
 
     additional_content = []
-    data = []
+    data = [":data"]
     srcs_exclude = []
     data_exclude = [] + data_exclude
     dependencies = sorted([normalize_name(d) for d in dependencies])

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -64,7 +64,12 @@ filegroup(
     name = "{data_label}",
     srcs = glob(
         ["**/*"],
-        exclude = ["{whl_name}", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "{whl_name}",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -59,7 +59,9 @@ filegroup(
 
 filegroup(
     name = "{data_label}",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(["**/*"],
+                exclude = ["{whl_name}", "site-packages/**"],
+                allow_empty = True),
 )
 
 filegroup(

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -28,12 +28,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "data",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["foo.whl", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -94,12 +101,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "data",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["foo.whl", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -246,12 +260,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "data",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["foo.whl", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -334,12 +355,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "data",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["foo.whl", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -408,12 +436,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(
+        ["site-packages/*.dist-info/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "data",
-    srcs = glob(["data/**"], allow_empty = True),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["foo.whl", "site-packages/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -40,6 +40,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "foo.whl",
             "site-packages/**",
@@ -118,6 +119,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "foo.whl",
             "site-packages/**",
@@ -282,6 +284,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "foo.whl",
             "site-packages/**",
@@ -309,7 +312,7 @@ py_library(
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
-    data = ["file_dest", "exec_dest"] + glob(
+    data = [":data", "file_dest", "exec_dest"] + glob(
         ["site-packages/**/*"],
         exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "data_exclude_all"],
     ),
@@ -382,6 +385,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "foo.whl",
             "site-packages/**",
@@ -468,6 +472,7 @@ filegroup(
         ["**/*"],
         exclude = [
             "WORKSPACE",
+            "REPO.bazel",
             "BUILD.bazel",
             "foo.whl",
             "site-packages/**",

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -67,7 +67,7 @@ py_library(
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
-    data = [] + glob(
+    data = [":data"] + glob(
         ["site-packages/**/*"],
         exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
     ),
@@ -156,7 +156,7 @@ py_library(
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
-    data = [] + glob(
+    data = [":data"] + glob(
         ["site-packages/**/*"],
         exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
     ),
@@ -409,7 +409,7 @@ py_library(
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
-    data = [] + glob(
+    data = [":data"] + glob(
         ["site-packages/**/*"],
         exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
     ),
@@ -501,7 +501,7 @@ py_library(
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
-    data = [] + glob(
+    data = [":data"] + glob(
         ["site-packages/**/*"],
         exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
     ),

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -38,7 +38,12 @@ filegroup(
     name = "data",
     srcs = glob(
         ["**/*"],
-        exclude = ["foo.whl", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "foo.whl",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )
@@ -111,7 +116,12 @@ filegroup(
     name = "data",
     srcs = glob(
         ["**/*"],
-        exclude = ["foo.whl", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "foo.whl",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )
@@ -270,7 +280,12 @@ filegroup(
     name = "data",
     srcs = glob(
         ["**/*"],
-        exclude = ["foo.whl", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "foo.whl",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )
@@ -365,7 +380,12 @@ filegroup(
     name = "data",
     srcs = glob(
         ["**/*"],
-        exclude = ["foo.whl", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "foo.whl",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )
@@ -446,7 +466,12 @@ filegroup(
     name = "data",
     srcs = glob(
         ["**/*"],
-        exclude = ["foo.whl", "site-packages/**"],
+        exclude = [
+            "WORKSPACE",
+            "BUILD.bazel",
+            "foo.whl",
+            "site-packages/**",
+        ],
         allow_empty = True,
     ),
 )


### PR DESCRIPTION
This fixes wheels like ruff which want to emplace `bin/` and other dirs used as library data.