### PR TITLE
fix: Resolve the test manifest with the runfiles lib.

### DIFF
--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -116,7 +116,7 @@ def gazelle_python_manifest(
         attrs = {
             "env": {
                 "_TEST_MANIFEST": "$(rootpath {})".format(manifest),
-                "_TEST_MANIFEST_GENERATOR_HASH": "$(rootpath {})".format(manifest_generator_hash),
+                "_TEST_MANIFEST_GENERATOR_HASH": "$(rlocationpath {})".format(manifest_generator_hash),
                 "_TEST_REQUIREMENTS": "$(rootpath {})".format(requirements),
             },
             "size": "small",
@@ -130,7 +130,10 @@ def gazelle_python_manifest(
                 manifest_generator_hash,
             ],
             rundir = ".",
-            deps = [Label("//manifest")],
+            deps = [
+                Label("//manifest"),
+                Label("@com_github_bazelbuild_rules_go//go/runfiles"),
+            ],
             # kwargs could contain test-specific attributes like size or timeout
             **dict(attrs, **kwargs)
         )

--- a/gazelle/manifest/test/test.go
+++ b/gazelle/manifest/test/test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/bazelbuild/rules_python/gazelle/manifest"
 )
 
@@ -49,7 +50,12 @@ func TestGazelleManifestIsUpdated(t *testing.T) {
 		t.Fatal("failed to find the Gazelle manifest file integrity")
 	}
 
-	manifestGeneratorHashPath := os.Getenv("_TEST_MANIFEST_GENERATOR_HASH")
+	manifestGeneratorHashPath, err := runfiles.Rlocation(
+		os.Getenv("_TEST_MANIFEST_GENERATOR_HASH"))
+	if err != nil {
+		t.Fatal("failed to resolve runfiles path of manifest: %v", err)
+	}
+
 	manifestGeneratorHash, err := os.Open(manifestGeneratorHashPath)
 	if err != nil {
 		t.Fatalf("opening %q: %v", manifestGeneratorHashPath, err)


### PR DESCRIPTION
This makes it possible for the test to work with sibling repository layout.

Tested by running the :gazelle_python_manifest.test in build_file_generation with all combinations of both values of --legacy_external_runfiles, --enable_bzlmod and --sibling_repository_layout.
