### PR TITLE
fix: use runfiles strategy to get runfiles root

### DIFF
--- a/python/runfiles/runfiles.py
+++ b/python/runfiles/runfiles.py
@@ -95,6 +95,9 @@ class _DirectoryBased:
             raise TypeError()
         self._runfiles_root = path
 
+    def _GetRunfilesDir(self) -> str:
+        return self._runfiles_root
+
     def RlocationChecked(self, path: str) -> str:
         # Use posixpath instead of os.path, because Bazel only creates a runfiles
         # tree on Unix platforms, so `Create()` will only create a directory-based
@@ -118,7 +121,7 @@ class Runfiles:
 
     def __init__(self, strategy: Union[_ManifestBased, _DirectoryBased]) -> None:
         self._strategy = strategy
-        self._python_runfiles_root = _FindPythonRunfilesRoot()
+        self._python_runfiles_root = self._strategy._GetRunfilesDir()
         self._repo_mapping = _ParseRepoMapping(
             strategy.RlocationChecked("_repo_mapping")
         )
@@ -320,19 +323,6 @@ class Runfiles:
 
 # Support legacy imports by defining a private symbol.
 _Runfiles = Runfiles
-
-
-def _FindPythonRunfilesRoot() -> str:
-    """Finds the root of the Python runfiles tree."""
-    root = __file__
-    # Walk up our own runfiles path to the root of the runfiles tree from which
-    # the current file is being run. This path coincides with what the Bazel
-    # Python stub sets up as sys.path[0]. Since that entry can be changed at
-    # runtime, we rederive it here.
-    for _ in range("rules_python/python/runfiles/runfiles.py".count("/") + 1):
-        root = os.path.dirname(root)
-    return root
-
 
 def _ParseRepoMapping(repo_mapping_path: Optional[str]) -> Dict[Tuple[str, str], str]:
     """Parses the repository mapping manifest."""

--- a/tests/runfiles/runfiles_test.py
+++ b/tests/runfiles/runfiles_test.py
@@ -527,7 +527,7 @@ class RunfilesTest(unittest.TestCase):
             expected = ""
         else:
             expected = "rules_python"
-        r = runfiles.Create({"RUNFILES_DIR": "whatever"})
+        r = runfiles.Create({"RUNFILES_DIR": os.environ.get("RUNFILES_DIR")})
         assert r is not None  # mypy doesn't understand the unittest api.
         self.assertEqual(r.CurrentRepository(), expected)
 


### PR DESCRIPTION
When attempting to calculate the current repository, the runfiles helper used a strategy of walking up the current files directory four times, however this fails to correctly resolve the runfiles root when the runfiles helper is consumed via the PyPi package and linked into a virtual environment (the root will be determined to be the venv `lib` directory).

This change makes it so the runfiles root is fetched from the helper strategy, which is either created with the `$RUNFILES_ROOT` environment variable (directory based), or calculates the root via the runfiles manifest (manifest based).

With these changes, the runfiles helper correctly identifies the runfiles root when linked into a Python virtual environment.