### PR TITLE
Fix typo in changelog text from #1863

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ A brief description of the categories of changes:
   the whl and sdist files will be written to the lock file. Controlling whether
   the downloading of metadata is done in parallel can be done using
   `parallel_download` attribute.
-* (gazelle) Add a new annotation `include_deps`. Also add documentation for
+* (gazelle) Add a new annotation `include_dep`. Also add documentation for
   annotations to `gazelle/README.md`.
 * (deps): `rules_python` depends now on `rules_cc` 0.0.9
 * (pip_parse): A new flag `use_hub_alias_dependencies` has been added that is going


### PR DESCRIPTION
The annotation is `include_dep`, not `include_deps`.

```console
$ # Before this PR:
$ rg -F "include_deps"
CHANGELOG.md
76:* (gazelle) Add a new annotation `include_deps`. Also add documentation for
$
$ # After this PR, there are no more references to "include_deps"
$ rg -F "include_deps"
$
```