### PR TITLE
fix: handle whitespace in the python file names

### DIFF
--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -257,7 +257,11 @@ def generate_whl_library_build_bazel(
 
     additional_content = []
     data = []
-    srcs_exclude = []
+    srcs_exclude = [
+        # there are sometimes files with whitespace in their names i.e. in `imgaug/augmenters/convolutional (copy).py`
+        # they cannot be imported in any sane way so we exclude them
+        "**/* *",
+    ]
     data_exclude = [] + data_exclude
     dependencies = sorted([normalize_name(d) for d in dependencies])
     dependencies_by_platform = {


### PR DESCRIPTION
This is not a breaking change because previously we just failed at the runfiles with
```
link or target filename contains space on line 9877: '_main/external/rules_python~override~pip~pypi_311_imgaug/site-packages/imgaug/augmenters/arithmetic (copy).py /root/.cache/bazel/_bazel_root/00e0182df830644af7af00c92693c660/external/rules_python~override~pip~pypi_311_imgaug/site-packages/imgaug/augmenters/arithmetic (copy).py'
```

the only sane way to handle names in whitespaces in .py files from whl is to ignore it, so we can as well do this in the core rule itself.