### PR TITLE
fix: incorrect abi parsing logic in wheel.py

### DIFF
--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -201,7 +201,7 @@ class Platform:
             os, _, arch = tail.partition("_")
             arch = arch or "*"
 
-            minor_version = int(abi[len("cp3") :]) if abi and abi != "none" else None
+            minor_version = int(abi[len("cp3") :]) if abi else None
 
             if arch != "*":
                 ret.add(

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -190,7 +190,11 @@ class Platform:
                 continue
 
             abi, _, tail = p.partition("_")
-            if not abi.startswith("cp"):
+            if abi in ('abi3', 'none'):
+                # PEP 425 and PEP 384
+                abi = None
+
+            if abi and not abi.startswith("cp"):
                 # The first item is not an abi
                 tail = p
                 abi = ""


### PR DESCRIPTION
This PR fixes the incorrect abi parsing logic. Currently, the logic would incorrectly assume the first item is not an abi for packages that do not specify an abi compatibility, e.g. watchdog-4.0.0-py3-none-manylinux2014_aarch64.whl. This would render the os incorrectly parsed, causing total build failures later on.

```
python3 -m python.pip_install.tools.wheel_installer.wheel_installer --requirement "watchdog==4.0.0" --whl-file [REMOVED]/7b77203049f425466cc854899ac39021/external/pip_watchdog/watchdog-4.0.0-py3-none-manylinux2014_aarch64.whl --platform=none_linux_aarch64
<stdout empty>
===== stderr start =====
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "[REMOVED]7b77203049f425466cc854899ac39021/external/rules_python/python/pip_install/tools/wheel_installer/wheel_installer.py", line 205, in <module>
    main()
[REMOVED]
  File "[REMOVED]7b77203049f425466cc854899ac39021/external/rules_python/python/pip_install/tools/wheel_installer/wheel.py", line 205, in from_string
    os=OS[os] if os != "*" else None,
       ~~^^^^
  File
 "[REMOVED]7b77203049f425466cc854899ac39021/external/python311_aarch64-unknown-linux-gnu/lib/python3.11/enum.py", line 790, in __getitem__
    return cls._member_map_[name]
           ~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'none'
```