### PR TITLE
fix: make versioned rules return both builtin and rules_python providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ A brief description of the categories of changes:
 * (rules) User dependencies come before runtime site-packages when using
   {obj}`--bootstrap_impl=script`.
   ([#2064](https://github.com/bazelbuild/rules_python/issues/2064)).
+* (rules) Version-aware rules now return both `@_builtins` and `@rules_python`
+  providers instead of only one.
+  ([#2114](https://github.com/bazelbuild/rules_python/issues/2114)).
 * (pip) Fixed pypi parse_simpleapi_html function for feeds with package metadata
   containing ">" sign
 * (toolchains) Added missing executable permission to

--- a/tests/config_settings/transition/multi_version_tests.bzl
+++ b/tests/config_settings/transition/multi_version_tests.bzl
@@ -16,7 +16,9 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", rt_util = "util")
+load("//python:py_info.bzl", "PyInfo")
 load("//python/config_settings:transition.bzl", py_binary_transitioned = "py_binary", py_test_transitioned = "py_test")
+load("//python/private:reexports.bzl", "BuiltinPyInfo")  # buildifier: disable=bzl-visibility
 load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
 
 # NOTE @aignas 2024-06-04: we are using here something that is registered in the MODULE.Bazel
@@ -45,7 +47,8 @@ def _test_py_test_with_transition(name):
 
 def _test_py_test_with_transition_impl(env, target):
     # Nothing to assert; we just want to make sure it builds
-    _ = env, target  # @unused
+    env.expect.that_target(target).has_provider(PyInfo)
+    env.expect.that_target(target).has_provider(BuiltinPyInfo)
 
 _tests.append(_test_py_test_with_transition)
 
@@ -65,7 +68,8 @@ def _test_py_binary_with_transition(name):
 
 def _test_py_binary_with_transition_impl(env, target):
     # Nothing to assert; we just want to make sure it builds
-    _ = env, target  # @unused
+    env.expect.that_target(target).has_provider(PyInfo)
+    env.expect.that_target(target).has_provider(BuiltinPyInfo)
 
 _tests.append(_test_py_binary_with_transition)
 


### PR DESCRIPTION
This makes the versioned rules return both the `@builtin` and `@rules_python` provider
objects. This makes the versioned rules more compatible with the non-versioned rules.

Fixes https://github.com/bazelbuild/rules_python/issues/2114