### PR TITLE
build(internal_deps): Update 'maintained by' comments to be correct

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ internal_deps.install()
 use_repo(
     internal_deps,
     "rules_python_internal",
-    # START: maintained by 'bazel run //tools/private:update_pip_deps'
+    # START: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
     "pypi__build",
     "pypi__click",
     "pypi__colorama",
@@ -33,7 +33,7 @@ use_repo(
     "pypi__tomli",
     "pypi__wheel",
     "pypi__zipp",
-    # END: maintained by 'bazel run //tools/private:update_pip_deps'
+    # END: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
 )
 
 # We need to do another use_extension call to expose the "pythons_hub"

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 _RULE_DEPS = [
-    # START: maintained by 'bazel run //tools/private:update_pip_deps'
+    # START: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
     (
         "pypi__build",
         "https://files.pythonhosted.org/packages/58/91/17b00d5fac63d3dca605f1b8269ba3c65e98059e1fd99d00283e42a454f0/build-0.10.0-py3-none-any.whl",
@@ -94,7 +94,7 @@ _RULE_DEPS = [
         "https://files.pythonhosted.org/packages/8c/08/d3006317aefe25ea79d3b76c9650afabaf6d63d1c8443b236e7405447503/zipp-3.16.2-py3-none-any.whl",
         "679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
     ),
-    # END: maintained by 'bazel run //tools/private:update_pip_deps'
+    # END: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
 ]
 
 _GENERIC_WHEEL = """\

--- a/tools/private/update_deps/update_pip_deps.py
+++ b/tools/private/update_deps/update_pip_deps.py
@@ -111,13 +111,13 @@ def main():
     parser.add_argument(
         "--start",
         type=str,
-        default="# START: maintained by 'bazel run //tools/private:update_pip_deps'",
+        default="# START: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'",
         help="The text to match in a file when updating them.",
     )
     parser.add_argument(
         "--end",
         type=str,
-        default="# END: maintained by 'bazel run //tools/private:update_pip_deps'",
+        default="# END: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'",
         help="The text to match in a file when updating them.",
     )
     parser.add_argument(


### PR DESCRIPTION
This fixes a minor error in the "maintained by" comments in
`./MODULE.bazel` and `./python/pip_install/repositories.bzl`. The
comments now agree with what `DEVELOPING.md` says.