### PR TITLE
docs: Fix link to toolchain configuration doc in side bar

### DIFF
--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -57,7 +57,7 @@ by buildifier.
 self
 getting-started
 pypi-dependencies
-configuring
+toolchains
 pip
 coverage
 gazelle


### PR DESCRIPTION
The index had the wrong doc name, so it wasn't showing up in the rendered docs.