### PR TITLE
cleanup: Remove uses of legacy struct providers

### DIFF
--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -183,7 +183,7 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
         data_runfiles = runfiles_details.data_runfiles.merge(extra_exec_runfiles),
     )
 
-    legacy_providers, modern_providers = _create_providers(
+    return _create_providers(
         ctx = ctx,
         executable = executable,
         runfiles_details = runfiles_details,
@@ -196,10 +196,6 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
         inherited_environment = inherited_environment,
         semantics = semantics,
         output_groups = exec_result.output_groups,
-    )
-    return struct(
-        legacy_providers = legacy_providers,
-        providers = modern_providers,
     )
 
 def _get_build_info(ctx, cc_toolchain):
@@ -749,9 +745,7 @@ def _create_providers(
         semantics: BinarySemantics struct; see create_binary_semantics()
 
     Returns:
-        A two-tuple of:
-        1. A dict of legacy providers.
-        2. A list of modern providers.
+        A list of modern providers.
     """
     providers = [
         DefaultInfo(
@@ -821,13 +815,13 @@ def _create_providers(
     providers.append(builtin_py_info)
     providers.append(create_output_group_info(py_info.transitive_sources, output_groups))
 
-    extra_legacy_providers, extra_providers = semantics.get_extra_providers(
+    extra_providers = semantics.get_extra_providers(
         ctx,
         main_py = main_py,
         runtime_details = runtime_details,
     )
     providers.extend(extra_providers)
-    return extra_legacy_providers, providers
+    return providers
 
 def _create_run_environment_info(ctx, inherited_environment):
     expanded_env = {}

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -99,15 +99,11 @@ def create_executable_rule(*, attrs, **kwargs):
 
 def py_executable_bazel_impl(ctx, *, is_test, inherited_environment):
     """Common code for executables for Bazel."""
-    result = py_executable_base_impl(
+    return py_executable_base_impl(
         ctx = ctx,
         semantics = create_binary_semantics_bazel(),
         is_test = is_test,
         inherited_environment = inherited_environment,
-    )
-    return struct(
-        providers = result.providers,
-        **result.legacy_providers
     )
 
 def create_binary_semantics_bazel():
@@ -143,7 +139,7 @@ def _get_debugger_deps(ctx, runtime_details):
 
 def _get_extra_providers(ctx, main_py, runtime_details):
     _ = ctx, main_py, runtime_details  # @unused
-    return {}, []
+    return []
 
 def _get_stamp_flag(ctx):
     # NOTE: Undocumented API; private to builtins

--- a/python/private/common/py_test_rule_bazel.bzl
+++ b/python/private/common/py_test_rule_bazel.bzl
@@ -45,7 +45,7 @@ def _py_test_impl(ctx):
         is_test = True,
         inherited_environment = ctx.attr.env_inherit,
     )
-    maybe_add_test_execution_info(providers.providers, ctx)
+    maybe_add_test_execution_info(providers, ctx)
     return providers
 
 py_test = create_executable_rule(


### PR DESCRIPTION
The code still supported legacy struct providers, although none were generated or used.