### PR TITLE
chore: refer to rules_python toolchain type target instead of bazel_tools

### DIFF
--- a/examples/pip_parse/BUILD.bazel
+++ b/examples/pip_parse/BUILD.bazel
@@ -24,7 +24,7 @@ load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_cons
 #toolchain(
 #    name = "my_py_toolchain",
 #    toolchain = ":my_py_runtime_pair",
-#    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+#    toolchain_type = "@rules_python//python:toolchain_type",
 #)
 # End of toolchain setup.
 

--- a/python/current_py_toolchain.bzl
+++ b/python/current_py_toolchain.bzl
@@ -14,6 +14,8 @@
 
 """Public entry point for current_py_toolchain rule."""
 
+load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")
+
 def _current_py_toolchain_impl(ctx):
     toolchain = ctx.toolchains[ctx.attr._toolchain]
 
@@ -50,9 +52,9 @@ current_py_toolchain = rule(
     """,
     implementation = _current_py_toolchain_impl,
     attrs = {
-        "_toolchain": attr.string(default = str(Label("@bazel_tools//tools/python:toolchain_type"))),
+        "_toolchain": attr.string(default = str(TARGET_TOOLCHAIN_TYPE)),
     },
     toolchains = [
-        str(Label("@bazel_tools//tools/python:toolchain_type")),
+        str(TARGET_TOOLCHAIN_TYPE),
     ],
 )

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -16,6 +16,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//python/private:flags.bzl", "BootstrapImplFlag")
+load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")
 load(":attributes_bazel.bzl", "IMPORTS_ATTRS")
 load(
     ":common.bzl",
@@ -78,7 +79,7 @@ the `srcs` of Python targets as required.
         # GraphlessQueryTest.testLabelsOperator relies on it to test for
         # query behavior of implicit dependencies.
         "_py_toolchain_type": attr.label(
-            default = "@bazel_tools//tools/python:toolchain_type",
+            default = TARGET_TOOLCHAIN_TYPE,
         ),
         "_windows_launcher_maker": attr.label(
             default = "@bazel_tools//tools/launcher:launcher_maker",

--- a/tests/toolchains/defs.bzl
+++ b/tests/toolchains/defs.bzl
@@ -17,6 +17,7 @@
 
 load("//python:versions.bzl", "PLATFORMS", "TOOL_VERSIONS")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
+load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")  # buildifier: disable=bzl-visibility
 
 _WINDOWS_RUNNER_TEMPLATE = """\
 @ECHO OFF
@@ -76,7 +77,7 @@ def _acceptance_test_impl(ctx):
     )
     files.append(run_acceptance_test_py)
 
-    toolchain = ctx.toolchains["@bazel_tools//tools/python:toolchain_type"]
+    toolchain = ctx.toolchains[TARGET_TOOLCHAIN_TYPE]
     py3_runtime = toolchain.py3_runtime
     interpreter_path = py3_runtime.interpreter_path
     if not interpreter_path:
@@ -164,7 +165,7 @@ _acceptance_test = rule(
         ),
     },
     test = True,
-    toolchains = ["@bazel_tools//tools/python:toolchain_type"],
+    toolchains = [TARGET_TOOLCHAIN_TYPE],
 )
 
 def acceptance_test(python_version, **kwargs):


### PR DESCRIPTION
The `@rules_python//python:toolchain_type` target is just an alias to the bazel tools one, so this should be a no-op change. It's less confusing to use a consistent label than to have a mix of them.
