### PR TITLE
refactor(bzlmod): generate fewer targets for pip_config_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ A brief description of the categories of changes:
   reduce the total number of targets in the hub repo.
 
 ### Fixed
+* Nothing yet
 
 ### Removed
 * Nothing yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ A brief description of the categories of changes:
 
 ### Changed
 * `protobuf`/`com_google_protobuf` dependency bumped to `v24.4`
+* (bzlmod): optimize the creation of config settings used in pip to
+  reduce the total number of targets in the hub repo.
 
 ### Fixed
-* Nothing yet
 
 ### Removed
 * Nothing yet

--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -88,6 +88,33 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "is_pip_whl_auto",
+    flag_values = {
+        ":pip_whl": UseWhlFlag.AUTO,
+    },
+    # NOTE: Only public because it is used in pip hub repos.
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_pip_whl_no",
+    flag_values = {
+        ":pip_whl": UseWhlFlag.NO,
+    },
+    # NOTE: Only public because it is used in pip hub repos.
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_pip_whl_only",
+    flag_values = {
+        ":pip_whl": UseWhlFlag.ONLY,
+    },
+    # NOTE: Only public because it is used in pip hub repos.
+    visibility = ["//visibility:public"],
+)
+
 string_flag(
     name = "pip_whl_osx_arch",
     build_setting_default = UniversalWhlFlag.ARCH,

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -182,7 +182,7 @@ def construct_config_settings(name = None):  # buildifier: disable=function-docs
     )
 
     native.config_setting(
-        name = "is_python_default",
+        name = "is_python_version_unset",
         flag_values = {
             Label("//python/config_settings:python_version"): "",
         },

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -181,6 +181,14 @@ def construct_config_settings(name = None):  # buildifier: disable=function-docs
         visibility = ["//visibility:public"],
     )
 
+    native.config_setting(
+        name = "is_python_default",
+        flag_values = {
+            Label("//python/config_settings:python_version"): "",
+        },
+        visibility = ["//visibility:public"],
+    )
+
     for version, matching_versions in VERSION_FLAG_VALUES.items():
         is_python_config_setting(
             name = "is_python_{}".format(version),

--- a/python/private/pip_config_settings.bzl
+++ b/python/private/pip_config_settings.bzl
@@ -291,17 +291,13 @@ def _dist_config_setting(*, name, is_pip_whl, is_python, python_version, native 
         **kwargs: The kwargs passed to the config_setting rule. Visibility of
             the main alias target is also taken from the kwargs.
     """
-    name = "is_cp{}_{}".format(python_version, name) if python_version else "is_{}".format(name)
-    if python_version:
-        _name = name.replace("is_cp{}".format(python_version), "_is")
-    else:
-        _name = "_" + name
+    _name = "_is_" + name
 
-    # First match by the python version
     visibility = kwargs.get("visibility")
     native.alias(
-        name = name,
+        name = "is_cp{}_{}".format(python_version, name) if python_version else "is_{}".format(name),
         actual = select({
+            # First match by the python version
             is_python: _name,
             "//conditions:default": is_python,
         }),
@@ -313,7 +309,7 @@ def _dist_config_setting(*, name, is_pip_whl, is_python, python_version, native 
         # `python_version` setting.
         return
 
-    config_setting_name = "_{}_setting".format(name)
+    config_setting_name = _name + "_setting"
     native.config_setting(name = config_setting_name, **kwargs)
 
     # Next match by the `pip_whl` flag value and then match by the flags that

--- a/python/private/pip_flags.bzl
+++ b/python/private/pip_flags.bzl
@@ -54,6 +54,7 @@ WhlLibcFlag = enum(
 )
 
 INTERNAL_FLAGS = [
+    "dist",
     "whl_plat",
     "whl_plat_py3",
     "whl_plat_py3_abi3",

--- a/tests/pip_hub_repository/render_pkg_aliases/render_pkg_aliases_test.bzl
+++ b/tests/pip_hub_repository/render_pkg_aliases/render_pkg_aliases_test.bzl
@@ -926,8 +926,10 @@ def _test_config_settings_exist(env):
                 mock_rule = lambda name, **kwargs: available_config_settings.append(name)
                 pip_config_settings(
                     python_versions = ["3.11"],
-                    alias_rule = mock_rule,
-                    config_setting_rule = mock_rule,
+                    native = struct(
+                        alias = mock_rule,
+                        config_setting = mock_rule,
+                    ),
                     **kwargs
                 )
 


### PR DESCRIPTION
Remove the `python_version` from `flag_values` and reduces the number of
targets we create by a lot because we no longer need to create all of the micro
version combinations to also match when we want to match e.g. 3.10 on a
particular platform by using a trick I've learned in #1968:
```starlark
select({
    "is_python_3.x": "my_config_setting"
    "//conditions:default": "is_python_3.x"
})
```

Then further optimization was done on how we create the aliases and config
settings and optimizing the usage of `pip_whl` flag finally reduced the
internal number targets. The number config settings targets in
`//tests/private/pip_config_settings/...` where we have multiple python
versions has changed:

* `:is_*` - from **995** to **996** (the extra addition being is_python_default).
* `:_.*is_*` - from **28272** to **2480** (just python version) and then to **496** (final).

Work towards #260
