### PR TITLE
fix(gazelle): generate empty py_library only when need

### DIFF
--- a/gazelle/python/testdata/remove_invalid_library/others/BUILD.in
+++ b/gazelle/python/testdata/remove_invalid_library/others/BUILD.in
@@ -1,0 +1,5 @@
+genrule(
+    name = "others",  # same to directory name
+    outs = ["data.txt"],
+    cmd = "echo foo bar baz > $@",
+)

--- a/gazelle/python/testdata/remove_invalid_library/others/BUILD.out
+++ b/gazelle/python/testdata/remove_invalid_library/others/BUILD.out
@@ -1,0 +1,5 @@
+genrule(
+    name = "others",  # same to directory name
+    outs = ["data.txt"],
+    cmd = "echo foo bar baz > $@",
+)


### PR DESCRIPTION
#1887 incorrectly generated an empty py_library for all dirs, although it will eventually be removed because it is empty, but it will easily conflict with other existing rules.

Fix this error, and only generate an empty py_library for bazel packages with the same name py_library rule.