### PR TITLE
feat: render aliases for `extra_targets` of `whl_mods`.

### DIFF
--- a/python/private/render_pkg_aliases.bzl
+++ b/python/private/render_pkg_aliases.bzl
@@ -134,6 +134,10 @@ def _render_common_aliases(*, name, aliases, default_version = None, group_name 
             actual = repr(":pkg"),
         ),
     )
+    targets = [DATA_LABEL, DIST_INFO_LABEL]
+    for alias in aliases:
+        targets.extend(alias.extra_targets)
+    targets = {k: None for k in targets}.keys()
     lines.extend(
         [
             _render_whl_library_alias(
@@ -146,9 +150,7 @@ def _render_common_aliases(*, name, aliases, default_version = None, group_name 
             for target_name, name in {
                 PY_LIBRARY_PUBLIC_LABEL: PY_LIBRARY_IMPL_LABEL if group_name else PY_LIBRARY_PUBLIC_LABEL,
                 WHEEL_FILE_PUBLIC_LABEL: WHEEL_FILE_IMPL_LABEL if group_name else WHEEL_FILE_PUBLIC_LABEL,
-                DATA_LABEL: DATA_LABEL,
-                DIST_INFO_LABEL: DIST_INFO_LABEL,
-            }.items()
+            }.items() + [(target, target) for target in targets]
         ],
     )
     if group_name:


### PR DESCRIPTION
I'm trying to get rules_ros2 to Bzlmod. There is a dependency on numpy headers that are exposed via an additive_build_content cc_library. One of the last migration challenges is how to properly consume these headers in both Bzlmod and Workspace and without hardcoding a Python version. See https://github.com/mvukov/rules_ros2/pull/238#discussion_r1549195117 for the WIP PR.

I dug a little into how the aliasing works and come up with a proof of concept of how a list of extra_targets could be propagated from pip.whl_mods like
```Starlark
pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
pip.whl_mods(
    additive_build_content = """\
cc_library(
    name = "headers",
    hdrs = glob(["site-packages/numpy/core/include/numpy/**/*.h"]),
    includes = ["site-packages/numpy/core/include"],
    deps = ["@rules_python//python/cc:current_py_cc_headers"],
)
""",
    extra_targets = ["headers"],  # <--- this is new
    hub_name = "whl_mods_hub",
    whl_name = "numpy",
)
use_repo(pip, "whl_mods_hub")
```
This makes it possible to depend on `"@rules_ros2_pip_deps//numpy:headers"` instead of e.g. `"@rules_ros2_pip_deps_310_numpy//:headers`

Workspace doesn't have this problem, but the label looks slightly different.
That can be worked around with an alias for now.
```Starlark
load("@rules_python//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
alias(
    name = "rules_ros2_pip_deps_numpy_headers",
    actual = "@rules_ros2_pip_deps//numpy:headers" if BZLMOD_ENABLED else "@rules_ros2_pip_deps_numpy//:headers",
    visibility = ["//visibility:public"],
)
```

You can see this in action in https://github.com/mvukov/rules_ros2/pull/238/commits/e2b926c03075913754a8d8175e356a5637b0f5c7

Please let me know what you think of this. Maybe there is a more elegant way to achieve this?

<!--
PR Instructions/requirements
* Title uses `type: description` format. See CONTRIBUTING.md for types.
  * Common types are: build, docs, feat, fix, refactor, revert, test
  * Update `CHANGELOG.md` as applicable
* Breaking changes include "!" after the type and a "BREAKING CHANGES:"
  section at the bottom.
  See CONTRIBUTING.md for our breaking changes process.
* Body text describes:
  * Why this change is being made, briefly.
  * Before and after behavior, as applicable
  * References issue number, as applicable
* Update docs and tests, as applicable
* Delete these instructions prior to sending the PR
-->