### PR TITLE
fix: remove 'site-packages' from install dir prefix

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -81,7 +81,7 @@ pip.whl_mods(
         "@@//whl_mods:data/copy_file.txt": "copied_content/file.txt",
     },
     data = [":generated_file"],
-    data_exclude_glob = ["site-packages/*.dist-info/WHEEL"],
+    data_exclude_glob = ["*.dist-info/WHEEL"],
     hub_name = "whl_mods_hub",
     whl_name = "wheel",
 )

--- a/examples/bzlmod/whl_mods/pip_whl_mods_test.py
+++ b/examples/bzlmod/whl_mods/pip_whl_mods_test.py
@@ -98,7 +98,7 @@ class PipWhlModsTest(unittest.TestCase):
         current_wheel_version = "0.40.0"
 
         r = runfiles.Create()
-        dist_info_dir = "{}/site-packages/wheel-{}.dist-info".format(
+        dist_info_dir = "{}/wheel-{}.dist-info".format(
             self._wheel_pkg_dir,
             current_wheel_version,
         )
@@ -135,7 +135,7 @@ class PipWhlModsTest(unittest.TestCase):
 
         # This test verifies that the patches are applied to the wheel.
         r = runfiles.Create()
-        metadata_path = "{}/site-packages/requests-{}.dist-info/METADATA".format(
+        metadata_path = "{}/requests-{}.dist-info/METADATA".format(
             self._requests_pkg_dir,
             current_wheel_version,
         )

--- a/examples/pip_parse/pip_parse_test.py
+++ b/examples/pip_parse/pip_parse_test.py
@@ -73,12 +73,12 @@ class PipInstallTest(unittest.TestCase):
         self.assertListEqual(
             actual,
             [
-                "site-packages/requests-2.25.1.dist-info/INSTALLER",
-                "site-packages/requests-2.25.1.dist-info/LICENSE",
-                "site-packages/requests-2.25.1.dist-info/METADATA",
-                "site-packages/requests-2.25.1.dist-info/RECORD",
-                "site-packages/requests-2.25.1.dist-info/WHEEL",
-                "site-packages/requests-2.25.1.dist-info/top_level.txt",
+                "requests-2.25.1.dist-info/INSTALLER",
+                "requests-2.25.1.dist-info/LICENSE",
+                "requests-2.25.1.dist-info/METADATA",
+                "requests-2.25.1.dist-info/RECORD",
+                "requests-2.25.1.dist-info/WHEEL",
+                "requests-2.25.1.dist-info/top_level.txt",
             ],
         )
 

--- a/examples/pip_repository_annotations/WORKSPACE
+++ b/examples/pip_repository_annotations/WORKSPACE
@@ -45,7 +45,7 @@ write_file(
         copy_executables = {"@pip_repository_annotations_example//:data/copy_executable.py": "copied_content/executable.py"},
         copy_files = {"@pip_repository_annotations_example//:data/copy_file.txt": "copied_content/file.txt"},
         data = [":generated_file"],
-        data_exclude_glob = ["site-packages/*.dist-info/WHEEL"],
+        data_exclude_glob = ["*.dist-info/WHEEL"],
     ),
 }
 

--- a/examples/pip_repository_annotations/pip_repository_annotations_test.py
+++ b/examples/pip_repository_annotations/pip_repository_annotations_test.py
@@ -82,7 +82,7 @@ class PipRepositoryAnnotationsTest(unittest.TestCase):
         current_wheel_version = "0.38.4"
 
         r = runfiles.Create()
-        dist_info_dir = "pip_repository_annotations_example/external/{}/site-packages/wheel-{}.dist-info".format(
+        dist_info_dir = "pip_repository_annotations_example/external/{}/wheel-{}.dist-info".format(
             self.wheel_pkg_dir(),
             current_wheel_version,
         )

--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -54,7 +54,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "{dist_info_label}",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -72,19 +72,19 @@ filegroup(
 py_library(
     name = "{py_library_impl_label}",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude={srcs_exclude},
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = {data} + glob(
-        ["site-packages/**/*"],
+        ["**/*"],
         exclude={data_exclude},
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = {dependencies},
     tags = {tags},
     visibility = {impl_vis},
@@ -299,6 +299,12 @@ def generate_whl_library_build_bazel(
         # of generated files produced when wheels are installed. The file is ignored to avoid
         # Bazel caching issues.
         "**/*.dist-info/RECORD",
+        "*.whl",
+        "**/__pycache__/**",
+        "bin/**/*",
+        "BUILD.bazel",
+        "WORKSPACE",
+        "{}*.py".format(WHEEL_ENTRY_POINT_PREFIX),
     ]
     for item in data_exclude:
         if item not in _data_exclude:

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -600,8 +600,8 @@ class Wheel:
 
     def unzip(self, directory: str) -> None:
         installation_schemes = {
-            "purelib": "/site-packages",
-            "platlib": "/site-packages",
+            "purelib": "/",
+            "platlib": "/",
             "headers": "/include",
             "scripts": "/bin",
             "data": "/data",

--- a/python/pip_install/tools/wheel_installer/wheel_installer_test.py
+++ b/python/pip_install/tools/wheel_installer/wheel_installer_test.py
@@ -58,7 +58,7 @@ class TestRequirementExtrasParsing(unittest.TestCase):
 class TestWhlFilegroup(unittest.TestCase):
     def setUp(self) -> None:
         self.wheel_name = "example_minimal_package-0.0.1-py3-none-any.whl"
-        self.wheel_dir = tempfile.mkdtemp()
+        self.wheel_dir = tempfile.mkdtemp(prefix=os.environ.get("TEST_TMPDIR"))
         self.wheel_path = os.path.join(self.wheel_dir, self.wheel_name)
         shutil.copy(os.path.join("examples", "wheel", self.wheel_name), self.wheel_dir)
 
@@ -75,9 +75,10 @@ class TestWhlFilegroup(unittest.TestCase):
         )
 
         want_files = [
-            "metadata.json",
-            "site-packages",
             self.wheel_name,
+            'example_minimal_package-0.0.1.dist-info',
+            "examples",
+            "metadata.json",
         ]
         self.assertEqual(
             sorted(want_files),

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -28,7 +28,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -49,19 +49,19 @@ filegroup(
 py_library(
     name = "_pkg",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude=[],
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = [] + glob(
-        ["site-packages/**/*"],
-        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
+        ["**/*"],
+        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "*.whl", "**/__pycache__/**", "bin/**/*", "BUILD.bazel", "WORKSPACE", "rules_python_wheel_entry_point*.py"],
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = [
         "@pypi_bar_baz//:pkg",
         "@pypi_foo//:pkg",
@@ -104,7 +104,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -136,19 +136,19 @@ filegroup(
 py_library(
     name = "_pkg",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude=[],
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = [] + glob(
-        ["site-packages/**/*"],
-        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
+        ["**/*"],
+        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "*.whl", "**/__pycache__/**", "bin/**/*", "BUILD.bazel", "WORKSPACE", "rules_python_wheel_entry_point*.py"],
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = [
         "@pypi_bar_baz//:pkg",
         "@pypi_foo//:pkg",
@@ -266,7 +266,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -287,19 +287,19 @@ filegroup(
 py_library(
     name = "_pkg",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude=["srcs_exclude_all"],
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = ["file_dest", "exec_dest"] + glob(
-        ["site-packages/**/*"],
-        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "data_exclude_all"],
+        ["**/*"],
+        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "*.whl", "**/__pycache__/**", "bin/**/*", "BUILD.bazel", "WORKSPACE", "rules_python_wheel_entry_point*.py", "data_exclude_all"],
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = [
         "@pypi_bar_baz//:pkg",
         "@pypi_foo//:pkg",
@@ -364,7 +364,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -385,19 +385,19 @@ filegroup(
 py_library(
     name = "_pkg",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude=[],
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = [] + glob(
-        ["site-packages/**/*"],
-        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
+        ["**/*"],
+        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "*.whl", "**/__pycache__/**", "bin/**/*", "BUILD.bazel", "WORKSPACE", "rules_python_wheel_entry_point*.py"],
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = [
         "@pypi_bar_baz//:pkg",
         "@pypi_foo//:pkg",
@@ -448,7 +448,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dist_info",
-    srcs = glob(["site-packages/*.dist-info/**"], allow_empty = True),
+    srcs = glob(["*.dist-info/**"], allow_empty = True),
 )
 
 filegroup(
@@ -475,19 +475,19 @@ filegroup(
 py_library(
     name = "_pkg",
     srcs = glob(
-        ["site-packages/**/*.py"],
+        ["**/*.py"],
         exclude=[],
         # Empty sources are allowed to support wheels that don't have any
         # pure-Python code, e.g. pymssql, which is written in Cython.
         allow_empty = True,
     ),
     data = [] + glob(
-        ["site-packages/**/*"],
-        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD"],
+        ["**/*"],
+        exclude=["**/* *", "**/*.py", "**/*.pyc", "**/*.pyc.*", "**/*.dist-info/RECORD", "*.whl", "**/__pycache__/**", "bin/**/*", "BUILD.bazel", "WORKSPACE", "rules_python_wheel_entry_point*.py"],
     ),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.
-    imports = ["site-packages"],
+    imports = ["."],
     deps = ["@pypi_bar_baz//:pkg"] + select(
         {
             "@platforms//os:linux": ["@pypi_box//:pkg"],


### PR DESCRIPTION
Removes the `site-packages` path segment in unpacked external dependency installs.

This additional path segment causes issues when dealing with very large dependency trees, so much so that the value of `PYTHONPATH` exceeds the OS limit of what can be set. 

This manifests due to the Python binary launcher adding workspace roots automatically to sys path, in addition to the `site-packages` segmented path, ie the `PYTHONPATH` var will end up with both (from printing the `PYTHONPATH` in `examples/pip_parse` in rules_python.

Before:
```
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_certifi/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_chardet/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_idna/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_urllib3/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_requests/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_alabaster/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_babel/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_docutils/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_imagesize/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_zipp/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_importlib_metadata/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_markupsafe/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_jinja2/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_packaging/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_pygments/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_snowballstemmer/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_jsmath/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinx/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_serializinghtml/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_qthelp/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_htmlhelp/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_devhelp/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_applehelp/site-packages
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/_main
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_alabaster
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_babel
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_certifi
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_chardet
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_docutils
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_idna
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_imagesize
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_importlib_metadata
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_jinja2
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_markupsafe
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_packaging
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_pygments
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_requests
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_snowballstemmer
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinx
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_applehelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_devhelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_htmlhelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_jsmath
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_qthelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_serializinghtml
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_urllib3
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_zipp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~python~python_3_9_aarch64-apple-darwin
```

After:
```
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_certifi
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_chardet
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_idna
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_urllib3
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_requests
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_alabaster
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_babel
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_docutils
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_imagesize
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_zipp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_importlib_metadata
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_markupsafe
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_jinja2
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_packaging
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_pygments
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_snowballstemmer
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_jsmath
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinx
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_serializinghtml
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_qthelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_htmlhelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_devhelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~pip~pypi_39_sphinxcontrib_applehelp
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/_main
/private/var/tmp/_bazel_matt/3cf6080de036ce65f48725921520350e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/main.runfiles/rules_python~override~python~python_3_9_aarch64-apple-darwin
```

In large graphs, this increase in env var length results in a catastrophic failure:

```
[REDACTED] line 374, in _RunExecv
    os.execv(python_program, [python_program, main_filename] + args)

OSError: [Errno 7] Argument list too long: /[REDACTED]/python3_9_x86_64-unknown-linux-gnu/bin/python3'
```

While this behaviour is possible to toggle via `--experimental_python_import_all_repositories`, there are a large number of dependencies that expect these roots to be available (runfiles for example iirc).