### PR TITLE
fix: Upgrade protobuf from 21.7 to 23.1/24.4

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -402,11 +402,12 @@ tasks:
     working_directory: examples/py_proto_library
     platform: macos
   integration_test_py_proto_library_windows_workspace:
-    <<: *reusable_build_test_all
     <<: *common_workspace_flags
     name: "examples/py_proto_library: Windows, workspace"
     working_directory: examples/py_proto_library
     platform: windows
+    build_targets: ["//..."] # Building everything triggers problems in protobuf
+    test_targets: ["//..."]
 
   integration_test_pip_repository_annotations_ubuntu_workspace:
     <<: *reusable_build_test_all

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
 
 internal_deps = use_extension("//python/private/bzlmod:internal_deps.bzl", "internal_deps")
 internal_deps.install()

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 
 # (py_proto_library specific) Add the protobuf library for well-known types (e.g. `Any`, `Timestamp`, etc)
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
 
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -33,10 +33,10 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
-    strip_prefix = "protobuf-24.4",
+    sha256 = "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
+    strip_prefix = "protobuf-25.3",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v24.4.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v25.3.tar.gz",
     ],
 )
 

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -33,10 +33,10 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
-    strip_prefix = "protobuf-25.3",
+    sha256 = "4fc5ff1b2c339fb86cd3a25f0b5311478ab081e65ad258c6789359cd84d421f8",
+    strip_prefix = "protobuf-26.1",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v25.3.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v26.1.tar.gz",
     ],
 )
 

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -40,6 +40,10 @@ http_archive(
     ],
 )
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 rules_proto_dependencies()

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -33,11 +33,10 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
+    sha256 = "dc167b7d23ec0d6e4a3d4eae1798de6c8d162e69fa136d39753aaeb7a6e1289d",
+    strip_prefix = "protobuf-23.1",
     urls = [
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v23.1.tar.gz",
     ],
 )
 

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -33,10 +33,10 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "dc167b7d23ec0d6e4a3d4eae1798de6c8d162e69fa136d39753aaeb7a6e1289d",
-    strip_prefix = "protobuf-23.1",
+    sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
+    strip_prefix = "protobuf-24.4",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v23.1.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v24.4.tar.gz",
     ],
 )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -184,11 +184,10 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-        strip_prefix = "protobuf-21.7",
+        sha256 = "dc167b7d23ec0d6e4a3d4eae1798de6c8d162e69fa136d39753aaeb7a6e1289d",
+        strip_prefix = "protobuf-23.1",
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v23.1.tar.gz",
         ],
     )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -184,10 +184,10 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "dc167b7d23ec0d6e4a3d4eae1798de6c8d162e69fa136d39753aaeb7a6e1289d",
-        strip_prefix = "protobuf-23.1",
+        sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
+        strip_prefix = "protobuf-24.4",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v23.1.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v24.4.tar.gz",
         ],
     )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -184,10 +184,10 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
-        strip_prefix = "protobuf-24.4",
+        sha256 = "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
+        strip_prefix = "protobuf-25.3",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v24.4.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v25.3.tar.gz",
         ],
     )
 


### PR DESCRIPTION
The older protobuf version (21.7) is still using legacy struct providers. If used rules_python will fail after the default of --incompatible_disallow_struct_provider_syntax is changed.

Only 23.1 is on BCR (that's why using this version in MODULE.bazel).
Unpatched 23.1 fails with `no such attribute 'exec_tools' in 'genrule' rule`.
Protobuf v24.4 and 25.3. fails on Windows.
That's why using 26.1

Issue: https://github.com/bazelbuild/bazel/issues/19467