### PR TITLE
chore(precompiling): use `PyCompile` as mnemonic to match Google mnemonic

### DIFF
--- a/docs/sphinx/precompiling.md
+++ b/docs/sphinx/precompiling.md
@@ -53,14 +53,14 @@ mechanisms are available:
 * The execution requirements can be customized using
   `--@rules_python//tools/precompiler:execution_requirements`. This is a list
   flag that can be repeated. Each entry is a key=value that is added to the
-  execution requirements of the `PyPrecompile` action. Note that this flag
+  execution requirements of the `PyCompile` action. Note that this flag
   is specific to the rules_python precompiler. If a custom binary is used,
   this flag will have to be propagated from the custom binary using the
   `testing.ExecutionInfo` provider; refer to the `py_interpreter_program` an
 
 The default precompiler implementation is an asynchronous/concurrent
 implementation. If you find it has bugs or hangs, please report them. In the
-meantime, the flag `--worker_extra_flag=PyPrecompile=--worker_impl=serial` can
+meantime, the flag `--worker_extra_flag=PyCompile=--worker_impl=serial` can
 be used to switch to a synchronous/serial implementation that may not perform
 as well, but is less likely to have issues.
 

--- a/python/private/common/common_bazel.bzl
+++ b/python/private/common/common_bazel.bzl
@@ -200,7 +200,7 @@ def _precompile(ctx, src, *, use_pycache):
         arguments = [precompiler_startup_args, precompile_request_args],
         inputs = [src],
         outputs = [pyc],
-        mnemonic = "PyPrecompile",
+        mnemonic = "PyCompile",
         progress_message = "Python precompiling %{input} into %{output}",
         tools = tools,
         env = env | {

--- a/tests/base_rules/precompile/precompile_tests.bzl
+++ b/tests/base_rules/precompile/precompile_tests.bzl
@@ -295,7 +295,7 @@ _tests.append(_test_precompiler_action)
 
 def _test_precompiler_action_impl(env, target):
     #env.expect.that_target(target).runfiles().contains_exactly([])
-    action = env.expect.that_target(target).action_named("PyPrecompile")
+    action = env.expect.that_target(target).action_named("PyCompile")
     action.contains_flag_values([
         ("--optimize", "2"),
         ("--python_version", "4.5"),


### PR DESCRIPTION
This is just to make the two implementations a bit closer; the mnemonic is a psuedo-public API as it shows up in flags, actions, queries, etc.