### PR TITLE
fix(rules): drop the unused argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ A brief description of the categories of changes:
 ### Removed
 * Nothing yet
 
+## [0.33.1] - 2024-06-13
+
+[0.33.1]: https://github.com/bazelbuild/rules_python/releases/tag/0.33.1
+
+### Fixed
+* (py_binary) Fix building of zip file when using `--build_python_zip`
+  argument. Fixes [#1954](https://github.com/bazelbuild/rules_python/issues/1954).
+
 ## [0.33.0] - 2024-06-12
 
 [0.33.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.33.0

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -270,7 +270,6 @@ def _create_executable(
             ctx,
             output = executable,
             zip_file = zip_file,
-            python_binary_path = runtime_details.executable_interpreter_path,
             stage2_bootstrap = stage2_bootstrap,
             runtime_details = runtime_details,
         )

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -69,7 +69,11 @@ _tests.append(_test_basic_windows)
 
 def _test_basic_zip(name, config):
     if rp_config.enable_pystar:
-        target_compatible_with = []
+        target_compatible_with = select({
+            # Disable the new test on windows because we have _test_basic_windows.
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        })
     else:
         target_compatible_with = ["@platforms//:incompatible"]
     rt_util.helper_target(


### PR DESCRIPTION
It seems that there is an extra argument that is there but I am not sure about
the reason, it is most likely a leftover. As part of this change we add an
analysis test for non-windows zip building. I could reproduce the failure and
now the newly added test passes.

Fixes #1954
