### PR TITLE
docs: Removes dead link after docs were migrated to sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,9 @@ Documentation for rules_python is at <https://rules-python.readthedocs.io> and i
 
 Examples live in the [examples](examples) directory.
 
-Currently, the core rules build into the Bazel binary, and the symbols in this
-repository are simple aliases. However, we are migrating the rules to Starlark and removing them from the Bazel binary. Therefore, the future-proof way to depend on Python rules is via this repository. See[`Migrating from the Bundled Rules`](#Migrating-from-the-bundled-rules) below.
-
 The core rules are stable. Their implementation in Bazel is subject to Bazel's
 [backward compatibility policy](https://docs.bazel.build/versions/master/backward-compatibility.html).
-Once migrated to rules_python, they may evolve at a different
-rate, but this repository will still follow [semantic versioning](https://semver.org).
+This repository aims to follow [semantic versioning](https://semver.org).
 
 The Bazel community maintains this repository. Neither Google nor the Bazel team provides support for the code. However, this repository is part of the test suite used to vet new Bazel releases. See [How to contribute](CONTRIBUTING.md) page for information on our development workflow.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation for rules_python is at <https://rules-python.readthedocs.io> and i
 
 Examples live in the [examples](examples) directory.
 
-The core rules are stable. Their implementation in Bazel is subject to Bazel's
+The core rules are stable. Their implementation is subject to Bazel's
 [backward compatibility policy](https://docs.bazel.build/versions/master/backward-compatibility.html).
 This repository aims to follow [semantic versioning](https://semver.org).
 


### PR DESCRIPTION
I believe the intended content is now here: https://rules-python.readthedocs.io/en/latest/#migrating-from-the-bundled-rules

Im not sure there is much value linking to that page, but I don't mind. Just let me know.