### PR TITLE
fix: Fix broken logger statement in parse_requirements.bzl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ A brief description of the categories of changes:
   platform specific wheel and use `experimental_target_platforms`.
   Fixes [#1996](https://github.com/bazelbuild/rules_python/issues/1996).
 * (rules) The first element of the default outputs is now the executable again.
+* (pip) Fixed crash when pypi packages lacked a sha (e.g. yanked packages)
 
 ### Removed
 * (pip): Removes the `entrypoint` macro that was replaced by `py_console_script_binary` in 0.26.0.

--- a/python/private/pypi/parse_requirements.bzl
+++ b/python/private/pypi/parse_requirements.bzl
@@ -449,7 +449,7 @@ def _add_dists(requirement, index_urls, python_version, logger = None):
             continue
 
         if logger:
-            logger.warn("Could not find a whl or an sdist with sha256={}".format(sha256))
+            logger.warn(lambda: "Could not find a whl or an sdist with sha256={}".format(sha256))
 
     yanked = {}
     for dist in whls + [sdist]:


### PR DESCRIPTION
parse_requirements.bzl includes a broken logger statement by passing a string instead of a lambda. The result is that when a hash is no longer available on pypi (say, due to a release being yanked) that rules_python causes Bazel to halt. Since we use Bazel to generate requirements files, this means the only solution is to use non-Bazel tooling to get back to a functional state before then running Bazel tooling to update the requirements file -- all down to a faulty log statement.

This PR corrects the faulty log statement. A more thorough fix might be to update the logger to warn if its invoked with a string instead of a lambda rather than failing.

An example traceback which led to this discovery:
```
ERROR: Traceback (most recent call last):
	File ".../external/rules_python~/python/private/bzlmod/pip.bzl", line 472, column 52, in _pip_impl
		is_hub_reproducible = _create_whl_repos(module_ctx, pip_attr, hub_whl_map, whl_overrides, hub_group_map, simpleapi_cache)
	File ".../external/rules_python~/python/private/bzlmod/pip.bzl", line 187, column 50, in _create_whl_repos
		requirements_by_platform = parse_requirements(
	File ".../external/rules_python~/python/private/parse_requirements.bzl", line 348, column 37, in parse_requirements
		whls, sdist = _add_dists(
	File ".../external/rules_python~/python/private/parse_requirements.bzl", line 452, column 24, in _add_dists
		logger.warn("Could not find a whl or an sdist with sha256={}".format(sha256))
	File ".../external/rules_python~/python/private/repo_utils.bzl", line 78, column 39, in lambda
		warn = lambda message_cb: _log(0, "WARNING", message_cb),
	File ".../external/rules_python~/python/private/repo_utils.bzl", line 72, column 71, in _log
		print("\nrules_python: {}: ".format(level.upper()), message_cb())  # buildifier: disable=print
Error: 'string' object is not callable
```
