### PR TITLE
fix(internal): correctly template error message in repository rules

### DIFF
--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -161,7 +161,7 @@ def _which_checked(rctx, binary_name):
     binary = rctx.which(binary_name)
     if binary == None:
         fail(("Unable to find the binary '{binary_name}' on PATH.\n" +
-              "  PATH = {path}".format(rctx.os.environ.get("PATH"))))
+              "  PATH = {path}".format(path = rctx.os.environ.get("PATH"))))
     return binary
 
 def _args_to_str(arguments):

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -160,8 +160,13 @@ def _which_checked(rctx, binary_name):
     """
     binary = rctx.which(binary_name)
     if binary == None:
-        fail(("Unable to find the binary '{binary_name}' on PATH.\n" +
-              "  PATH = {path}".format(path = rctx.os.environ.get("PATH"))))
+        fail((
+            "Unable to find the binary '{binary_name}' on PATH.\n" +
+            "  PATH = {path}"
+        ).format(
+            binary_name = binary_name,
+            path = rctx.os.environ.get("PATH"),
+        ))
     return binary
 
 def _args_to_str(arguments):


### PR DESCRIPTION
Fixes "Error in format: Missing argument 'path'" error and correctly templates the binary name and `PATH`.

```
(17:54:57) ERROR: /Users/jesses/work/canva/WORKSPACE:120:17: fetching whl_library rule //external:pypi_jsmin: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/rules_python/python/pip_install/pip_repository.bzl", line 783, column 59, in _whl_library_impl
		environment = _create_repository_execution_environment(rctx, python_interpreter)
	File "/private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/rules_python/python/pip_install/pip_repository.bzl", line 257, column 47, in _create_repository_execution_environment
		cppflags.extend(_get_xcode_location_cflags(rctx))
	File "/private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/rules_python/python/pip_install/pip_repository.bzl", line 121, column 46, in _get_xcode_location_cflags
		arguments = [repo_utils.which_checked(rctx, "xcode-select"), "--print-path"],
	File "/private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/rules_python/python/private/repo_utils.bzl", line 164, column 39, in _which_checked
		"  PATH = {path}".format(rctx.os.environ.get("PATH"))))
Error in format: Missing argument 'path'
```
