### PR TITLE
feat: make py_wheel inherently version aware

### DIFF
--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -25,13 +25,18 @@ load("//python/config_settings/private:py_args.bzl", "py_args")
 load("//python/private:reexports.bzl", "BuiltinPyInfo", "BuiltinPyRuntimeInfo")
 
 def _transition_python_version_impl(_, attr):
-    return {"//python/config_settings:python_version": str(attr.python_version)}
+    if attr.python_version:
+        return {"//python/config_settings:python_version": str(attr.python_version)}
+    else:
+        return {}
 
 _transition_python_version = transition(
     implementation = _transition_python_version_impl,
     inputs = [],
     outputs = ["//python/config_settings:python_version"],
 )
+
+public_trans = _transition_python_version
 
 def _transition_py_impl(ctx):
     target = ctx.attr.target

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -14,6 +14,7 @@
 
 "Implementation of py_wheel rule"
 
+load("//python/config_settings:transition.bzl", "public_trans")
 load("//python/private:stamp.bzl", "is_stamping_enabled")
 load(":py_package.bzl", "py_package_lib")
 load(":py_wheel_normalize_pep440.bzl", "normalize_pep440")
@@ -530,6 +531,11 @@ py_wheel_lib = struct(
     implementation = _py_wheel_impl,
     attrs = _concat_dicts(
         {
+            "python_version": attr.string(),
+            # Required to Opt-in to the transitions feature.
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
             "deps": attr.label_list(
                 doc = """\
 Targets to be included in the distribution.
@@ -566,4 +572,5 @@ For example, a `bazel query` for a user's `py_wheel` macro expands to `py_wheel`
 in the way they expect.
 """,
     attrs = py_wheel_lib.attrs,
+    cfg = public_trans,
 )


### PR DESCRIPTION
This allows building a wheel for multiple Python versions in a single invocation, similar to the version-aware base rules. All that's necessary is to create separate `py_wheel` targets that set the `python_version` attribute appropriately.

Do not submit -- Work in progress