### PR TITLE
fix: make first default output the executable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ A brief description of the categories of changes:
   `interpreter_version_info` arg.
 * (bzlmod) Correctly pass `isolated`, `quiet` and `timeout` values to `whl_library`
   and drop the defaults from the lock file.
+* (rules) The first element of the default outputs is now the executable again.
 
 ### Removed
 * (pip): Removes the `entrypoint` macro that was replaced by `py_console_script_binary` in 0.26.0.

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -166,9 +166,10 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
         main_py = precompile_result.py_to_pyc_map[main_py]
     direct_pyc_files = depset(precompile_result.pyc_files)
 
-    default_outputs = precompile_result.keep_srcs + precompile_result.pyc_files
     executable = _declare_executable_file(ctx)
-    default_outputs.append(executable)
+    default_outputs = [executable]
+    default_outputs.extend(precompile_result.keep_srcs)
+    default_outputs.extend(precompile_result.pyc_files)
 
     imports = collect_imports(ctx, semantics)
 

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -297,6 +297,15 @@ def _test_files_to_build_impl(env, target):
             "{package}/{test_name}_subject.py",
         ])
 
+        # Convention and historical behavior is that the first default output is
+        # the executable, so verify that is the case.
+        # rules_testing DepsetFileSubject.contains_exactly doesn't provide an
+        # in_order() call, nor access to the underlying depset, so we have to
+        # do things manually.
+        first_default_output = target[DefaultInfo].files.to_list()[0]
+        executable = target[DefaultInfo].files_to_run.executable
+        env.expect.that_file(first_default_output).equals(executable)
+
 def _test_name_cannot_end_in_py(name, config):
     # Bazel 5 will crash with a Java stacktrace when the native Python
     # rules have an error.


### PR DESCRIPTION
This fixes a small change in behavior identified by some Google regression tests. When precompiling was introduced, the target's executable was no longer the first file in the default outputs depset. While that behavior isn't a strong contract, it is the convention with many other rules, and the existing behavior for Bazel 7+.

To fix, put the executable as the first value in the default outputs list. Also adds a test for this behavior.