### PR TITLE
fix(sphinxdocs): use Label in the readthedocs_install macro

### DIFF
--- a/sphinxdocs/private/readthedocs.bzl
+++ b/sphinxdocs/private/readthedocs.bzl
@@ -43,6 +43,6 @@ def readthedocs_install(name, docs, **kwargs):
             "$(rlocationpaths {})".format(d)
             for d in docs
         ],
-        deps = ["//python/runfiles"],
+        deps = [Label("//python/runfiles")],
         **kwargs
     )


### PR DESCRIPTION
This just makes it possible to use the macro outside `rules_python`.

Not adding anything to the CHANGELOG as this is not a documented
API.
