### PR TITLE
fix: Stop using PYTHONPATH to set up sys.path

### DIFF
--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -168,6 +168,15 @@ Specifies additional environment variables to set when the target is executed by
         # The value is required, but varies by rule and/or rule type. Use
         # create_stamp_attr to create one.
         "stamp": None,
+        "_entrypoint_py_template": attr.label(
+            default = "@rules_python//python/private/common:entrypoint.tmpl.py",
+            allow_single_file = True,
+        ),
+        "_runfiles": attr.label(
+            default = "@rules_python//python/runfiles",
+            providers = [PyInfo],
+        ),
+
     },
     allow_none = True,
 )

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -176,7 +176,6 @@ Specifies additional environment variables to set when the target is executed by
             default = "@rules_python//python/runfiles",
             providers = [PyInfo],
         ),
-
     },
     allow_none = True,
 )

--- a/python/private/common/common.bzl
+++ b/python/private/common/common.bzl
@@ -262,7 +262,11 @@ def filter_to_py_srcs(srcs):
     return [f for f in srcs if f.extension == "py"]
 
 def collect_imports(ctx, semantics):
-    return depset(direct = semantics.get_imports(ctx), transitive = [
+    if hasattr(ctx.attr, "_runfiles"):
+        base = [ctx.attr._runfiles[PyInfo].imports]
+    else:
+        base = []
+    return depset(direct = semantics.get_imports(ctx), transitive = base + [
         dep[PyInfo].imports
         for dep in ctx.attr.deps
         if PyInfo in dep

--- a/python/private/common/common.bzl
+++ b/python/private/common/common.bzl
@@ -263,6 +263,8 @@ def filter_to_py_srcs(srcs):
 
 def collect_imports(ctx, semantics):
     if hasattr(ctx.attr, "_runfiles"):
+        # Executable rules have a private _runfiles attribute so they can pull
+        # in the runfiles library.
         base = [ctx.attr._runfiles[PyInfo].imports]
     else:
         base = []

--- a/python/private/common/entrypoint.tmpl.py
+++ b/python/private/common/entrypoint.tmpl.py
@@ -1,0 +1,21 @@
+import runpy
+import sys
+from pathlib import Path
+
+from python.runfiles import runfiles
+
+RUNFILES = runfiles.Create()
+RUNFILES_DIR = Path(RUNFILES.EnvVars()["RUNFILES_DIR"])
+MAIN = RUNFILES_DIR / "%MAIN_REPO%/%MAIN_SHORT_PATH%"
+
+IMPORTS = %IMPORTS%
+
+# Work around sys.path[0] escaping the sandbox by deleting it.
+# See https://github.com/bazelbuild/rules_python/issues/382 for more info.
+# TODO(phil): How do we distinguish between safe-path Python and non-safe-path
+# Python? I.e. how do we know if sys.path[0] should be deleted or not?
+del sys.path[0]
+
+sys.path[0:0] = [str(RUNFILES_DIR / path) for path in IMPORTS]
+
+runpy.run_path(str(MAIN), run_name="__main__")

--- a/python/private/common/entrypoint.tmpl.py
+++ b/python/private/common/entrypoint.tmpl.py
@@ -2,6 +2,8 @@ import runpy
 import sys
 from pathlib import Path
 
+# TODO(phil): Migrate runfiles detection from
+# python/private/python_bootstrap_template.txt into here.
 from python.runfiles import runfiles
 
 RUNFILES = runfiles.Create()
@@ -10,12 +12,38 @@ MAIN = RUNFILES_DIR / "%MAIN_REPO%/%MAIN_SHORT_PATH%"
 
 IMPORTS = %IMPORTS%
 
+# We add the root of each repository with external Python dependencies to the
+# import search path.
+# Can we get rid of this now that bzlmod mangles the repository names?
+MODULE_IMPORTS = [
+    Path(path).parts[0]
+    for path in IMPORTS
+]
+
+def Deduplicate(items):
+  """Efficiently filter out duplicates, keeping the first element only."""
+  seen = set()
+  for it in items:
+      if it not in seen:
+          seen.add(it)
+          yield it
+
 # Work around sys.path[0] escaping the sandbox by deleting it.
 # See https://github.com/bazelbuild/rules_python/issues/382 for more info.
-# TODO(phil): How do we distinguish between safe-path Python and non-safe-path
-# Python? I.e. how do we know if sys.path[0] should be deleted or not?
-del sys.path[0]
+if getattr(sys.flags, "safe_path", False):
+    # We are running on Python 3.11 and we don't need this workaround
+    pass
+elif ".runfiles" not in sys.path[0]:
+    sys.path = sys.path[1:]
 
-sys.path[0:0] = [str(RUNFILES_DIR / path) for path in IMPORTS]
+sys.path[0:0] = list(Deduplicate([
+    # The top of the runfiles tree always should be first in the search path.
+    # Can we get rid of this now that bzlmod mangles the repository names?
+    str(RUNFILES_DIR),
+] + MODULE_IMPORTS + [
+    # Inject the import paths for all the bazel-managed packages so that they are
+    # searched before standard library paths.
+    str(RUNFILES_DIR / path) for path in IMPORTS
+]))
 
 runpy.run_path(str(MAIN), run_name="__main__")

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -14,7 +14,6 @@
 """Common functionality between test/binary executables."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")
 load(
     ":attributes.bzl",
@@ -148,7 +147,7 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
     direct_sources = filter_to_py_srcs(ctx.files.srcs)
     output_sources = semantics.maybe_precompile(ctx, direct_sources)
     if ctx.attr.incompatible_generate_entrypoint_shim:
-        output_sources += [entrypoint_py]
+        output_sources.append(entrypoint_py)
     imports = collect_imports(ctx, semantics)
     executable, files_to_build = _compute_outputs(ctx, output_sources)
 
@@ -244,10 +243,10 @@ def _generate_entrypoint_py(ctx, imports, main_py, entrypoint_py):
         template = ctx.file._entrypoint_py_template,
         output = entrypoint_py,
         substitutions = {
+            "%IMPORTS%": json.encode_indent(imports.to_list()),
             # Is there a better way to retrieve the name of the main repo?
             "%MAIN_REPO%": ctx.label.workspace_name or ctx.workspace_name,
             "%MAIN_SHORT_PATH%": main_py.short_path,
-            "%IMPORTS%": json.encode_indent(imports.to_list()),
         },
     )
 

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -196,8 +196,6 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
         ] + runfiles_library_dep,
         semantics = semantics,
     )
-    if ctx.attr.incompatible_generate_entrypoint_shim:
-        print("Found incompatible_generate_entrypoint_shim on " + str(ctx.label))
     exec_result = semantics.create_executable(
         ctx,
         executable = executable,

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -305,6 +305,7 @@ def _expand_bootstrap_template(
             "%coverage_tool%": coverage_tool_runfiles_path,
             "%import_all%": "True" if ctx.fragments.bazel_py.python_import_all_repositories else "False",
             "%imports%": ":".join(imports.to_list()),
+            "%incompatible_generate_entrypoint_shim%": str(ctx.attr.incompatible_generate_entrypoint_shim),
             "%is_zipfile%": "True" if is_for_zip else "False",
             "%main%": "{}/{}".format(
                 ctx.workspace_name,

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -464,7 +464,12 @@ def Main():
     module_space = FindModuleSpace(main_rel_path)
     delete_module_space = False
 
-  python_imports = '%imports%'
+  incompatible_generate_entrypoint_shim = %incompatible_generate_entrypoint_shim%
+  if incompatible_generate_entrypoint_shim:
+    python_imports = ''
+  else:
+    python_imports = '%imports%'
+
   python_path_entries = CreatePythonPathEntries(python_imports, module_space)
   python_path_entries += GetRepositoriesImports(module_space, %import_all%)
   # Remove duplicates to avoid overly long PYTHONPATH (#10977). Preserve order,

--- a/tests/pythonpath/BUILD.bazel
+++ b/tests/pythonpath/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//python:py_test.bzl", "py_test")
+
+py_test(
+    name = "pythonpath_test",
+    srcs = ["pythonpath_test.py"],
+    incompatible_generate_entrypoint_shim = True,
+)

--- a/tests/pythonpath/pythonpath_test.py
+++ b/tests/pythonpath/pythonpath_test.py
@@ -1,0 +1,11 @@
+import os
+import unittest
+
+class PythonPathTest(unittest.TestCase):
+
+    def test_environment(self):
+        """Validates that PYTHONPATH is empty."""
+        self.assertFalse(os.environ["PYTHONPATH"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch is an experiment for setting up `sys.path` inside
the final Python process instead of letting the runtime do it
via PYTHONPATH.

The motivation here is to address these 2 issues:
* #382 
* #792 

Try it with:
```
$ bazel run //tools:wheelmaker -- --help
```
Look at the generated files.