### PR TITLE
refactor(internal): move the os/arch detection to repo_utils

### DIFF
--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -46,7 +46,7 @@ def _local_runtime_repo_impl(rctx):
     on_failure = rctx.attr.on_failure
 
     platforms_os_name = repo_utils.get_platforms_os_name(rctx)
-    if not platforms_os_name:
+    if platforms_os_name not in ["linux", "osx", "windows"]:
         if on_failure == "fail":
             fail("Unrecognized host platform '{}': cannot determine OS constraint".format(
                 rctx.os.name,

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -45,22 +45,6 @@ def _local_runtime_repo_impl(rctx):
     logger = repo_utils.logger(rctx)
     on_failure = rctx.attr.on_failure
 
-    platforms_os_name = repo_utils.get_platforms_os_name(rctx)
-    if platforms_os_name not in ["linux", "osx", "windows"]:
-        if on_failure == "fail":
-            fail("Unrecognized host platform '{}': cannot determine OS constraint".format(
-                rctx.os.name,
-            ))
-
-        if on_failure == "warn":
-            logger.warn(lambda: "Unrecognized host platform '{}': cannot determine OS constraint".format(
-                rctx.os.name,
-            ))
-
-        # else, on_failure must be skip
-        rctx.file("BUILD.bazel", _expand_incompatible_template())
-        return
-
     result = _resolve_interpreter_path(rctx)
     if not result.resolved_path:
         if on_failure == "fail":

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -165,6 +165,7 @@ bzl_library(
         ":requirements_files_by_platform_bzl",
         ":whl_target_platforms_bzl",
         "//python/private:normalize_name_bzl",
+        "//python/private:repo_utils_bzl",
     ],
 )
 
@@ -233,8 +234,7 @@ bzl_library(
     name = "pypi_repo_utils_bzl",
     srcs = ["pypi_repo_utils.bzl"],
     deps = [
-        "//python:versions_bzl",
-        "//python/private:toolchains_repo_bzl",
+        "//python/private:repo_utils_bzl",
     ],
 )
 

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -199,7 +199,7 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides, group_map, s
         logger = logger,
     )
 
-    repository_platform = host_platform(module_ctx.os)
+    repository_platform = host_platform(module_ctx)
     for whl_name, requirements in requirements_by_platform.items():
         # We are not using the "sanitized name" because the user
         # would need to guess what name we modified the whl name

--- a/python/private/pypi/parse_requirements.bzl
+++ b/python/private/pypi/parse_requirements.bzl
@@ -235,7 +235,7 @@ def host_platform(ctx):
     """
     return "{}_{}".format(
         repo_utils.get_platforms_os_name(ctx),
-        repo_utils.get_platforms_arch_name(ctx),
+        repo_utils.get_platforms_cpu_name(ctx),
     )
 
 def _add_dists(requirement, index_urls, python_version, logger = None):

--- a/python/private/pypi/parse_requirements.bzl
+++ b/python/private/pypi/parse_requirements.bzl
@@ -27,58 +27,10 @@ behavior.
 """
 
 load("//python/private:normalize_name.bzl", "normalize_name")
+load("//python/private:repo_utils.bzl", "repo_utils")
 load(":index_sources.bzl", "index_sources")
 load(":parse_requirements_txt.bzl", "parse_requirements_txt")
 load(":whl_target_platforms.bzl", "select_whls")
-
-# This includes the vendored _translate_cpu and _translate_os from
-# @platforms//host:extension.bzl at version 0.0.9 so that we don't
-# force the users to depend on it.
-
-def _translate_cpu(arch):
-    if arch in ["i386", "i486", "i586", "i686", "i786", "x86"]:
-        return "x86_32"
-    if arch in ["amd64", "x86_64", "x64"]:
-        return "x86_64"
-    if arch in ["ppc", "ppc64", "ppc64le"]:
-        return "ppc"
-    if arch in ["arm", "armv7l"]:
-        return "arm"
-    if arch in ["aarch64"]:
-        return "aarch64"
-    if arch in ["s390x", "s390"]:
-        return "s390x"
-    if arch in ["mips64el", "mips64"]:
-        return "mips64"
-    if arch in ["riscv64"]:
-        return "riscv64"
-    return arch
-
-def _translate_os(os):
-    if os.startswith("mac os"):
-        return "osx"
-    if os.startswith("freebsd"):
-        return "freebsd"
-    if os.startswith("openbsd"):
-        return "openbsd"
-    if os.startswith("linux"):
-        return "linux"
-    if os.startswith("windows"):
-        return "windows"
-    return os
-
-# TODO @aignas 2024-05-13: consider using the same platform tags as are used in
-# the //python:versions.bzl
-DEFAULT_PLATFORMS = [
-    "linux_aarch64",
-    "linux_arm",
-    "linux_ppc",
-    "linux_s390x",
-    "linux_x86_64",
-    "osx_aarch64",
-    "osx_x86_64",
-    "windows_x86_64",
-]
 
 def parse_requirements(
         ctx,
@@ -271,20 +223,19 @@ def select_requirement(requirements, *, platform):
 
     return maybe_requirement[0]
 
-def host_platform(repository_os):
+def host_platform(ctx):
     """Return a string representation of the repository OS.
 
     Args:
-        repository_os (struct): The `module_ctx.os` or `repository_ctx.os` attribute.
-            See https://bazel.build/rules/lib/builtins/repository_os.html
+        ctx (struct): The `module_ctx` or `repository_ctx` attribute.
 
     Returns:
         The string representation of the platform that we can later used in the `pip`
         machinery.
     """
     return "{}_{}".format(
-        _translate_os(repository_os.name.lower()),
-        _translate_cpu(repository_os.arch.lower()),
+        repo_utils.get_platforms_os_name(ctx),
+        repo_utils.get_platforms_arch_name(ctx),
     )
 
 def _add_dists(requirement, index_urls, python_version, logger = None):

--- a/python/private/pypi/pip_repository.bzl
+++ b/python/private/pypi/pip_repository.bzl
@@ -84,7 +84,7 @@ def _pip_repository_impl(rctx):
     )
     selected_requirements = {}
     options = None
