### PR TITLE
chore: include aignas to PyPI code reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 /examples/build_file_generation/ @f0rmiga
 
 # PyPI integration related code
-/python/private/pypi/ @groodt
-/tests/pypi/ @groodt
+/python/private/pypi/ @aignas @groodt
+/tests/pypi/ @aignas @groodt


### PR DESCRIPTION
It seems that I am not added to PyPI reviewers. After rereading the comment at the top of the file, it makes sense.