### PR TITLE
fix(PyRuntimeInfo): use builtin PyRuntimeInfo unless pystar is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ A brief description of the categories of changes:
 * (toolchain) Changed the `host_toolchain` to symlink all files to support
   Windows host environments without symlink support.
 
+* (PyRuntimeInfo) Switch back to builtin PyRuntimeInfo for Bazel 6.4 and when pystar
+  is disabled. This (for now) fixes an error about `target ... does not have
+  ... PyRuntimeInfo`. This error is likely to recur in a subsequent release when
+  the rules_python implementation of the rules and providers ("pystar") is
+  enabled -- see associated issue for how to handle this case when it occurs.
+  ([#1732](https://github.com/bazelbuild/rules_python/issues/1732))
+
 ### Added
 
 * (py_wheel) Added `requires_file` and `extra_requires_files` attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,9 @@ A brief description of the categories of changes:
 * (toolchain) Changed the `host_toolchain` to symlink all files to support
   Windows host environments without symlink support.
 
-* (PyRuntimeInfo) Switch back to builtin PyRuntimeInfo for Bazel 6.4 and when pystar
-  is disabled. This (for now) fixes an error about `target ... does not have
-  ... PyRuntimeInfo`. This error is likely to recur in a subsequent release when
-  the rules_python implementation of the rules and providers ("pystar") is
-  enabled -- see associated issue for how to handle this case when it occurs.
+* (PyRuntimeInfo) Switch back to builtin PyRuntimeInfo for Bazel 6.4 and when
+  pystar is disabled. This fixes an error about `target ... does not have ...
+  PyRuntimeInfo`.
   ([#1732](https://github.com/bazelbuild/rules_python/issues/1732))
 
 ### Added

--- a/python/py_runtime_info.bzl
+++ b/python/py_runtime_info.bzl
@@ -14,8 +14,8 @@
 
 """Public entry point for PyRuntimeInfo."""
 
+load("@rules_python_internal//:rules_python_config.bzl", "config")
 load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")
-load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")
 load("//python/private/common:providers.bzl", _starlark_PyRuntimeInfo = "PyRuntimeInfo")
 
-PyRuntimeInfo = _starlark_PyRuntimeInfo if IS_BAZEL_6_OR_HIGHER else BuiltinPyRuntimeInfo
+PyRuntimeInfo = _starlark_PyRuntimeInfo if config.enable_pystar else BuiltinPyRuntimeInfo

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests common to py_binary and py_test (executable rules)."""
 
+load("@rules_python//python:py_runtime_info.bzl", RulesPythonPyRuntimeInfo = "PyRuntimeInfo")
 load("@rules_python_internal//:rules_python_config.bzl", rp_config = "config")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:truth.bzl", "matching")
@@ -20,7 +21,6 @@ load("@rules_testing//lib:util.bzl", rt_util = "util")
 load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", "WINDOWS_ATTR", pt_util = "util")
 load("//tests/support:test_platforms.bzl", "WINDOWS")
-load("@rules_python//python:py_runtime_info.bzl", RulesPythonPyRuntimeInfo = "PyRuntimeInfo")
 
 BuiltinPyRuntimeInfo = PyRuntimeInfo
 
@@ -229,7 +229,6 @@ def _test_explicit_main_cannot_be_ambiguous_impl(env, target):
     )
 
 def _test_files_to_build(name, config):
-    print(config.rule)
     rt_util.helper_target(
         config.rule,
         name = name + "_subject",

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -22,7 +22,7 @@ load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", "WINDOWS_ATTR", pt_util = "util")
 load("//tests/support:test_platforms.bzl", "WINDOWS")
 
-BuiltinPyRuntimeInfo = PyRuntimeInfo
+_BuiltinPyRuntimeInfo = PyRuntimeInfo
 
 _tests = []
 
@@ -296,9 +296,10 @@ def _test_py_runtime_info_provided_impl(env, target):
 
     # For compatibility during the transition, the builtin PyRuntimeInfo should
     # also be provided.
-    env.expect.that_target(target).has_provider(BuiltinPyRuntimeInfo)
+    env.expect.that_target(target).has_provider(_BuiltinPyRuntimeInfo)
 
 _tests.append(_test_py_runtime_info_provided)
+
 # Can't test this -- mandatory validation happens before analysis test
 # can intercept it
 # TODO(#1069): Once re-implemented in Starlark, modify rule logic to make this


### PR DESCRIPTION
This fixes the bug where the PyRuntimeInfo symbol rules_python exported wasn't matching the provider identity that `py_binary` actually provided.

The basic problem was, when pystar is disabled:
 * PyRuntimeInfo is the rules_python defined provider
 * py_binary is `native.py_binary`, which provides only the builtin PyRuntimeInfo provider.

Thus, when users loaded the rules_python PyRuntimeInfo symbol, it was referring to a provider that the underlying py_binary didn't actually provide. Pystar is always disabled on Bazel 6.4,
and enabling it for Bazel 7 will happen eminently.

This typically showed up when users had a custom rule with an attribute definition that used the rules_python PyRuntimeInfo.

To fix, only use the rules_python define PyRuntimeInfo if pystar is enabled. This ensures the providers the underlying rules are providing match the symbols that rules_python is exported.

* Also fixes `py_binary` and `py_test` to also return the builtin PyRuntimeInfo. This
  should make the transition from the builtin symbols to the rules_python symbols a bit
  easier.

Fixes https://github.com/bazelbuild/rules_python/issues/1732