### PR TITLE
chore: adjust CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,11 @@
 # NB: Last matching rule takes precedence in CODEOWNERS.
 
-* @rickeylev
+* @rickeylev, @aignas
 
 # Directory containing the Gazelle extension and Go code.
 /gazelle/ @f0rmiga
 /examples/build_file_generation/ @f0rmiga
 
-# Toolchains
-/python/repositories.bzl @f0rmiga
-/python/private/toolchains_repo.bzl @f0rmiga
-/python/tests/toolchains/ @f0rmiga
-
 # PyPI integration related code
-/python/private/pypi/ @aignas
-/tests/pypi/ @aignas
+/python/private/pypi/ @groodt
+/tests/pypi/ @groodt


### PR DESCRIPTION
Add @aignas to all code and @groodt to `pypi`. Remove @f0rmiga from
toolchains as the main maintainers have sufficient knowledge about them.

Gazelle plugin ownership should be better, but we can solve it in a
subsequent PR.

PR Instructions/requirements
* Title uses `type: description` format. See CONTRIBUTING.md for types.
  * Common types are: build, docs, feat, fix, refactor, revert, test
  * Update `CHANGELOG.md` as applicable
* Breaking changes include "!" after the type and a "BREAKING CHANGES:"
  section at the bottom.
  See CONTRIBUTING.md for our breaking changes process.
* Body text describes:
  * Why this change is being made, briefly.
  * Before and after behavior, as applicable
  * References issue number, as applicable
* Update docs and tests, as applicable
* Delete these instructions prior to sending the PR
