### PR TITLE
fix(whl_library): stop duplicating deps in whl_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ A brief description of the categories of changes:
 * (whl_library): Fix the experimental_target_platforms overriding for platform
   specific wheels when the wheels are for any python interpreter version. Fixes
   [#1810](https://github.com/bazelbuild/rules_python/issues/1810).
+* (whl_library): Stop generating duplicate dependencies when encountering
+  duplicates in the METADATA. Fixes
+  [#1873](https://github.com/bazelbuild/rules_python/issues/1873).
 * (gazelle) In `project` or `package` generation modes, do not generate `py_test`
   rules when there are no test files and do not set `main = "__test__.py"` when
   that file doesn't exist.

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -370,6 +370,24 @@ class Deps:
 
         if not platform:
             self._deps.add(dep)
+
+            # If the dep is in the platform-specific list, remove it from the select.
+            pop_keys = []
+            for p, deps in self._select.items():
+                if dep not in deps:
+                    continue
+
+                deps.remove(dep)
+                if not deps:
+                    pop_keys.append(p)
+
+            for p in pop_keys:
+                self._select.pop(p)
+            return
+
+        if dep in self._deps:
+            # If the dep is already in the main dependency list, no need to add it in the
+            # platform-specific dependency list.
             return
 
         # Add the platform-specific dep


### PR DESCRIPTION
Before this PR we would incorrectly add deps to the platform-specific
list if there were multiple entries in the `METADATA` file. It seems
that some projects (e.g. [opencv-python]) have multiple entries in their
METADATA file to help SAT solvers with selecting the right version when
different interpreter versions are used.

In our case, we will have only one version of a given package because we
are operating with a locked dependency list, so we should ensure that we
do not have duplicates across the lists. With this PR we are solving
this during the construction of the dependency sets so that the internal
model is always consistent.

Fixes #1873

[opencv-python]: https://pypi.org/project/opencv-python/
