### PR TITLE
fix(toolchain): delete 'share/terminfo' for recent linux python toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ A brief description of the categories of changes:
 * Particular sub-systems are identified using parentheses, e.g. `(bzlmod)` or
   `(docs)`.
 
+## Unreleased
+
+[x.x.x]: https://github.com/bazelbuild/rules_python/releases/tag/x.x.x
+
+### Changed
+
+### Fixed
+
+### Added
+
+## [0.32.2] - 2024-05-14
+
+[0.32.2]: https://github.com/bazelbuild/rules_python/releases/tag/0.32.2
+
+### Fixed
+
+* Workaround existence of infinite symlink loops on case insensitive filesystems when targeting linux platforms with recent Python toolchains. Works around an upstream [issue][indygreg-231]. Fixes [#1800][rules_python_1800].
+
+[indygreg-231]: https://github.com/indygreg/python-build-standalone/issues/231
+[rules_python_1800]: https://github.com/bazelbuild/rules_python/issues/1800
+
 ## [0.32.0] - 2024-05-12
 
 [0.32.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.32.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ python.toolchain(
     is_default = True,
     python_version = "3.11",
 )
-use_repo(python, "python_versions", "pythons_hub")
+use_repo(python, "python_3_11", "python_versions", "pythons_hub")
 
 # This call registers the Python toolchains.
 register_toolchains("@pythons_hub//:all")

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -25,22 +25,3 @@ build_test(
         "//python/entry_points:py_console_script_binary_bzl",
     ],
 )
-
-# Used for manual tests when downloading a toolchain for a particular platform
-platform(
-    name = "linux_x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-platform(
-    name = "windows_x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-    ],
-    visibility = ["//:__subpackages__"],
-)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -25,3 +25,22 @@ build_test(
         "//python/entry_points:py_console_script_binary_bzl",
     ],
 )
+
+# Used for manual tests when downloading a toolchain for a particular platform
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+platform(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/support/BUILD.bazel
+++ b/tests/support/BUILD.bazel
@@ -37,3 +37,29 @@ platform(
         "@platforms//os:windows",
     ],
 )
+
+# Used when testing downloading of toolchains for a different platform
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "mac_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+)
+
+platform(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+)


### PR DESCRIPTION
This affects Linux toolchains that have the `terminfo` databases bundled
with the toolchain. Our solution to this is to remove the
`share/terminfo` altogether if we are downloading an affected `linux`
toolchain.

Tested with (on a Mac):
```console
bazel build --platforms=//tests/support:linux_x86_64 @python_3_11//:files
bazel build --platforms=//tests/support:windows_x86_64 @python_3_11//:files
```

Workaround https://github.com/indygreg/python-build-standalone/issues/231
Fixes #1800
