### PR TITLE
 tweak(whl_library): Extend PyWheelInfo provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ A brief description of the categories of changes:
 
 ### Changed
 
+* Add version and distribution fields to `PyWheelInfo` provider
+
 ### Fixed
 
 ### Added

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -21,9 +21,15 @@ load(":py_wheel_normalize_pep440.bzl", "normalize_pep440")
 PyWheelInfo = provider(
     doc = "Information about a wheel produced by `py_wheel`",
     fields = {
+        "distribution": (
+            "Name of the distribution."
+        ),
         "name_file": (
             "File: A file containing the canonical name of the wheel (after " +
             "stamping, if enabled)."
+        ),
+        "version": (
+            "Version number of the package."
         ),
         "wheel": "File: The wheel file itself.",
     },
@@ -489,6 +495,8 @@ def _py_wheel_impl(ctx):
         PyWheelInfo(
             wheel = outfile,
             name_file = name_file,
+            version = version,
+            distribution = ctx.attr.distribution,
         ),
     ]
 


### PR DESCRIPTION
Adds `version` and `distribution` fields to `PyWheelInfo` provider.

Bigger projects (like mine) have rules to generate one file with versions of all subsequent components. I would like to expose needed fields in convenient and "bazelish" way.