### PR TITLE
docs: Add some missing attribute docs

### DIFF
--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -93,6 +93,7 @@ filename in `srcs`, `main` must be specified.
             default = "PY3",
             # NOTE: Some tests care about the order of these values.
             values = ["PY2", "PY3"],
+            doc = "Defunct, unused, does nothing.",
         ),
         "_windows_constraints": attr.label_list(
             default = [


### PR DESCRIPTION
Adds docs for: stamp, srcs, deps, srcs_version, data, and python_version