### PR TITLE
refactor: call a function to define internal pypi flags instead of listcomp

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -10,10 +10,10 @@ load(
 )
 load(
     "//python/private/pypi:flags.bzl",
-    "INTERNAL_FLAGS",
     "UniversalWhlFlag",
     "UseWhlFlag",
     "WhlLibcFlag",
+    "define_pypi_internal_flags",
 )
 load(":config_settings.bzl", "construct_config_settings")
 
@@ -163,14 +163,6 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
-# private pip whl related flags. Their values cannot be changed and they
-# are an implementation detail of how `pip_config_settings` work.
-[
-    string_flag(
-        name = "_internal_pip_" + flag,
-        build_setting_default = "",
-        values = [""],
-        visibility = ["//visibility:public"],
-    )
-    for flag in INTERNAL_FLAGS
-]
+define_pypi_internal_flags(
+    name = "define_pypi_internal_flags",
+)

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -92,7 +92,10 @@ bzl_library(
 bzl_library(
     name = "flags_bzl",
     srcs = ["flags.bzl"],
-    deps = ["//python/private:enum_bzl"],
+    deps = [
+        "//python/private:enum_bzl",
+        "@bazel_skylib//lib:common_settings",
+    ],
 )
 
 bzl_library(

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -94,7 +94,7 @@ bzl_library(
     srcs = ["flags.bzl"],
     deps = [
         "//python/private:enum_bzl",
-        "@bazel_skylib//lib:common_settings",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 

--- a/python/private/pypi/flags.bzl
+++ b/python/private/pypi/flags.bzl
@@ -68,3 +68,12 @@ INTERNAL_FLAGS = [
     "whl_pycp3x_abi3",
     "whl_pycp3x_abicp",
 ]
+
+def define_pypi_internal_flags(name):
+    for flag in INTERNAL_FLAGS:
+        string_flag(
+            name = "_internal_pip_" + flag,
+            build_setting_default = "",
+            values = [""],
+            visibility = ["//visibility:public"],
+        )

--- a/python/private/pypi/flags.bzl
+++ b/python/private/pypi/flags.bzl
@@ -18,6 +18,7 @@ NOTE: The transitive loads of this should be kept minimal. This avoids loading
 unnecessary files when all that are needed are flag definitions.
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//python/private:enum.bzl", "enum")
 
 # Determines if we should use whls for third party


### PR DESCRIPTION
This is updated so tooling can more automatically process the files. In particular, it helps tools, like buildozer, process the files, which makes it easier to import the code into Google. This is because there is a named target that buildozer can be told to process, whereas, with a list comprehension, it's an arbitrary chunk of code that has to be patched, without an identifiable label.