### PR TITLE
docs: move Sphinx object inventory for Bazel under sphinxdocs

### DIFF
--- a/docs/sphinx/BUILD.bazel
+++ b/docs/sphinx/BUILD.bazel
@@ -17,7 +17,7 @@ load("//python:pip.bzl", "compile_pip_requirements")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
 load("//sphinxdocs:readthedocs.bzl", "readthedocs_install")
-load("//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs", "sphinx_inventory")
+load("//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 load("//sphinxdocs:sphinx_stardoc.bzl", "sphinx_stardocs")
 
 # We only build for Linux and Mac because:

--- a/docs/sphinx/BUILD.bazel
+++ b/docs/sphinx/BUILD.bazel
@@ -38,7 +38,6 @@ _TARGET_COMPATIBLE_WITH = select({
 sphinx_docs(
     name = "docs",
     srcs = [
-        ":bazel_inventory",
         ":bzl_api_docs",
     ] + glob(
         include = [
@@ -60,17 +59,12 @@ sphinx_docs(
     renamed_srcs = {
         "//:CHANGELOG.md": "changelog.md",
         "//:CONTRIBUTING.md": "contributing.md",
+        "//sphinxdocs/inventories:bazel_inventory": "bazel_inventory.inv",
     },
     sphinx = ":sphinx-build",
     strip_prefix = package_name() + "/",
     tags = ["docs"],
     target_compatible_with = _TARGET_COMPATIBLE_WITH,
-)
-
-sphinx_inventory(
-    name = "bazel_inventory",
-    src = "bazel_inventory.txt",
-    visibility = ["//:__subpackages__"],
 )
 
 sphinx_stardocs(

--- a/sphinxdocs/inventories/BUILD.bazel
+++ b/sphinxdocs/inventories/BUILD.bazel
@@ -1,0 +1,22 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//sphinxdocs:sphinx.bzl", "sphinx_inventory")
+
+# Inventory for the current Bazel version
+sphinx_inventory(
+    name = "bazel_inventory",
+    src = "bazel_inventory.txt",
+    visibility = ["//visibility:public"],
+)

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -10,7 +10,7 @@ bool bzl:type 1 rules/lib/bool -
 int bzl:type 1 rules/lib/int -
 depset bzl:type 1 rules/lib/depset -
 dict bzl:type 1 rules/lib/dict -
-label bzl:type 1 concepts/labels -
+label bzl:doc 1 concepts/labels -
 attr.bool bzl:type 1 rules/lib/toplevel/attr#bool -
 attr.int bzl:type 1 rules/lib/toplevel/attr#int -
 attr.label bzl:type 1 rules/lib/toplevel/attr#label -

--- a/sphinxdocs/tests/sphinx_stardoc/BUILD.bazel
+++ b/sphinxdocs/tests/sphinx_stardoc/BUILD.bazel
@@ -15,7 +15,7 @@ sphinx_docs(
         "html",
     ],
     renamed_srcs = {
-        "//docs/sphinx:bazel_inventory": "bazel_inventory.inv",
+        "//sphinxdocs/inventories:bazel_inventory": "bazel_inventory.inv",
     },
     sphinx = ":sphinx-build",
     strip_prefix = package_name() + "/",


### PR DESCRIPTION
This moves the inventory file for Bazel objects under the sphinxdocs directory. Inventory
files are the manifest of things that can be cross referenced from some external source.

They're moved under sphinxdocs since these are about Bazel in general and aren't specific
to rules_python.