### PR TITLE
fix(whl_library): only add group machinery when it is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ A brief description of the categories of changes:
 * (gazelle) In `project` or `package` generation modes, do not generate `py_test`
   rules when there are no test files and do not set `main = "__test__.py"` when
   that file doesn't exist.
+* (whl_library) The group redirection is only added when the package is part of
+  the group potentially fixing aspects that want to traverse a `py_library` graph.
+  Fixes [#1760](https://github.com/bazelbuild/rules_python/issues/1760).
 
 ### Added
 

--- a/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
+++ b/tests/pip_install/whl_library/generate_build_bazel_tests.bzl
@@ -37,17 +37,17 @@ filegroup(
 )
 
 filegroup(
-    name = "_whl",
+    name = "whl",
     srcs = ["foo.whl"],
     data = [
         "@pypi_bar_baz//:whl",
         "@pypi_foo//:whl",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
-    name = "_pkg",
+    name = "pkg",
     srcs = glob(
         ["site-packages/**/*.py"],
         exclude=[],
@@ -67,17 +67,7 @@ py_library(
         "@pypi_foo//:pkg",
     ],
     tags = ["tag1", "tag2"],
-    visibility = ["//visibility:private"],
-)
-
-alias(
-   name = "pkg",
-   actual = "_pkg",
-)
-
-alias(
-   name = "whl",
-   actual = "_whl",
+    visibility = ["//visibility:public"],
 )
 """
     actual = generate_whl_library_build_bazel(
@@ -113,7 +103,7 @@ filegroup(
 )
 
 filegroup(
-    name = "_whl",
+    name = "whl",
     srcs = ["foo.whl"],
     data = [
         "@pypi_bar_baz//:whl",
@@ -130,11 +120,11 @@ filegroup(
             "//conditions:default": [],
         },
     ),
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
-    name = "_pkg",
+    name = "pkg",
     srcs = glob(
         ["site-packages/**/*.py"],
         exclude=[],
@@ -165,17 +155,7 @@ py_library(
         },
     ),
     tags = ["tag1", "tag2"],
-    visibility = ["//visibility:private"],
-)
-
-alias(
-   name = "pkg",
-   actual = "_pkg",
-)
-
-alias(
-   name = "whl",
-   actual = "_whl",
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -275,17 +255,17 @@ filegroup(
 )
 
 filegroup(
-    name = "_whl",
+    name = "whl",
     srcs = ["foo.whl"],
     data = [
         "@pypi_bar_baz//:whl",
         "@pypi_foo//:whl",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
-    name = "_pkg",
+    name = "pkg",
     srcs = glob(
         ["site-packages/**/*.py"],
         exclude=["srcs_exclude_all"],
@@ -305,17 +285,7 @@ py_library(
         "@pypi_foo//:pkg",
     ],
     tags = ["tag1", "tag2"],
-    visibility = ["//visibility:private"],
-)
-
-alias(
-   name = "pkg",
-   actual = "_pkg",
-)
-
-alias(
-   name = "whl",
-   actual = "_whl",
+    visibility = ["//visibility:public"],
 )
 
 copy_file(
@@ -373,17 +343,17 @@ filegroup(
 )
 
 filegroup(
-    name = "_whl",
+    name = "whl",
     srcs = ["foo.whl"],
     data = [
         "@pypi_bar_baz//:whl",
         "@pypi_foo//:whl",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
-    name = "_pkg",
+    name = "pkg",
     srcs = glob(
         ["site-packages/**/*.py"],
         exclude=[],
@@ -403,17 +373,7 @@ py_library(
         "@pypi_foo//:pkg",
     ],
     tags = ["tag1", "tag2"],
-    visibility = ["//visibility:private"],
-)
-
-alias(
-   name = "pkg",
-   actual = "_pkg",
-)
-
-alias(
-   name = "whl",
-   actual = "_whl",
+    visibility = ["//visibility:public"],
 )
 
 py_binary(
@@ -502,16 +462,6 @@ py_library(
     visibility = ["@pypi__groups//:__pkg__"],
 )
 
-alias(
-   name = "pkg",
-   actual = "@pypi__groups//:qux_pkg",
-)
-
-alias(
-   name = "whl",
-   actual = "@pypi__groups//:qux_whl",
-)
-
 config_setting(
     name = "is_linux_x86_64",
     constraint_values = [
@@ -519,6 +469,16 @@ config_setting(
         "@platforms//os:linux",
     ],
     visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "pkg",
+    actual = "@pypi__groups//:qux_pkg",
+)
+
+alias(
+    name = "whl",
+    actual = "@pypi__groups//:qux_whl",
 )
 """
     actual = generate_whl_library_build_bazel(


### PR DESCRIPTION
This removes the `alias` additions when the package groups are not used
fixing alias that attempt to traverse the entire py_library dependency
tree.

I noticed that for some code that I want to write for `whl_library`
having it explicit whether we are using groups or not in the `pip.parse`
and or `whl_library` makes the code easier to understand and write.

Fixes #1760
