### PR TITLE
fix(bzlmod): use same target in requirement('foo') and all_requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ A brief description of the categories of changes:
 * `protobuf`/`com_google_protobuf` dependency bumped to `v24.4`
 
 ### Fixed
-* Nothing yet
+* (bzlmod): Targets in `all_requirements` now use the same form as targets returned by the `requirement` macro.
 
 ### Removed
 * Nothing yet

--- a/python/private/bzlmod/pip_repository.bzl
+++ b/python/private/bzlmod/pip_repository.bzl
@@ -55,7 +55,7 @@ def _pip_repository_impl(rctx):
             for p in bzl_packages
         ]),
         "%%ALL_REQUIREMENTS%%": render.list([
-            macro_tmpl.format(p, p)
+            macro_tmpl.format(p, "pkg")
             for p in bzl_packages
         ]),
         "%%ALL_WHL_REQUIREMENTS_BY_PACKAGE%%": render.dict({


### PR DESCRIPTION
We have at least one instance in our pre-bzlmod workspace like:
```
deps = list(all_requirements)
deps.remove(requirement('foo'))
```

But when using bzlmod, the generated `all_requirements` list contains targets like `@@rules_python~~pip~my_deps//sqlalchemy:sqlalchemy`, whereas `requirement('sqlalchemy')` will return `@@rules_python~~pip~my_deps//sqlalchemy:pkg`. So this operation now fails.

This change makes `all_requirements` also use the `:pkg` targets to match `requirement`.