### PR TITLE
fix(gazelle): delete invalid py_library and use correct NonEmptyAttrs for py_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ A brief description of the categories of changes:
 
 ### Fixed
 
+* (gazelle) Remove `visibility` from `NonEmptyAttr`.
+  Now empty(have no `deps/main/srcs/imports` attr) `py_library/test/binary` rules will
+  be automatically deleted correctly. For example, if `python_generation_mode`
+  is set to package, when `__init__.py` is deleted, the `py_library` generated
+  for this package before will be deleted automatically.
+
 ### Added
 
 ## [0.32.2] - 2024-05-14
@@ -80,11 +86,6 @@ A brief description of the categories of changes:
   See [#1371](https://github.com/bazelbuild/rules_python/issues/1371).
 * (refactor) The pre-commit developer workflow should now pass `isort` and `black`
   checks (see [#1674](https://github.com/bazelbuild/rules_python/issues/1674)).
-* (gazelle) Remove `visibility` from `NonEmptyAttr`.
-  Now empty(have no `deps/main/srcs/imports` attr) `py_library/test/binary` rules will
-  be automatically deleted correctly. For example, if `python_generation_mode`
-  is set to package, when `__init__.py` is deleted, the `py_library` generated
-  for this package before will be deleted automatically.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ A brief description of the categories of changes:
   See [#1371](https://github.com/bazelbuild/rules_python/issues/1371).
 * (refactor) The pre-commit developer workflow should now pass `isort` and `black`
   checks (see [#1674](https://github.com/bazelbuild/rules_python/issues/1674)).
+* (gazelle) Remove `visibility` from `NonEmptyAttr`.
+  Now empty(have no `deps/main/srcs/imports` attr) `py_library/test/binary` rules will
+  be automatically deleted correctly. For example, if `python_generation_mode`
+  is set to package, when `__init__.py` is deleted, the `py_library` generated
+  for this package before will be deleted automatically.
 
 ### Added
 

--- a/gazelle/python/kinds.go
+++ b/gazelle/python/kinds.go
@@ -34,11 +34,10 @@ var pyKinds = map[string]rule.KindInfo{
 	pyBinaryKind: {
 		MatchAny: true,
 		NonEmptyAttrs: map[string]bool{
-			"deps":       true,
-			"main":       true,
-			"srcs":       true,
-			"imports":    true,
-			"visibility": true,
+			"deps":    true,
+			"main":    true,
+			"srcs":    true,
+			"imports": true,
 		},
 		SubstituteAttrs: map[string]bool{},
 		MergeableAttrs: map[string]bool{
@@ -52,10 +51,9 @@ var pyKinds = map[string]rule.KindInfo{
 		MatchAny:   false,
 		MatchAttrs: []string{"srcs"},
 		NonEmptyAttrs: map[string]bool{
-			"deps":       true,
-			"srcs":       true,
-			"imports":    true,
-			"visibility": true,
+			"deps":    true,
+			"srcs":    true,
+			"imports": true,
 		},
 		SubstituteAttrs: map[string]bool{},
 		MergeableAttrs: map[string]bool{
@@ -68,11 +66,10 @@ var pyKinds = map[string]rule.KindInfo{
 	pyTestKind: {
 		MatchAny: false,
 		NonEmptyAttrs: map[string]bool{
-			"deps":       true,
-			"main":       true,
-			"srcs":       true,
-			"imports":    true,
-			"visibility": true,
+			"deps":    true,
+			"main":    true,
+			"srcs":    true,
+			"imports": true,
 		},
 		SubstituteAttrs: map[string]bool{},
 		MergeableAttrs: map[string]bool{

--- a/gazelle/python/testdata/remove_invalid_library/BUILD.in
+++ b/gazelle/python/testdata/remove_invalid_library/BUILD.in
@@ -5,3 +5,8 @@ py_library(
     srcs = ["__init__.py"],
     visibility = ["//:__subpackages__"],
 )
+
+py_library(
+    name = "deps_with_no_srcs_library",
+    deps = ["//:remove_invalid_library"],
+)

--- a/gazelle/python/testdata/remove_invalid_library/BUILD.in
+++ b/gazelle/python/testdata/remove_invalid_library/BUILD.in
@@ -8,5 +8,9 @@ py_library(
 
 py_library(
     name = "deps_with_no_srcs_library",
-    deps = ["//:remove_invalid_library"],
+    deps = [
+        "//:remove_invalid_library",
+        "@pypi//bar",
+        "@pypi//foo",
+    ],
 )

--- a/gazelle/python/testdata/remove_invalid_library/BUILD.in
+++ b/gazelle/python/testdata/remove_invalid_library/BUILD.in
@@ -1,0 +1,7 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "remove_invalid_library",
+    srcs = ["__init__.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/remove_invalid_library/BUILD.out
+++ b/gazelle/python/testdata/remove_invalid_library/BUILD.out
@@ -2,5 +2,9 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
     name = "deps_with_no_srcs_library",
-    deps = ["//:remove_invalid_library"],
+    deps = [
+        "//:remove_invalid_library",
+        "@pypi//bar",
+        "@pypi//foo",
+    ],
 )

--- a/gazelle/python/testdata/remove_invalid_library/BUILD.out
+++ b/gazelle/python/testdata/remove_invalid_library/BUILD.out
@@ -1,0 +1,6 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "deps_with_no_srcs_library",
+    deps = ["//:remove_invalid_library"],
+)

--- a/gazelle/python/testdata/remove_invalid_library/README.md
+++ b/gazelle/python/testdata/remove_invalid_library/README.md
@@ -1,0 +1,3 @@
+# Remove invalid
+
+This test case asserts that `py_library` should be deleted if invalid.

--- a/gazelle/python/testdata/remove_invalid_library/WORKSPACE
+++ b/gazelle/python/testdata/remove_invalid_library/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/remove_invalid_library/test.yaml
+++ b/gazelle/python/testdata/remove_invalid_library/test.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---


### PR DESCRIPTION
Before gazelle would leave generated py_library targets aroundeven when no files in a directory exist because X. With this change gazelle correctly handles this case.