### PR TITLE
feat: Make Sphinx integration experimental publicly visible

### DIFF
--- a/sphinxdocs/private/BUILD.bazel
+++ b/sphinxdocs/private/BUILD.bazel
@@ -34,7 +34,7 @@ exports_files(
         "sphinx_build.py",
         "sphinx_server.py",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(
@@ -70,14 +70,14 @@ py_binary(
     name = "inventory_builder",
     srcs = ["inventory_builder.py"],
     # Only public because it's an implicit attribute
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(
     name = "proto_to_markdown",
     srcs = ["proto_to_markdown.py"],
     # Only public because it's an implicit attribute
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":proto_to_markdown_lib"],
 )
 
@@ -85,7 +85,7 @@ py_library(
     name = "proto_to_markdown_lib",
     srcs = ["proto_to_markdown.py"],
     # Only public because it's an implicit attribute
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":stardoc_output_proto_py_pb2",
     ],

--- a/sphinxdocs/sphinx.bzl
+++ b/sphinxdocs/sphinx.bzl
@@ -23,6 +23,8 @@ The general usage of the Sphinx rules requires two pieces:
 
 Defining your own `sphinx-build` binary is necessary because Sphinx uses
 a plugin model to support extensibility.
+
+The Sphinx integration is still experimental.
 """
 
 load(


### PR DESCRIPTION
With this commit the visibility settings are adjusted to use the Sphinx Integration from rules_python also in other (dependent) projects.

Since the Sphinx integration is not yet stable, we denote in the documentation that this is done under the experimental API support. Meaning, breaking changes can occure at any point in time.

See the discussion in #1796
