### PR TITLE
build(deps): Bump pip tools to >= 7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ A brief description of the categories of changes:
   default in order to reduce the size of the lock file.
 * (deps): Bumped bazel_features to 1.9.1 to detect optional support
   non-blocking downloads.
+* (deps): Updated `pip_tools` to >= 7.4.0
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ A brief description of the categories of changes:
 * (bzlmod): The `MODULE.bazel.lock` `whl_library` rule attributes are now
   sorted in the attributes section. We are also removing values that are not
   default in order to reduce the size of the lock file.
+* (coverage) Bump `coverage.py` to [7.4.3](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-743--2024-02-23).
 * (deps): Bumped bazel_features to 1.9.1 to detect optional support
   non-blocking downloads.
 * (deps): Updated `pip_tools` to >= 7.4.0
@@ -74,9 +75,6 @@ A brief description of the categories of changes:
 [test_file_pattern_issue]: https://github.com/bazelbuild/rules_python/issues/1816
 [test_file_pattern_docs]: gazelle/README.md#directive-python_test_file_pattern
 
-### Changed
-
-* (coverage) Bump `coverage.py` to [7.4.3](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-743--2024-02-23).
 
 ## [0.31.0] - 2024-02-12
 

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -21,8 +21,8 @@ _RULE_DEPS = [
     # START: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
     (
         "pypi__build",
-        "https://files.pythonhosted.org/packages/58/91/17b00d5fac63d3dca605f1b8269ba3c65e98059e1fd99d00283e42a454f0/build-0.10.0-py3-none-any.whl",
-        "af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
+        "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+        "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
     ),
     (
         "pypi__click",
@@ -66,8 +66,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__pip_tools",
-        "https://files.pythonhosted.org/packages/e8/df/47e6267c6b5cdae867adbdd84b437393e6202ce4322de0a5e0b92960e1d6/pip_tools-7.3.0-py3-none-any.whl",
-        "8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e",
+        "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+        "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
     ),
     (
         "pypi__pyproject_hooks",

--- a/python/pip_install/tools/requirements.txt
+++ b/python/pip_install/tools/requirements.txt
@@ -7,7 +7,7 @@ more_itertools
 packaging
 pep517
 pip
-pip_tools
+pip_tools >= 7.4.0
 setuptools
 tomli
 wheel


### PR DESCRIPTION
Bump pip_tools to >= 7.4.0 so that we can make use of better
`pyproject.toml` parsing error messages during compiling.

Specifically: https://github.com/jazzband/pip-tools/pull/1979
