### PR TITLE
fix: use downloaded archive in sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ A brief description of the categories of changes:
 * (toolchains) Added missing executable permission to
   `//python/runtime_env_toolchains` interpreter script so that it is runnable.
   ([#2085](https://github.com/bazelbuild/rules_python/issues/2085)).
+* (pip) Correctly use the `sdist` downloaded by the bazel downloader when using
+  `experimental_index_url` feature. Fixes
+  [#2091](https://github.com/bazelbuild/rules_python/issues/2090).
 
 ### Added
 * (rules) `PYTHONSAFEPATH` is inherited from the calling environment to allow

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -123,7 +123,7 @@ def _parse_optional_attrs(rctx, args, extra_pip_args = None):
             "--extra_pip_args",
             json.encode(struct(arg = [
                 envsubst(pip_arg, rctx.attr.envsubst, getenv)
-                for pip_arg in rctx.attr.extra_pip_args
+                for pip_arg in extra_pip_args
             ])),
         ]
 


### PR DESCRIPTION
Before this PR the extra arguments added by the `experimental_index_url`
code paths were not used and the `sdist` was being redownloaded every time
we would build from `sdist`.

This PR fixes the code to not ignore the extra args added in
https://github.com/bazelbuild/rules_python/pull/2091/files#diff-c007ed21502bf8ea19b98b3f1b402e7071615f8520e4291b00a71bca2cd451e8R231

Fixes #2090