-    repository_platform = host_platform(rctx.os)
+    repository_platform = host_platform(rctx)
     for name, requirements in requirements_by_platform.items():
         r = select_requirement(
             requirements,

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -368,7 +368,7 @@ def _get_platforms_os_name(rctx):
         return "windows"
     return os
 
-def _get_platforms_arch_name(rctx):
+def _get_platforms_cpu_name(rctx):
     """Return the name in @platforms//cpu for the host arch.
 
     Args:
@@ -414,8 +414,8 @@ repo_utils = struct(
     execute_checked = _execute_checked,
     execute_checked_stdout = _execute_checked_stdout,
     execute_unchecked = _execute_unchecked,
+    get_platforms_cpu_name = _get_platforms_cpu_name,
     get_platforms_os_name = _get_platforms_os_name,
-    get_platforms_arch_name = _get_platforms_arch_name,
     getenv = _getenv,
     is_repo_debug_enabled = _is_repo_debug_enabled,
     logger = _logger,

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -341,6 +341,10 @@ def _outputs_to_str(result):
             lines.append("<{} empty>".format(name))
     return "\n".join(lines)
 
+# This includes the vendored _translate_cpu and _translate_os from
+# @platforms//host:extension.bzl at version 0.0.9 so that we don't
+# force the users to depend on it.
+
 def _get_platforms_os_name(rctx):
     """Return the name in @platforms//os for the host os.
 
@@ -348,18 +352,49 @@ def _get_platforms_os_name(rctx):
         rctx: repository_ctx
 
     Returns:
-        `str | None`. The target name if it maps to known platforms
-        value, otherwise None.
+        `str`. The target name.
     """
     os = rctx.os.name.lower()
-    if "linux" in os:
-        return os
-    if "windows" in os:
-        return "windows"
-    if "mac" in os:
-        return "osx"
 
-    return None
+    if os.startswith("mac os"):
+        return "osx"
+    if os.startswith("freebsd"):
+        return "freebsd"
+    if os.startswith("openbsd"):
+        return "openbsd"
+    if os.startswith("linux"):
+        return "linux"
+    if os.startswith("windows"):
+        return "windows"
+    return os
+
+def _get_platforms_arch_name(rctx):
+    """Return the name in @platforms//cpu for the host arch.
+
+    Args:
+        rctx: repository_ctx
+
+    Returns:
+        `str`. The target name.
+    """
+    arch = rctx.os.arch.lower()
+    if arch in ["i386", "i486", "i586", "i686", "i786", "x86"]:
+        return "x86_32"
+    if arch in ["amd64", "x86_64", "x64"]:
+        return "x86_64"
+    if arch in ["ppc", "ppc64", "ppc64le"]:
+        return "ppc"
+    if arch in ["arm", "armv7l"]:
+        return "arm"
+    if arch in ["aarch64"]:
+        return "aarch64"
+    if arch in ["s390x", "s390"]:
+        return "s390x"
+    if arch in ["mips64el", "mips64"]:
+        return "mips64"
+    if arch in ["riscv64"]:
+        return "riscv64"
+    return arch
 
 # TODO: Remove after Bazel 6 support dropped
 def _watch(rctx, *args, **kwargs):
@@ -380,6 +415,7 @@ repo_utils = struct(
     execute_checked_stdout = _execute_checked_stdout,
     execute_unchecked = _execute_unchecked,
     get_platforms_os_name = _get_platforms_os_name,
+    get_platforms_arch_name = _get_platforms_arch_name,
     getenv = _getenv,
     is_repo_debug_enabled = _is_repo_debug_enabled,
     logger = _logger,


### PR DESCRIPTION
This also changes the local_runtime_repo to explicitly check for
supported platforms instead of relying on a `None` value returned by the
helper method. This makes the behaviour exactly the same to the
behaviour before this PR and we can potentially drop the need for the
validation in the future if our local_runtime detection is more robust.

This also makes the platform detectino in `pypi_repo_utils` not depend
on `uname` and only use the `repository_ctx`. Apparently the
`module_ctx.watch` throws an error if one attempts to watch files on the
system (this is left for `repository_rule` it seems and one can only do
`module_ctx.watch` on files within the current workspace. This was
surprising, but could have been worked around by just unifying code.

This splits out things from #2059 and makes the code more succinct.

Work towards #260, #1105, #1868.
