### PR TITLE
test(bzlmod): make the check for hub repo naming less strict

### DIFF
--- a/examples/bzlmod/libs/my_lib/__init__.py
+++ b/examples/bzlmod/libs/my_lib/__init__.py
@@ -17,6 +17,6 @@ import websockets
 
 def websockets_is_for_python_version(sanitized_version_check):
     # We are checking that the name of the repository folders
-    # match the expexted generated names. If we update the folder
-    # structure or naming we will need to modify this test
-    return f"pip_{sanitized_version_check}_websockets" in websockets.__file__
+    # match the expected generated names. If we update the folder
+    # structure or naming we will need to modify this test.
+    return f"_{sanitized_version_check}_websockets" in websockets.__file__


### PR DESCRIPTION
When adding a whl-only hub that gets selected for a particular
platform only, this check needed to be adjusted (as seen in #1744).
