### PR TITLE
fix: allow creating PyRuntimeInfo without specifying interpreter_version_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ A brief description of the categories of changes:
 * (rules) Auto exec groups are enabled. This allows actions run by the rules,
   such as precompiling, to pick an execution platform separately from what
   other toolchains support.
+* (providers) {obj}`PyRuntimeInfo` doesn't require passing the
+  `interpreter_version_info` arg.
 
 ### Removed
 * Nothing yet

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -41,13 +41,13 @@ def interpreter_version_info_struct_from_dict(info_dict):
     """Create a struct of interpreter version info from a dict from an attribute.
 
     Args:
-        info_dict: dict of versio info fields. See interpreter_version_info
+        info_dict: (dict | None) of version info fields. See interpreter_version_info
             provider field docs.
 
     Returns:
         struct of version info; see interpreter_version_info provider field docs.
     """
-    info_dict = dict(info_dict)  # Copy in case the original is frozen
+    info_dict = dict(info_dict or {})  # Copy in case the original is frozen
     if info_dict:
         if not ("major" in info_dict and "minor" in info_dict):
             fail("interpreter_version_info must have at least two keys, 'major' and 'minor'")

--- a/tests/py_runtime_info/BUILD.bazel
+++ b/tests/py_runtime_info/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":py_runtime_info_tests.bzl", "py_runtime_info_test_suite")
+
+py_runtime_info_test_suite(
+    name = "py_runtime_info_tests",
+)

--- a/tests/py_runtime_info/py_runtime_info_tests.bzl
+++ b/tests/py_runtime_info/py_runtime_info_tests.bzl
@@ -1,0 +1,59 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Starlark tests for PyRuntimeInfo provider."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
+
+def _create_py_runtime_info_without_interpreter_version_info_impl(ctx):
+    return [PyRuntimeInfo(
+        interpreter = ctx.file.interpreter,
+        files = depset(ctx.files.files),
+        python_version = "PY3",
+        bootstrap_template = ctx.attr.bootstrap_template,
+    )]
+
+_create_py_runtime_info_without_interpreter_version_info = rule(
+    implementation = _create_py_runtime_info_without_interpreter_version_info_impl,
+    attrs = {
+        "interpreter": attr.label(allow_single_file = True, default = "interpreter.sh"),
+        "files": attr.label_list(allow_files = True, default = ["data.txt"]),
+        "python_version": attr.string(default = "PY3"),
+        "bootstrap_template": attr.label(allow_single_file = True, default = "bootstrap.txt"),
+    },
+)
+
+_tests = []
+
+def _test_can_create_py_runtime_info_without_interpreter_version_info(name):
+    _create_py_runtime_info_without_interpreter_version_info(
+        name = name + "_subject",
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_can_create_py_runtime_info_without_interpreter_version_info_impl,
+    )
+
+def _test_can_create_py_runtime_info_without_interpreter_version_info_impl(env, target):
+    pass
+
+_tests.append(_test_can_create_py_runtime_info_without_interpreter_version_info)
+
+def py_runtime_info_test_suite(name):
+    test_suite(
+        name = name,
+        tests = _tests,
+    )


### PR DESCRIPTION
This regression was flagged by some of the Bazel tests. When the dict->struct interpreter_version code was factored out, it didn't properly handle the value `None`, which occurs if the provider is directly instantiated (None comes from the initializer default).

To fix, treat None as an empty dict. The logic already assumes the dict is potentially empty or missing keys, so it can continue on OK.

Also adds a test for creating PyRuntimeInfo without this argument.