### PR TITLE
docs(getting-started): fix link to python-build-standalone quirks

### DIFF
--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -159,7 +159,7 @@ pip_parse(
 
 After registration, your Python targets will use the toolchain's interpreter during execution, but a system-installed interpreter
 is still used to 'bootstrap' Python targets (see https://github.com/bazelbuild/rules_python/issues/691).
-You may also find some quirks while using this toolchain. Please refer to [python-build-standalone documentation's _Quirks_ section]([https://python-build-standalone.readthedocs.io/en/latest/quirks.html](https://gregoryszorc.com/docs/python-build-standalone/main/quirks.html)).
+You may also find some quirks while using this toolchain. Please refer to [python-build-standalone documentation's _Quirks_ section](https://gregoryszorc.com/docs/python-build-standalone/main/quirks.html).
 
 ## Toolchain usage in other rules
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -159,7 +159,7 @@ pip_parse(
 
 After registration, your Python targets will use the toolchain's interpreter during execution, but a system-installed interpreter
 is still used to 'bootstrap' Python targets (see https://github.com/bazelbuild/rules_python/issues/691).
-You may also find some quirks while using this toolchain. Please refer to [python-build-standalone documentation's _Quirks_ section](https://python-build-standalone.readthedocs.io/en/latest/quirks.html).
+You may also find some quirks while using this toolchain. Please refer to [python-build-standalone documentation's _Quirks_ section]([https://python-build-standalone.readthedocs.io/en/latest/quirks.html](https://gregoryszorc.com/docs/python-build-standalone/main/quirks.html)).
 
 ## Toolchain usage in other rules
 


### PR DESCRIPTION
The `python-build-standalone.readthedocs.io` site seems to be dead.

