### PR TITLE
fix(multiplatform): Add i386 Linux support

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -532,6 +532,17 @@ PLATFORMS = {
         os_name = LINUX_NAME,
         arch = "armv7",
     ),
+    "i386-unknown-linux-gnu": struct(
+        compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:i386",
+        ],
+        flag_values = {
+            Label("//python/config_settings:py_linux_libc"): "glibc",
+        },
+        os_name = LINUX_NAME,
+        arch = "i386",
+    ),
     "ppc64le-unknown-linux-gnu": struct(
         compatible_with = [
             "@platforms//os:linux",


### PR DESCRIPTION
Enable i386 Linux platform detection support.

Without this change `rules_python` complains about an unrecognized platform when run on a 32-bit platform, e.g. where `os.uname().machine` returns `i686`. This effectively makes `rules_python` unusable on 32-bit platforms.