### PR TITLE
fix(bzlmod): silence duplicate version registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ A brief description of the categories of changes:
   [#2091](https://github.com/bazelbuild/rules_python/issues/2090).
 * (gazelle) Make `gazelle_python_manifest.update` manual to avoid unnecessary
   network behavior. 
+* (bzlmod): The conflicting toolchains during `python` extension will no longer
+  cause warnings by default. In order to see the warnings for diagnostic purposes
+  set the env var `RULES_PYTHON_REPO_DEBUG_VERBOSITY` to one of `INFO`, `DEBUG` or `TRACE`.
+  Fixes [#1818](https://github.com/bazelbuild/rules_python/issues/1818).
 
 ### Added
 * (rules) `PYTHONSAFEPATH` is inherited from the calling environment to allow

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -132,6 +132,7 @@ bzl_library(
     srcs = ["python.bzl"],
     deps = [
         ":pythons_hub_bzl",
+        ":repo_utils_bzl",
         ":toolchains_repo_bzl",
         ":util_bzl",
         "//python:repositories_bzl",


### PR DESCRIPTION
Before this PR we would warn when non-root modules register interpreter
versions and the owners of root modules would have no way to silence the
warning except for patching rules_python.

This PR reduces the default verbosity of the warning to INFO to avoid
spamming users by default.

Fixes #1818.
