### PR TITLE
docs: Fix a few typos in docs and function names

### DIFF
--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -335,7 +335,7 @@ in the resulting output or not. Valid values are:
 
 * `inherit`: Inherit the value from the `--precompile_source_retention` flag.
 * `keep_source`: Include the original Python source.
-* `omit_source`: Don't include the orignal py source.
+* `omit_source`: Don't include the original py source.
 * `omit_if_generated_source`: Keep the original source if it's a regular source
   file, but omit it if it's a generated file.
 """,

--- a/python/private/parse_requirements.bzl
+++ b/python/private/parse_requirements.bzl
@@ -270,7 +270,7 @@ def parse_requirements(
         contents = ctx.read(file)
 
         # Parse the requirements file directly in starlark to get the information
-        # needed for the whl_libary declarations later.
+        # needed for the whl_library declarations later.
         parse_result = parse(contents)
 
         # Replicate a surprising behavior that WORKSPACE builds allowed:

--- a/python/private/py_interpreter_program.bzl
+++ b/python/private/py_interpreter_program.bzl
@@ -57,7 +57,7 @@ def _py_interpreter_program_impl(ctx):
 
 py_interpreter_program = rule(
     doc = """
-Binary-like rule that doesn't require a toolchain becaues its part of
+Binary-like rule that doesn't require a toolchain because its part of
 implementing build tools for the toolchain. This rule expects the Python
 interprter to be externally provided.
 

--- a/python/private/py_toolchain_suite.bzl
+++ b/python/private/py_toolchain_suite.bzl
@@ -36,7 +36,7 @@ def py_toolchain_suite(*, prefix, user_repository_name, python_version, set_pyth
     """
 
     # We have to use a String value here because bzlmod is passing in a
-    # string as we cannot have list of bools in build rule attribues.
+    # string as we cannot have list of bools in build rule attributes.
     # This if statement does not appear to work unless it is in the
     # toolchain file.
     if set_python_version_constraint in ["True", "False"]:

--- a/python/private/render_pkg_aliases.bzl
+++ b/python/private/render_pkg_aliases.bzl
@@ -544,7 +544,7 @@ def get_filename_config_settings(
             suffixes = target_platforms
         else:
             prefixes = ["{}_{}".format(py, abi)]
-            suffixes = _whl_config_setting_sufixes(
+            suffixes = _whl_config_setting_suffixes(
                 platform_tag = parsed.platform_tag,
                 glibc_versions = glibc_versions,
                 muslc_versions = muslc_versions,
@@ -578,7 +578,7 @@ def get_filename_config_settings(
     else:
         return [":is_{}".format(p) for p in prefixes], setting_supported_versions
 
-def _whl_config_setting_sufixes(
+def _whl_config_setting_suffixes(
         platform_tag,
         glibc_versions,
         muslc_versions,

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -86,7 +86,7 @@ def _execute_internal(
         arguments,
         environment = {},
         **kwargs):
-    """Execute a subprocess with debugging instrumention.
+    """Execute a subprocess with debugging instrumentation.
 
     Args:
         rctx: repository_ctx object

--- a/python/private/zip_main_template.py
+++ b/python/private/zip_main_template.py
@@ -2,7 +2,7 @@
 #
 # NOTE: This file is a "stage 1" bootstrap, so it's responsible for locating the
 # desired runtime and having it run the stage 2 bootstrap. This means it can't
-# assume much about the current runtime and environment. e.g, the current
+# assume much about the current runtime and environment. e.g., the current
 # runtime may not be the correct one, the zip may not have been extract, the
 # runfiles env vars may not be set, etc.
 #


### PR DESCRIPTION
These were found by some Google internal typo checkers

