### PR TITLE
test(toolchain): use flag_values in test platform defs

### DIFF
--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -267,7 +267,7 @@ def _create_toolchain_attr_structs(mod):
                 break
         if register_all:
             arg_structs.extend([
-                _create_toolchain_attrs_struct(tag = struct(python_version = v, configure_coverage_tool = True, is_default = False))
+                _create_toolchain_attrs_struct(python_version = v)
                 for v in TOOL_VERSIONS.keys()
                 if v not in seen_versions
             ])

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -267,7 +267,7 @@ def _create_toolchain_attr_structs(mod):
                 break
         if register_all:
             arg_structs.extend([
-                _create_toolchain_attrs_struct(python_version = v)
+                _create_toolchain_attrs_struct(tag = struct(python_version = v, configure_coverage_tool = True, is_default = False))
                 for v in TOOL_VERSIONS.keys()
                 if v not in seen_versions
             ])

--- a/tests/toolchains/defs.bzl
+++ b/tests/toolchains/defs.bzl
@@ -26,6 +26,7 @@ def define_toolchain_tests(name):
     for platform_key, platform_info in PLATFORMS.items():
         native.config_setting(
             name = "_is_{}".format(platform_key),
+            flag_values = platform_info.flag_values,
             constraint_values = platform_info.compatible_with,
         )
 


### PR DESCRIPTION
This PR uses the `flag_values` from the platform definitions
for the toolchains so that in the future we can distinguish
between `musl` and `glibc` toolchains in our tests.

For now the change is no-op.

As part of this change we are also registering the coverage
tools so that we can run `bazel coverage` with no errors.

See comment on #2095.