### PR TITLE
fix: Fix up search path of bootstrapped Python toolchain dylib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ A brief description of the categories of changes:
   It would work well in cases to reduce merge conflicts.
 
 ### Fixed
+* (rules) Fixes build targets linking against `@rules_python//python/cc:current_py_cc_libs`
+  in host platform builds on macOS, by editing the `LC_ID_DYLIB` field of the hermetic interpreter's
+  `libpython3.x.dylib` using `install_name_tool`, setting it to its absolute path under Bazel's
+  execroot.
 * (rules) Signals are properly received when using {obj}`--bootstrap_impl=script`
   (for non-zip builds).
   ([#2043](https://github.com/bazelbuild/rules_python/issues/2043))

--- a/tests/cc/current_py_cc_libs/BUILD.bazel
+++ b/tests/cc/current_py_cc_libs/BUILD.bazel
@@ -20,12 +20,14 @@ current_py_cc_libs_test_suite(name = "current_py_cc_libs_tests")
 cc_test(
     name = "python_libs_linking_test",
     srcs = ["python_libs_linking_test.cc"],
-    # Mac and Windows fail with linking errors, but its not clear why; someone
-    # with more C + Mac/Windows experience will have to figure it out.
+    # Windows fails with linking errors, but its not clear why; someone
+    # with more C + Windows experience will have to figure it out.
     # - rickeylev@
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:osx": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",
         "@rules_python//python/cc:current_py_cc_libs",


### PR DESCRIPTION
Previously, `//tests/cc/current_py_cc_libs::python_libs_linking_test` failed on macOS because the bootstrapped toolchain's dylib had an incorrect LC_ID_DYLIB field set, pointing to a local directory on the Python standalone build host machine.

To fix, add a small conditional to the Python repository rule patching the LC_ID_DYLIB field of the bootstrapped Python's dylib with its fully qualified file system path. Patching is carried out with macOS's own `install_name_tool`, which is part of the standard macOS dynamic linking toolchain.

Qualifies the mentioned test as executable on Mac, now only Windows linker errors are left to fix.