### PR TITLE
fix: Add `configure=True` for internal_config_repo

### DIFF
--- a/python/private/internal_config_repo.bzl
+++ b/python/private/internal_config_repo.bzl
@@ -92,6 +92,7 @@ def _internal_config_repo_impl(rctx):
 
 internal_config_repo = repository_rule(
     implementation = _internal_config_repo_impl,
+    configure = True,
     environ = [_ENABLE_PYSTAR_ENVVAR_NAME],
 )
 


### PR DESCRIPTION
Mark internal_config_repo as `configure = True` so that it won't be vendored by Bazel vendor mode.

https://bazel.build/rules/lib/globals/bzl#parameters_7