### PR TITLE
fix(gazelle): Consistent substitution pattern for python_default_visibility directive

### DIFF
--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -199,7 +199,7 @@ Python-specific directives are as follows:
 | `# gazelle:resolve py ...` | n/a |
 | Instructs the plugin what target to add as a dependency to satisfy a given import statement. The syntax is `# gazelle:resolve py import-string label` where `import-string` is the symbol in the python `import` statement, and `label` is the Bazel label that Gazelle should write in `deps`. | |
 | [`# gazelle:python_default_visibility labels`](#directive-python_default_visibility) | |
-| Instructs gazelle to use these visibility labels on all python targets. `labels` is a comma-separated list of labels (without spaces). | `//$python_root:__subpackages__` |
+| Instructs gazelle to use these visibility labels on all python targets. `labels` is a comma-separated list of labels (without spaces). | `//$python_root$:__subpackages__` |
 | [`# gazelle:python_visibility label`](#directive-python_visibility) | |
 | Appends additional visibility labels to each generated target. This directive can be set multiple times. | |
 | [`# gazelle:python_test_file_pattern`](#directive-python_test_file_pattern) | `*_test.py,test_*.py` |
@@ -268,11 +268,11 @@ py_library(
 ```
 
 You can also inject the `python_root` value by using the exact string
-`$python_root`. All instances of this string will be replaced by the `python_root`
+`$python_root$`. All instances of this string will be replaced by the `python_root`
 value.
 
 ```starlark
-# gazelle:python_default_visibility //$python_root:__pkg__,//foo/$python_root/tests:__subpackages__
+# gazelle:python_default_visibility //$python_root$:__pkg__,//foo/$python_root$/tests:__subpackages__
 
 # Assuming the "# gazelle:python_root" directive is set in ./py/src/BUILD.bazel,
 # the results will be:

--- a/gazelle/python/configure.go
+++ b/gazelle/python/configure.go
@@ -177,8 +177,8 @@ func (py *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 				config.SetDefaultVisibility([]string{defaultVisibility})
 			default:
 				// Handle injecting the python root. Assume that the user used the
-				// exact string "$python_root".
-				labels := strings.ReplaceAll(directiveArg, "$python_root", config.PythonProjectRoot())
+				// exact string "$python_root$".
+				labels := strings.ReplaceAll(directiveArg, "$python_root$", config.PythonProjectRoot())
 				config.SetDefaultVisibility(strings.Split(labels, ","))
 			}
 		case pythonconfig.Visibility:

--- a/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.in
+++ b/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.in
@@ -1,2 +1,2 @@
 # gazelle:python_root
-# gazelle:python_default_visibility //foo/$python_root/bar:__pkg__
+# gazelle:python_default_visibility //foo/$python_root$/bar:__pkg__

--- a/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.out
+++ b/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.out
@@ -1,7 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_library")
 
 # gazelle:python_root
-# gazelle:python_default_visibility //foo/$python_root/bar:__pkg__
+# gazelle:python_default_visibility //foo/$python_root$/bar:__pkg__
 
 py_library(
     name = "test3_injection",

--- a/gazelle/python/testdata/directive_python_default_visibility/test8_multiple_python_root_dirs/proj2/src/pkg2/BUILD.in
+++ b/gazelle/python/testdata/directive_python_default_visibility/test8_multiple_python_root_dirs/proj2/src/pkg2/BUILD.in
@@ -1,3 +1,3 @@
 # proj1 depends on proj2
 # So we have to make sure that proj2 is visible by proj1
-# gazelle:python_default_visibility //$python_root:__subpackages__,//test8_multiple_python_root_dirs/proj1/src:__subpackages__
+# gazelle:python_default_visibility //$python_root$:__subpackages__,//test8_multiple_python_root_dirs/proj1/src:__subpackages__

--- a/gazelle/python/testdata/directive_python_default_visibility/test8_multiple_python_root_dirs/proj2/src/pkg2/BUILD.out
+++ b/gazelle/python/testdata/directive_python_default_visibility/test8_multiple_python_root_dirs/proj2/src/pkg2/BUILD.out
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 # proj1 depends on proj2
 # So we have to make sure that proj2 is visible by proj1
-# gazelle:python_default_visibility //$python_root:__subpackages__,//test8_multiple_python_root_dirs/proj1/src:__subpackages__
+# gazelle:python_default_visibility //$python_root$:__subpackages__,//test8_multiple_python_root_dirs/proj1/src:__subpackages__
 
 py_library(
     name = "pkg2",


### PR DESCRIPTION
Make the substitution pattern for `python_default_visibility` consistent
with the existing `python_*_naming_convention` pattern.

In #1787 I added the `python_default_visibility` directive and used a
substitution pattern `$python_root`. However, I missed that the existing
`python_*_naming_convention` directives include a trailing `$`.

This PR is just:
```
rg -l -F "\$python_root" | xargs sed -i 's/\$python_root/$python_root$/g'
```