### PR TITLE
chore: various cleanups to make google imports/patching easier

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -33,7 +33,7 @@ string_flag(
     name = "precompile",
     build_setting_default = PrecompileFlag.AUTO,
     values = sorted(PrecompileFlag.__members__.values()),
-    # NOTE: Only public because its an implicit dependency
+    # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],
 )
 
@@ -41,7 +41,7 @@ string_flag(
     name = "precompile_source_retention",
     build_setting_default = PrecompileSourceRetentionFlag.KEEP_SOURCE,
     values = sorted(PrecompileSourceRetentionFlag.__members__.values()),
-    # NOTE: Only public because its an implicit dependency
+    # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],
 )
 
@@ -49,7 +49,7 @@ string_flag(
     name = "precompile_add_to_runfiles",
     build_setting_default = PrecompileAddToRunfilesFlag.ALWAYS,
     values = sorted(PrecompileAddToRunfilesFlag.__members__.values()),
-    # NOTE: Only public because its an implicit dependency
+    # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],
 )
 
@@ -57,7 +57,7 @@ string_flag(
     name = "pyc_collection",
     build_setting_default = PycCollectionFlag.DISABLED,
     values = sorted(PycCollectionFlag.__members__.values()),
-    # NOTE: Only public because its an implicit dependency
+    # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],
 )
 
@@ -65,7 +65,7 @@ string_flag(
     name = "bootstrap_impl",
     build_setting_default = BootstrapImplFlag.SYSTEM_PYTHON,
     values = sorted(BootstrapImplFlag.__members__.values()),
-    # NOTE: Only public because its an implicit dependency
+    # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],
 )
 

--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -35,6 +35,7 @@ bzl_library(
         "//python/private:enum_bzl",
         "//python/private:flags_bzl",
         "//python/private:reexports_bzl",
+        "//python/private:rules_cc_srcs_bzl",
         "@bazel_skylib//rules:common_settings",
     ],
 )

--- a/python/private/common/py_library.bzl
+++ b/python/private/common/py_library.bzl
@@ -102,25 +102,7 @@ def py_library_impl(ctx, *, semantics):
         create_output_group_info(py_info.transitive_sources, extra_groups = {}),
     ]
 
-def create_py_library_rule(*, attrs = {}, **kwargs):
-    """Creates a py_library rule.
-
-    Args:
-        attrs: dict of rule attributes.
-        **kwargs: Additional kwargs to pass onto the rule() call.
-    Returns:
-        A rule object
-    """
-    return rule(
-        attrs = dicts.add(LIBRARY_ATTRS, attrs),
-        toolchains = [
-            config_common.toolchain_type(TOOLCHAIN_TYPE, mandatory = False),
-            config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN_TYPE, mandatory = False),
-        ],
-        # TODO(b/253818097): fragments=py is only necessary so that
-        # RequiredConfigFragmentsTest passes
-        fragments = ["py"],
-        doc = """
+_DEFAULT_PY_LIBRARY_DOC = """
 A library of Python code that can be depended upon.
 
 Default outputs:
@@ -130,6 +112,28 @@ Default outputs:
 NOTE: Precompilation affects which of the default outputs are included in the
 resulting runfiles. See the precompile-related attributes and flags for
 more information.
-""",
+"""
+
+def create_py_library_rule(*, attrs = {}, **kwargs):
+    """Creates a py_library rule.
+
+    Args:
+        attrs: dict of rule attributes.
+        **kwargs: Additional kwargs to pass onto the rule() call.
+    Returns:
+        A rule object
+    """
+
+    # Within Google, the doc attribute is overridden
+    kwargs.setdefault("doc", _DEFAULT_PY_LIBRARY_DOC)
+    return rule(
+        attrs = dicts.add(LIBRARY_ATTRS, attrs),
+        toolchains = [
+            config_common.toolchain_type(TOOLCHAIN_TYPE, mandatory = False),
+            config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN_TYPE, mandatory = False),
+        ],
+        # TODO(b/253818097): fragments=py is only necessary so that
+        # RequiredConfigFragmentsTest passes
+        fragments = ["py"],
         **kwargs
     )


### PR DESCRIPTION
* Make py_library doc customizable.
* Correct a typo checkers are spammy about
* Add missing bzl_library. I would have expected our docgen to have also noticed this, but it must be picking it up from another transitive dependency, while the Google tests don't get that.