### PR TITLE
fix: Remove transitive legacy struct provider usage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,9 @@ test --test_output=errors
 # Python targets as required.
 build --incompatible_default_to_explicit_init_py
 
+# Ensure ongoing compatibility with this flag.
+common --incompatible_disallow_struct_provider_syntax
+
 # Windows makes use of runfiles for some rules
 build --enable_runfiles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ A brief description of the categories of changes:
 [x.x.x]: https://github.com/bazelbuild/rules_python/releases/tag/x.x.x
 
 ### Changed
-* Nothing yet
+* `protobuf`/`com_google_protobuf` dependency bumped to `v24.4`
 
 ### Fixed
 * Nothing yet

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
 bazel_dep(name = "rules_proto", version = "6.0.0-rc1")
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
 
 internal_deps = use_extension("//python/private/bzlmod:internal_deps.bzl", "internal_deps")
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "platforms", version = "0.0.4")
 
 # Those are loaded only when using py_proto_library
 bazel_dep(name = "rules_proto", version = "6.0.0-rc1")
-bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "24.4", repo_name = "com_google_protobuf")
 
 internal_deps = use_extension("//python/private/bzlmod:internal_deps.bzl", "internal_deps")
 use_repo(

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 
 # (py_proto_library specific) Add the protobuf library for well-known types (e.g. `Any`, `Timestamp`, etc)
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
 
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 
 # (py_proto_library specific) Add the protobuf library for well-known types (e.g. `Any`, `Timestamp`, etc)
-bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "24.4", repo_name = "com_google_protobuf")
 
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -173,11 +173,10 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-        strip_prefix = "protobuf-21.7",
+        sha256 = "72bae766561149f8507a81647f91fc519d2a60309613f004ed307cb5f9b1242b",
+        strip_prefix = "protobuf-23.1",
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protobuf-23.1.tar.gz",
         ],
     )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -173,10 +173,10 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "72bae766561149f8507a81647f91fc519d2a60309613f004ed307cb5f9b1242b",
-        strip_prefix = "protobuf-23.1",
+        sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
+        strip_prefix = "protobuf-24.4",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protobuf-23.1.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Makes `rules_python` compatible with `--incompatible_disallow_struct_provider_syntax`.

Fixes #1956