### PR TITLE
fix(pip.parse): make the pip extension reproducible if PyPI is not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ A brief description of the categories of changes:
   replaced by whl_modifications.
 * (pip) Correctly select wheels when the python tag includes minor versions.
   See ([#1930](https://github.com/bazelbuild/rules_python/issues/1930))
+* (pip.parse): The lock file is now reproducible on any host platform if the
+  `experimental_index_url` is not used by any of the modules in the dependency
+  chain. To make the lock file identical on each `os` and `arch`, please use
+  the `experimental_index_url` feature which will fetch metadata from PyPI or a
+  different private index and write the contents to the lock file. Fixes
+  [#1643](https://github.com/bazelbuild/rules_python/issues/1643).
 
 ### Added
 * (rules) Precompiling Python source at build time is available. but is

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,7 +56,7 @@ register_toolchains("@pythons_hub//:all")
 #####################
 # Install twine for our own runfiles wheel publishing and allow bzlmod users to use it.
 
-pip = use_extension("//python/extensions:pip.bzl", "pip")
+pip = use_extension("//python/private/bzlmod:pip.bzl", "pip_internal")
 pip.parse(
     experimental_index_url = "https://pypi.org/simple",
     hub_name = "rules_python_publish_deps",
@@ -80,8 +80,8 @@ bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True, repo_nam
 bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True, repo_name = "bazel_gazelle")
 
 dev_pip = use_extension(
-    "//python/extensions:pip.bzl",
-    "pip",
+    "//python/private/bzlmod:pip.bzl",
+    "pip_internal",
     dev_dependency = True,
 )
 dev_pip.parse(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,7 +58,6 @@ register_toolchains("@pythons_hub//:all")
 
 pip = use_extension("//python/private/bzlmod:pip.bzl", "pip_internal")
 pip.parse(
-    experimental_index_url = "https://pypi.org/simple",
     hub_name = "rules_python_publish_deps",
     python_version = "3.11",
     requirements_by_platform = {
@@ -85,8 +84,6 @@ dev_pip = use_extension(
     dev_dependency = True,
 )
 dev_pip.parse(
-    envsubst = ["PIP_INDEX_URL"],
-    experimental_index_url = "${PIP_INDEX_URL:-https://pypi.org/simple}",
     experimental_requirement_cycles = {
         "sphinx": [
             "sphinx",
@@ -102,8 +99,6 @@ dev_pip.parse(
     requirements_lock = "//docs/sphinx:requirements.txt",
 )
 dev_pip.parse(
-    envsubst = ["PIP_INDEX_URL"],
-    experimental_index_url = "${PIP_INDEX_URL:-https://pypi.org/simple}",
     hub_name = "pypiserver",
     python_version = "3.11",
     requirements_lock = "//examples/wheel:requirements_server.txt",


### PR DESCRIPTION
With this PR we can finally have fewer lock file entries in setups which
do not use the `experimental_index_url` feature yet. This is fully
backwards compatible change as it relies on `bazel` doing the right
thing and regenerating the lock file.

Fixes #1643.
