### PR TITLE
fix(bzlmod): pass only non-default values to whl_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ A brief description of the categories of changes:
   other toolchains support.
 * (providers) {obj}`PyRuntimeInfo` doesn't require passing the
   `interpreter_version_info` arg.
+* (bzlmod) Correctly pass `isolated`, `quiet` and `timeout` values to `whl_library`
+  and drop the defaults from the lock file.
 
 ### Removed
 * (pip): Removes the `entrypoint` macro that was replaced by `py_console_script_binary` in 0.26.0.

--- a/python/private/bzlmod/pip.bzl
+++ b/python/private/bzlmod/pip.bzl
@@ -239,7 +239,11 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides, group_map, s
             quiet = (pip_attr.quiet, True),
             timeout = (pip_attr.timeout, 600),
         )
-        whl_library_args.update({k: v for k, (v, default) in maybe_args_with_default.items() if v == default})
+        whl_library_args.update({
+            k: v
+            for k, (v, default) in maybe_args_with_default.items()
+            if v != default
+        })
 
         if get_index_urls:
             # TODO @aignas 2024-05-26: move to a separate function


### PR DESCRIPTION
Before this change `isolated`, `quiet` and `timeout` would get dropped
if they were specified to some non-default value. This fixes it.

Work towards #260.
