### PR TITLE
tests(bcr): Set Bazel version in BCR presubmit config.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -16,9 +16,11 @@ bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//..."


### PR DESCRIPTION
BCR now requires the presubmit configs to specify the Bazel versions to run tests with. Without this, the BCR checks fail and we can't do releases to BCR.