### PR TITLE
fix(gazelle): Use the correct rules_go label in gazelle/manifest/defs.bzl

### DIFF
--- a/gazelle/manifest/defs.bzl
+++ b/gazelle/manifest/defs.bzl
@@ -132,7 +132,7 @@ def gazelle_python_manifest(
             rundir = ".",
             deps = [
                 Label("//manifest"),
-                Label("@com_github_bazelbuild_rules_go//go/runfiles"),
+                Label("@io_bazel_rules_go//go/runfiles"),
             ],
             # kwargs could contain test-specific attributes like size or timeout
             **dict(attrs, **kwargs)


### PR DESCRIPTION
Fixes #2057.

Commit a1d2e45 (#1993) added a reference to `@com_github_bazelbuild_rules_go`, but the module is already added as `@io_bazel_rules_go`.