### PR TITLE
chore: add cxxopt std=c++14 to BCR presubmit config

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -22,5 +22,10 @@ bcr_test_module:
       name: "Run test module"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
+      test_flags:
+        - "--keep_going"
+          # Without these cxxopts, BCR's Mac builds fail
+        - '--cxxopt=-std=c++14'
+        - '--host_cxxopt=-std=c++14'
       test_targets:
         - "//..."


### PR DESCRIPTION
For some unknown reason, the BCR Mac jobs require `-std=c++14` when compiling. Without this, they fail with the error `C++ versions less than C++14 are not supported.`

This only appears to happen in the BCR presubmits.