### PR TITLE
tests(cclibs): Basic test that the `current_py_cc_libs` target works

### DIFF
--- a/tests/cc/current_py_cc_libs/BUILD.bazel
+++ b/tests/cc/current_py_cc_libs/BUILD.bazel
@@ -15,3 +15,12 @@
 load(":current_py_cc_libs_tests.bzl", "current_py_cc_libs_test_suite")
 
 current_py_cc_libs_test_suite(name = "current_py_cc_libs_tests")
+
+cc_test(
+    name = "python_libs_linking_test",
+    srcs = ["python_libs_linking_test.cc"],
+    deps = [
+        "@rules_python//python/cc:current_py_cc_headers",
+        "@rules_python//python/cc:current_py_cc_libs",
+    ],
+)

--- a/tests/cc/current_py_cc_libs/BUILD.bazel
+++ b/tests/cc/current_py_cc_libs/BUILD.bazel
@@ -16,9 +16,13 @@ load(":current_py_cc_libs_tests.bzl", "current_py_cc_libs_test_suite")
 
 current_py_cc_libs_test_suite(name = "current_py_cc_libs_tests")
 
+# buildifier: disable=native-cc
 cc_test(
     name = "python_libs_linking_test",
     srcs = ["python_libs_linking_test.cc"],
+    target_compatible_with = [
+        "@platforms/os:linux",
+    ],
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",
         "@rules_python//python/cc:current_py_cc_libs",

--- a/tests/cc/current_py_cc_libs/BUILD.bazel
+++ b/tests/cc/current_py_cc_libs/BUILD.bazel
@@ -20,8 +20,11 @@ current_py_cc_libs_test_suite(name = "current_py_cc_libs_tests")
 cc_test(
     name = "python_libs_linking_test",
     srcs = ["python_libs_linking_test.cc"],
+    # Mac and Windows fail with linking errors, but its not clear why; someone
+    # with more C + Mac/Windows experience will have to figure it out.
+    # - rickeylev@
     target_compatible_with = [
-        "@platforms/os:linux",
+        "@platforms//os:linux",
     ],
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",

--- a/tests/cc/current_py_cc_libs/python_libs_linking_test.cc
+++ b/tests/cc/current_py_cc_libs/python_libs_linking_test.cc
@@ -1,0 +1,18 @@
+#include <Python.h>
+
+int main(int argc, char** argv) {
+  // Early return to prevent the broken code below from running.
+  if (argc >= 1) {
+    return 0;
+  }
+
+  // The below code won't actually run. We just reference some Python
+  // symbols so the compiler and linker do some work to verify they are
+  // able to resolve the symbols.
+  // To make it actually run, more custom initialization is necessary.
+  // See https://docs.python.org/3/c-api/intro.html#embedding-python
+  Py_Initialize();
+  PyRun_SimpleString("print('Hello, world')\n");
+  Py_Finalize();
+  return 0;
+}


### PR DESCRIPTION
This is just a basic to to ensure the
`@rules_python//python/cc:current_py_cc_libs` target is making the Python C libraries available; that the compiler and linker are both happy enough to resolve symbols.

The test program itself isn't actually runnable, as that requires more configuration than I can figure out in telling Python where its embedded runtime information is.

Fow now, the test is restricted to Linux. The Mac and Windows CC building isn't happy with it, but I'm out of my depth about how to make those happy.

Work towards https://github.com/bazelbuild/rules_python/issues/824