### PR TITLE
docs: Update notice about rctx.getenv on Bazel 7

### DIFF
--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -202,10 +202,9 @@ def _parse_optional_attrs(rctx, args):
     if use_isolated(rctx, rctx.attr):
         args.append("--isolated")
 
-    # At the time of writing, the very latest Bazel, as in `USE_BAZEL_VERSION=last_green bazelisk`
-    # supports rctx.getenv(name, default): When building incrementally, any change to the value of
-    # the variable named by name will cause this repository to be re-fetched. That hasn't yet made
-    # its way into the official releases, though.
+    # Bazel version 7.1.0 and later (and rolling releases from version 8.0.0-pre.20240128.3)
+    # support rctx.getenv(name, default): When building incrementally, any change to the value of
+    # the variable named by name will cause this repository to be re-fetched.
     if "getenv" in dir(rctx):
         getenv = rctx.getenv
     else:
@@ -457,7 +456,7 @@ A list of environment variables to substitute (e.g. `["PIP_INDEX_URL",
 "PIP_RETRIES"]`). The corresponding variables are expanded in `extra_pip_args`
 using the syntax `$VARNAME` or `${VARNAME}` (expanding to empty string if unset)
 or `${VARNAME:-default}` (expanding to default if the variable is unset or empty
-in the environment). Note: On Bazel 6 and Bazel 7 changes to the variables named
+in the environment). Note: On Bazel 6 and Bazel 7.0 changes to the variables named
 here do not cause packages to be re-fetched. Don't fetch different things based
 on the value of these variables.
 """,


### PR DESCRIPTION
Bazel 7.1 has been released, and includes support for `repository_ctx.getenv`. Therefore, update the comments and docs to reflect the current status of the feature with released Bazel versions.