### PR TITLE
deps: load cc symbols from @rules_cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ user.bazelrc
 *.swp
 *.swo
 
+# CLion
+.clwb
+
 # Python cache
 **/__pycache__/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ A brief description of the categories of changes:
   the whl and sdist files will be written to the lock file. Controlling whether
   the downloading of metadata is done in parallel can be done using
   `parallel_download` attribute.
+* (deps): `rules_python` depends now on `rules_cc` 0.0.9
 
 [0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 [python_default_visibility]: gazelle/README.md#directive-python_default_visibility

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.9.1")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
@@ -71,7 +72,6 @@ use_repo(pip, "rules_python_publish_deps")
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "rules_bazel_integration_test", version = "0.20.0", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.6.0", dev_dependency = True)
-bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 
 # Extra gazelle plugin deps so that WORKSPACE.bzlmod can continue including it for e2e tests.
 # We use `WORKSPACE.bzlmod` because it is impossible to have dev-only local overrides.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -217,3 +217,10 @@ def rules_python_internal_deps():
         strip_prefix = "bazel_features-1.9.1",
         url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
     )
+
+    http_archive(
+        name = "rules_cc",
+        sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
+        strip_prefix = "rules_cc-0.0.9",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+    )

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -143,6 +143,7 @@ bzl_library(
     ],
     deps = [
         ":py_cc_toolchain_info_bzl",
+        ":rules_cc_srcs_bzl",
         ":util_bzl",
     ],
 )
@@ -291,6 +292,13 @@ bzl_library(
         # sources.
         "@bazel_tools//tools:bzl_srcs",
     ],
+)
+
+# @rules_cc does not offer a bzl_library target for @rules_cc//cc:defs.bzl
+bzl_library(
+    name = "rules_cc_srcs_bzl",
+    srcs = ["@rules_cc//cc:bzl_srcs"],
+    deps = [":bazel_tools_bzl"],
 )
 
 # Needed to define bzl_library targets for docgen. (We don't define the

