### PR TITLE
chore: use `**` globs instead of explcit BUILD.bazel reference in distribution filegroups

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -18,8 +18,7 @@ load(":config_settings.bzl", "construct_config_settings")
 
 filegroup(
     name = "distribution",
-    srcs = glob(["*.bzl"]) + [
-        "BUILD.bazel",
+    srcs = glob(["**"]) + [
         "//python/config_settings/private:distribution",
     ],
     visibility = ["//python:__pkg__"],

--- a/python/config_settings/private/BUILD.bazel
+++ b/python/config_settings/private/BUILD.bazel
@@ -1,7 +1,5 @@
 filegroup(
     name = "distribution",
-    srcs = glob(["*.bzl"]) + [
-        "BUILD.bazel",
-    ],
+    srcs = glob(["**"]),
     visibility = ["//python/config_settings:__pkg__"],
 )

--- a/python/entry_points/BUILD.bazel
+++ b/python/entry_points/BUILD.bazel
@@ -32,10 +32,6 @@ bzl_library(
 
 filegroup(
     name = "distribution",
-    srcs = glob([
-        "*.bzl",
-    ]) + [
-        "BUILD.bazel",
-    ],
+    srcs = glob(["**"]),
     visibility = ["//python:__subpackages__"],
 )


### PR DESCRIPTION
This is to make Google patching and imports of rules_python easier. Within Google, `BUILD` is the file name instead of `BUILD.bazel`. It's also easy for the distribution filegroups to accidentally miss files, so to prevent that, just glob everything.
