### PR TITLE
fix: enable auto exec groups using attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ A brief description of the categories of changes:
 
 ### Fixed
 * (bzlmod): Targets in `all_requirements` now use the same form as targets returned by the `requirement` macro.
+* (rules) Auto exec groups are enabled. This allows actions run by the rules,
+  such as precompiling, to pick an execution platform separately from what
+  other toolchains support.
 
 ### Removed
 * Nothing yet

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -361,6 +361,9 @@ in the resulting output or not. Valid values are:
             default = "//python/config_settings:precompile_source_retention",
             providers = [BuildSettingInfo],
         ),
+        # Force enabling auto exec groups, see
+        # https://bazel.build/extending/auto-exec-groups#how-enable-particular-rule
+        "_use_auto_exec_groups": attr.bool(default = True),
     },
     allow_none = True,
 )


### PR DESCRIPTION
This allows the precompile action to resolve its tools separately from other toolchains,
allowing toolchain types with otherwise incompatible `exec_compatible_with` definitions
to be used together.