--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -21,6 +21,7 @@ package(
 bzl_library(
     name = "attributes_bazel_bzl",
     srcs = ["attributes_bazel.bzl"],
+    deps = ["//python/private:rules_cc_srcs_bzl"],
 )
 
 bzl_library(
@@ -61,6 +62,7 @@ bzl_library(
         ":py_internal_bzl",
         ":semantics_bzl",
         "//python/private:reexports_bzl",
+        "//python/private:rules_cc_srcs_bzl",
     ],
 )
 
@@ -74,6 +76,7 @@ bzl_library(
     srcs = ["providers.bzl"],
     deps = [
         ":semantics_bzl",
+        "//python/private:rules_cc_srcs_bzl",
         "//python/private:util_bzl",
     ],
 )
@@ -121,6 +124,7 @@ bzl_library(
         ":common_bzl",
         ":providers_bzl",
         ":py_internal_bzl",
+        "//python/private:rules_cc_srcs_bzl",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Attributes for Python rules."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("//python/private:reexports.bzl", "BuiltinPyInfo")
 load(":common.bzl", "union_attrs")
 load(":providers.bzl", "PyInfo")
@@ -23,8 +24,6 @@ load(
     "SRCS_ATTR_ALLOW_FILES",
 )
 
-# TODO: Load CcInfo from rules_cc
-_CcInfo = CcInfo
 _PackageSpecificationInfo = getattr(py_internal, "PackageSpecificationInfo", None)
 
 _STAMP_VALUES = [-1, 0, 1]
@@ -166,7 +165,7 @@ PY_SRCS_ATTRS = union_attrs(
         "deps": attr.label_list(
             providers = [
                 [PyInfo],
-                [_CcInfo],
+                [CcInfo],
                 [BuiltinPyInfo],
             ],
             # TODO(b/228692666): Google-specific; remove these allowances once

--- a/python/private/common/common_bazel.bzl
+++ b/python/private/common/common_bazel.bzl
@@ -14,15 +14,10 @@
 """Common functions that are specific to Bazel rule implementation"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load(":common.bzl", "is_bool")
 load(":providers.bzl", "PyCcLinkParamsProvider")
 load(":py_internal.bzl", "py_internal")
-
-# TODO: Load cc_common from rules_cc
-_cc_common = cc_common
-
-# TODO: Load CcInfo from rules_cc
-_CcInfo = CcInfo
 
 _py_builtins = py_internal
 
@@ -42,13 +37,13 @@ def collect_cc_info(ctx, extra_deps = []):
         deps.extend(extra_deps)
     cc_infos = []
     for dep in deps:
-        if _CcInfo in dep:
-            cc_infos.append(dep[_CcInfo])
+        if CcInfo in dep:
+            cc_infos.append(dep[CcInfo])
 
         if PyCcLinkParamsProvider in dep:
             cc_infos.append(dep[PyCcLinkParamsProvider].cc_info)
 
-    return _cc_common.merge_cc_infos(cc_infos = cc_infos)
+    return cc_common.merge_cc_infos(cc_infos = cc_infos)
 
 def maybe_precompile(ctx, srcs):
     """Computes all the outputs (maybe precompiled) from the input srcs.

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -13,10 +13,8 @@
 # limitations under the License.
 """Providers for Python rules."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("//python/private:util.bzl", "IS_BAZEL_6_OR_HIGHER")
-
-# TODO: load CcInfo from rules_cc
-_CcInfo = CcInfo
 
 DEFAULT_STUB_SHEBANG = "#!/usr/bin/env python3"
 
@@ -241,7 +239,7 @@ This field is currently unused in Bazel and may go away in the future.
 
 def _PyCcLinkParamsProvider_init(cc_info):
     return {
-        "cc_info": _CcInfo(linking_context = cc_info.linking_context),
+        "cc_info": CcInfo(linking_context = cc_info.linking_context),
     }
 
 # buildifier: disable=name-conventions

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -14,6 +14,7 @@
 """Common functionality between test/binary executables."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@rules_cc//cc:defs.bzl", "cc_common")
 load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")
 load(
     ":attributes.bzl",
@@ -52,9 +53,6 @@ load(
     "IS_BAZEL",
     "PY_RUNTIME_ATTR_NAME",
 )
-
-# TODO: Load cc_common from rules_cc
-_cc_common = cc_common
 
 _py_builtins = py_internal
 
@@ -559,10 +557,10 @@ def _create_shared_native_deps_dso(
     linkstamps = py_internal.linking_context_linkstamps(cc_info.linking_context)
 
     partially_disabled_thin_lto = (
-        _cc_common.is_enabled(
+        cc_common.is_enabled(
             feature_name = "thin_lto_linkstatic_tests_use_shared_nonlto_backends",
             feature_configuration = feature_configuration,
-        ) and not _cc_common.is_enabled(
+        ) and not cc_common.is_enabled(
             feature_name = "thin_lto_all_linkstatic_use_shared_nonlto_backends",
             feature_configuration = feature_configuration,
         )
@@ -876,7 +874,7 @@ def cc_configure_features(ctx, *, cc_toolchain, extra_features):
     requested_features.extend(ctx.features)
     if "legacy_whole_archive" not in ctx.disabled_features:
         requested_features.append("legacy_whole_archive")
-    feature_configuration = _cc_common.configure_features(
+    feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = requested_features,

--- a/python/private/current_py_cc_headers.bzl
+++ b/python/private/current_py_cc_headers.bzl
@@ -14,6 +14,8 @@
 
 """Implementation of current_py_cc_headers rule."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
+
 def _current_py_cc_headers_impl(ctx):
     py_cc_toolchain = ctx.toolchains["//python/cc:toolchain_type"].py_cc_toolchain
     return py_cc_toolchain.headers.providers_map.values()

--- a/python/private/current_py_cc_libs.bzl
+++ b/python/private/current_py_cc_libs.bzl
@@ -14,6 +14,8 @@
 
 """Implementation of current_py_cc_libs rule."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
+
 def _current_py_cc_libs_impl(ctx):
     py_cc_toolchain = ctx.toolchains["//python/cc:toolchain_type"].py_cc_toolchain
     return py_cc_toolchain.libs.providers_map.values()

--- a/python/private/py_cc_toolchain_rule.bzl
+++ b/python/private/py_cc_toolchain_rule.bzl
@@ -18,6 +18,7 @@ NOTE: This is a beta-quality feature. APIs subject to change until
 https://github.com/bazelbuild/rules_python/issues/824 is considered done.
 """
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load(":py_cc_toolchain_info.bzl", "PyCcToolchainInfo")
 
 def _py_cc_toolchain_impl(ctx):

--- a/python/repositories.bzl
+++ b/python/repositories.bzl
@@ -62,6 +62,12 @@ def py_repositories():
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
         ],
     )
+    http_archive(
+        name = "rules_cc",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+        sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
+        strip_prefix = "rules_cc-0.0.9",
+    )
     pip_install_dependencies()
 
 ########

--- a/tests/cc/current_py_cc_headers/current_py_cc_headers_tests.bzl
+++ b/tests/cc/current_py_cc_headers/current_py_cc_headers_tests.bzl
@@ -14,6 +14,7 @@
 
 """Tests for current_py_cc_headers."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:truth.bzl", "matching")
 load("//tests:cc_info_subject.bzl", "cc_info_subject")

--- a/tests/cc/current_py_cc_libs/current_py_cc_libs_tests.bzl
+++ b/tests/cc/current_py_cc_libs/current_py_cc_libs_tests.bzl
@@ -14,6 +14,7 @@
 
 """Tests for current_py_cc_libs."""
 
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:truth.bzl", "matching")
 load("//tests:cc_info_subject.bzl", "cc_info_subject")

--- a/tests/cc/fake_cc_toolchain_config.bzl
+++ b/tests/cc/fake_cc_toolchain_config.bzl
@@ -14,6 +14,8 @@
 
 """Fake for providing CcToolchainConfigInfo."""
 
+load("@rules_cc//cc:defs.bzl", "cc_common")
+
 def _impl(ctx):
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,


### PR DESCRIPTION
Adds dependency on rules_cc 0.0.9 for both bzlmod and workspace

This elevates rules_cc from a dev dependency to a full dependency of rules_python.

Work towards incompatible_stop_exporting_language_modules, see https://github.com/bazelbuild/bazel/issues/19455


