### PR TITLE
[fix] Populating imports even when python_root is current directory

### DIFF
--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -240,6 +240,13 @@ py_libary(
     imports = ["../.."],  # Gazelle adds this
     ...
 )
+
+# in ./src/BUILD.bazel
+py_test(
+    srcs = ["baz_test.py"],
+    imports = ["."],  # This is not needed for "bazel test", but needed for "bazel coverage", when src/baz_test.py imports src/baz.py with "import baz".
+    ...
+)
 ```
 
 [python-packaging-user-guide]: https://github.com/pypa/packaging.python.org/blob/4c86169a/source/tutorials/packaging-projects.rst

--- a/gazelle/python/target.go
+++ b/gazelle/python/target.go
@@ -140,9 +140,6 @@ func (t *targetBuilder) generateImportsAttribute() *targetBuilder {
 	}
 	p, _ := filepath.Rel(t.bzlPackage, t.pythonProjectRoot)
 	p = filepath.Clean(p)
-	if p == "." {
-		return t
-	}
 	t.imports = []string{p}
 	return t
 }

--- a/gazelle/python/testdata/directive_python_default_visibility/test2_default_with_python_root/BUILD.out
+++ b/gazelle/python/testdata/directive_python_default_visibility/test2_default_with_python_root/BUILD.out
@@ -8,5 +8,6 @@ py_library(
         "__init__.py",
         "test2.py",
     ],
+    imports = ["."],
     visibility = ["//test2_default_with_python_root:__subpackages__"],
 )

--- a/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.out
+++ b/gazelle/python/testdata/directive_python_default_visibility/test3_injection/BUILD.out
@@ -9,5 +9,6 @@ py_library(
         "__init__.py",
         "test3.py",
     ],
+    imports = ["."],
     visibility = ["//foo/test3_injection/bar:__pkg__"],
 )

--- a/gazelle/python/testdata/first_party_dependencies/one/BUILD.out
+++ b/gazelle/python/testdata/first_party_dependencies/one/BUILD.out
@@ -5,6 +5,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "one_bin",
     srcs = ["__main__.py"],
+    imports = ["."],
     main = "__main__.py",
     visibility = ["//one:__subpackages__"],
     deps = [

--- a/gazelle/python/testdata/first_party_dependencies/three/BUILD.out
+++ b/gazelle/python/testdata/first_party_dependencies/three/BUILD.out
@@ -5,6 +5,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "three",
     srcs = ["__init__.py"],
+    imports = ["."],
     visibility = ["//three:__subpackages__"],
     deps = [
         "//one/bar",

--- a/gazelle/python/testdata/first_party_dependencies/two/BUILD.out
+++ b/gazelle/python/testdata/first_party_dependencies/two/BUILD.out
@@ -5,6 +5,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "two",
     srcs = ["__init__.py"],
+    imports = ["."],
     visibility = ["//two:__subpackages__"],
     deps = ["//one/foo"],
 )

--- a/gazelle/python/testdata/monorepo/coarse_grained/BUILD.out
+++ b/gazelle/python/testdata/monorepo/coarse_grained/BUILD.out
@@ -15,6 +15,7 @@ py_library(
         "bar/baz/hue.py",
         "foo/__init__.py",
     ],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = ["@root_pip_deps//rootboto3"],
 )
@@ -25,4 +26,5 @@ py_test(
         "bar/bar_test.py",
         "foo/bar/bar_test.py",
     ],
+    imports = ["."],
 )

--- a/gazelle/python/testdata/monorepo/one/BUILD.out
+++ b/gazelle/python/testdata/monorepo/one/BUILD.out
@@ -6,6 +6,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "one_bin",
     srcs = ["__main__.py"],
+    imports = ["."],
     main = "__main__.py",
     visibility = ["//one:__subpackages__"],
     deps = [

--- a/gazelle/python/testdata/monorepo/three/BUILD.out
+++ b/gazelle/python/testdata/monorepo/three/BUILD.out
@@ -9,6 +9,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "three",
     srcs = ["__init__.py"],
+    imports = ["."],
     visibility = ["//three:__subpackages__"],
     deps = [
         "//coarse_grained",

--- a/gazelle/python/testdata/monorepo/two/BUILD.out
+++ b/gazelle/python/testdata/monorepo/two/BUILD.out
@@ -7,6 +7,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "two",
     srcs = ["__init__.py"],
+    imports = ["."],
     visibility = ["//two:__subpackages__"],
     deps = [
         "//one/foo",


### PR DESCRIPTION
`bazel coverage` cannot find modules in the current directory unless the current directory is added to `imports` attribute of py targets (#1260). For regular modules, this is fine because it's generally a good practice to import with fully qualified path from python root. However, this becomes a problem for modules at python root to import each other. For example, when python root is at `src`, and `src/baz_test.py` wants to import `src/baz.py`, we will need `imports = ["."]` for the `py_test` target for `bazel coverage` to work. 
