### PR TITLE
refactor: Address a few improvements on `uv` toolchain

### DIFF
--- a/python/uv/private/BUILD.bazel
+++ b/python/uv/private/BUILD.bazel
@@ -36,6 +36,9 @@ bzl_library(
     name = "toolchains_repo",
     srcs = ["toolchains_repo.bzl"],
     visibility = ["//python/uv:__subpackages__"],
+    deps = [
+        "//python/private:text_util_bzl",
+    ],
 )
 
 bzl_library(

--- a/python/uv/private/toolchains_repo.bzl
+++ b/python/uv/private/toolchains_repo.bzl
@@ -14,6 +14,8 @@
 
 "Creates a repository to hold toolchains"
 
+load("//python/private:text_util.bzl", "render")
+
 _TOOLCHAIN_TEMPLATE = """
 toolchain(
     name = "{name}",
@@ -33,7 +35,7 @@ def _toolchains_repo_impl(repository_ctx):
             name = toolchain_name,
             toolchain_type = repository_ctx.attr.toolchain_type,
             toolchain_label = toolchain_label,
-            compatible_with = json.encode(toolchain_compatible_with),
+            compatible_with = render.list(toolchain_compatible_with),
         )
 
     repository_ctx.file("BUILD.bazel", build_content)

--- a/python/uv/private/versions.bzl
+++ b/python/uv/private/versions.bzl
@@ -16,49 +16,49 @@
 
 UV_PLATFORMS = {
     "aarch64-apple-darwin": struct(
-        default_repo_name = "rules_python_uv_darwin_aarch64",
+        default_repo_name = "uv_darwin_aarch64",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
     ),
     "aarch64-unknown-linux-gnu": struct(
-        default_repo_name = "rules_python_uv_linux_aarch64",
+        default_repo_name = "uv_linux_aarch64",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
         ],
     ),
     "powerpc64le-unknown-linux-gnu": struct(
-        default_repo_name = "rules_python_uv_linux_ppc",
+        default_repo_name = "uv_linux_ppc",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:ppc",
         ],
     ),
     "s390x-unknown-linux-gnu": struct(
-        default_repo_name = "rules_python_uv_linux_s390x",
+        default_repo_name = "uv_linux_s390x",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:s390x",
         ],
     ),
     "x86_64-apple-darwin": struct(
-        default_repo_name = "rules_python_uv_darwin_x86_64",
+        default_repo_name = "uv_darwin_x86_64",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
     ),
     "x86_64-pc-windows-msvc": struct(
-        default_repo_name = "rules_python_uv_windows_x86_64",
+        default_repo_name = "uv_windows_x86_64",
         compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
     ),
     "x86_64-unknown-linux-gnu": struct(
-        default_repo_name = "rules_python_uv_linux_x86_64",
+        default_repo_name = "uv_linux_x86_64",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",

--- a/python/uv/repositories.bzl
+++ b/python/uv/repositories.bzl
@@ -18,7 +18,6 @@ EXPERIMENTAL: This is experimental and may be removed without notice
 Create repositories for uv toolchain dependencies
 """
 
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//python/uv/private:toolchain_types.bzl", "UV_TOOLCHAIN_TYPE")
 load("//python/uv/private:toolchains_repo.bzl", "uv_toolchains_repo")
 load("//python/uv/private:versions.bzl", "UV_PLATFORMS", "UV_TOOL_VERSIONS")
@@ -98,8 +97,7 @@ def uv_register_toolchains(uv_version = None, register_toolchains = True):
     for platform in UV_PLATFORMS.keys():
         uv_repository_name = UV_PLATFORMS[platform].default_repo_name
 
-        maybe(
-            uv_repository,
+        uv_repository(
             name = uv_repository_name,
             uv_version = uv_version,
             platform = platform,


### PR DESCRIPTION
Follows: https://github.com/bazelbuild/rules_python/pull/1989

Addresses the following:
* Removes usage of `maybe`
* Pretty-print renders some generated *.bazel
* Shorter default_repo_names