### PR TITLE
refactor: use http_archive for the stdlib list

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -31,9 +31,5 @@ use_repo(
 python_stdlib_list = use_extension("//python:extensions.bzl", "python_stdlib_list")
 use_repo(
     python_stdlib_list,
-    "python_stdlib_list_3_10",
-    "python_stdlib_list_3_11",
-    "python_stdlib_list_3_12",
-    "python_stdlib_list_3_8",
-    "python_stdlib_list_3_9",
+    "python_stdlib_list",
 )

--- a/gazelle/deps.bzl
+++ b/gazelle/deps.bzl
@@ -18,7 +18,7 @@ load(
     "@bazel_gazelle//:deps.bzl",
     _go_repository = "go_repository",
 )
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def go_repository(name, **kwargs):
     if name not in native.existing_rules():
@@ -26,35 +26,12 @@ def go_repository(name, **kwargs):
 
 def python_stdlib_list_deps():
     "Fetch python stdlib list dependencies"
-    http_file(
-        name = "python_stdlib_list_3_8",
-        sha256 = "ee6dc367011ff298b906dbaab408940aa57086d5f8f47278f4b7523b9aa13ae3",
-        url = "https://raw.githubusercontent.com/pypi/stdlib-list/8cbc2067a4a0f9eee57fb541e4cd7727724b7db4/stdlib_list/lists/3.8.txt",
-        downloaded_file_path = "3.8.txt",
-    )
-    http_file(
-        name = "python_stdlib_list_3_9",
-        sha256 = "a4340e5ffe2e75bb18f548028cef6e6ac15384c44ae0a776e04dd869da1d1fd7",
-        url = "https://raw.githubusercontent.com/pypi/stdlib-list/8cbc2067a4a0f9eee57fb541e4cd7727724b7db4/stdlib_list/lists/3.9.txt",
-        downloaded_file_path = "3.9.txt",
-    )
-    http_file(
-        name = "python_stdlib_list_3_10",
-        sha256 = "0b867738b78ac98944237de2600093a1c6ef259d1810017e46f01a29f3d199e7",
-        url = "https://raw.githubusercontent.com/pypi/stdlib-list/8cbc2067a4a0f9eee57fb541e4cd7727724b7db4/stdlib_list/lists/3.10.txt",
-        downloaded_file_path = "3.10.txt",
-    )
-    http_file(
-        name = "python_stdlib_list_3_11",
-        sha256 = "3c1dbf991b17178d6ed3772f4fa8f64302feaf9c3385fef328a0c7ab736a79b1",
-        url = "https://raw.githubusercontent.com/pypi/stdlib-list/8cbc2067a4a0f9eee57fb541e4cd7727724b7db4/stdlib_list/lists/3.11.txt",
-        downloaded_file_path = "3.11.txt",
-    )
-    http_file(
-        name = "python_stdlib_list_3_12",
-        sha256 = "6d3d53194218b43ee1d04bf9a4f0b6a9309bb59cdcaddede7d9cfe8b6835d34a",
-        url = "https://raw.githubusercontent.com/pypi/stdlib-list/8cbc2067a4a0f9eee57fb541e4cd7727724b7db4/stdlib_list/lists/3.12.txt",
-        downloaded_file_path = "3.12.txt",
+    http_archive(
+        name = "python_stdlib_list",
+        build_file_content = """exports_files(glob(["stdlib_list/lists/*.txt"]))""",
+        sha256 = "3f6fc8fba0a99ce8fa76c1b794a24f38962f6275ea9d5cfb43a874abe472571e",
+        strip_prefix = "stdlib-list-0.10.0",
+        url = "https://github.com/pypi/stdlib-list/releases/download/v0.10.0/v0.10.0.tar.gz",
     )
 
 def gazelle_deps():

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -52,13 +52,13 @@ copy_file(
     name = "stdlib_list",
     src = select(
         {
-            "@rules_python//python/config_settings:is_python_3.10": "@python_stdlib_list_3_10//file",
-            "@rules_python//python/config_settings:is_python_3.11": "@python_stdlib_list_3_11//file",
-            "@rules_python//python/config_settings:is_python_3.12": "@python_stdlib_list_3_12//file",
-            "@rules_python//python/config_settings:is_python_3.8": "@python_stdlib_list_3_8//file",
-            "@rules_python//python/config_settings:is_python_3.9": "@python_stdlib_list_3_9//file",
+            "@rules_python//python/config_settings:is_python_3.10": "@python_stdlib_list//:stdlib_list/lists/3.10.txt",
+            "@rules_python//python/config_settings:is_python_3.11": "@python_stdlib_list//:stdlib_list/lists/3.11.txt",
+            "@rules_python//python/config_settings:is_python_3.12": "@python_stdlib_list//:stdlib_list/lists/3.12.txt",
+            "@rules_python//python/config_settings:is_python_3.8": "@python_stdlib_list//:stdlib_list/lists/3.8.txt",
+            "@rules_python//python/config_settings:is_python_3.9": "@python_stdlib_list//:stdlib_list/lists/3.9.txt",
             # This is the same behaviour as previously
-            "//conditions:default": "@python_stdlib_list_3_11//file",
+            "//conditions:default": "@python_stdlib_list//:stdlib_list/lists/3.11.txt",
         },
     ),
     out = "stdlib_list.txt",


### PR DESCRIPTION
The `http_file` repo rules relied on Github-specific per-file HTTP API. Change this to use an `http_archive` repo rule, which refers to a simple URL containing the source tarball for stdlib-list.

The release version of pypi/stdlib-list this is now pointing to is [v0.10.0](https://github.com/pypi/stdlib-list/releases/tag/v0.10.0). This tag is slightly older than the original commit it was pointing to (`8cbc2067a4a0f9eee57fb541e4cd7727724b7db4`) but, as discussed in https://github.com/pypi/stdlib-list/issues/122, the only differences are build or doc related, there are no differences in the sources (see the [diff](https://github.com/pypi/stdlib-list/compare/v0.10.0...8cbc2067a4a0f9eee57fb541e4cd7727724b7db4)).

(Creating an associated issue didn't feel particularly useful but happy to do it if it's a mandatory part of the process!)