### PR TITLE
fix(bcr): add mandatory gazelle bcr presubmit attrs

### DIFF
--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -16,10 +16,12 @@ bcr_test_module:
   module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       build_targets:
         - "//..."
         - ":modules_map"


### PR DESCRIPTION
The same as in f1d1732b11929671110e6a1b845c8d1a1a67530f.

Fixes that were needed in [bazel/bazel-central-registry#2019](https://github.com/bazelbuild/bazel-central-registry/pull/2019).
