### PR TITLE
Added arg for free threading support

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -12,6 +12,7 @@ load(
 load(
     "//python/private/pypi:flags.bzl",
     "UniversalWhlFlag",
+    "UseFreeThreadingFlag",
     "UseWhlFlag",
     "WhlLibcFlag",
     "define_pypi_internal_flags",
@@ -169,4 +170,11 @@ string_flag(
 
 define_pypi_internal_flags(
     name = "define_pypi_internal_flags",
+)
+
+string_flag(
+    name = "free_threading",
+    build_setting_default = UseFreeThreadingFlag.NO,
+    values = sorted(UseFreeThreadingFlag.__members__.values()),
+    visibility = ["//visibility:public"],
 )

--- a/python/private/py_exec_tools_toolchain.bzl
+++ b/python/private/py_exec_tools_toolchain.bzl
@@ -43,7 +43,7 @@ py_exec_tools_toolchain = rule(
 Provides a toolchain for build time tools.
 
 This provides `ToolchainInfo` with the following attributes:
-* `exec_tools`: {type}`PyExecToolsInfo` 
+* `exec_tools`: {type}`PyExecToolsInfo`
 * `toolchain_label`: {type}`Label` _only present when `--visibile_for_testing=True`
   for internal testing_. The rule's label; this allows identifying what toolchain
   implmentation was selected for testing purposes.

--- a/python/private/pypi/flags.bzl
+++ b/python/private/pypi/flags.bzl
@@ -70,6 +70,14 @@ INTERNAL_FLAGS = [
     "whl_pycp3x_abicp",
 ]
 
+# Determines if we use CPython with free-threading (disabled GIL)
+#
+# buildifier: disable=name-conventions
+UseFreeThreadingFlag = enum(
+    YES = "yes",
+    NO = "no",
+)
+
 def define_pypi_internal_flags(name):
     for flag in INTERNAL_FLAGS:
         string_flag(

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -357,6 +357,13 @@ def _process_single_version_overrides(*, tag, _fail = fail, default):
             for platform in sha256
         }
 
+    if tag.flag_values:
+        # Normalize flag keys to strings
+        flag_values = {str(k): v for k, v in tag.flag_values.items()}
+        override["flag_values"] = flag_values
+    if tag.suffix:
+        override["suffix"] = tag.suffix
+
     available_versions[tag.python_version] = {k: v for k, v in override.items() if v}
 
     if tag.distutils_content:
@@ -789,6 +796,15 @@ class.
             mandatory = False,
             doc = "The URL template to fetch releases for this Python version. See {attr}`python.single_version_platform_override.urls` for documentation.",
         ),
+        "flag_values": attr.string_dict(
+            mandatory = False,
+            doc = "TODO",
+        ),
+        "suffix": attr.string(
+            mandatory = False,
+            doc = "TODO",
+            default = "",
+        )
     },
 )
 

--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -129,6 +129,12 @@ def python_register_toolchains(
                 )],
             )
 
+        flag_values = tool_versions[python_version].get("flag_values", None)
+        free_threading_label = "@rules_python//python/config_settings:free_threading"
+        free_threading = False
+        if flag_values:
+            free_threading = flag_values.get(free_threading_label, False) == "yes"
+        suffix = tool_versions[python_version].get("suffix", "")
         python_repository(
             name = "{name}_{platform}".format(
                 name = name,
@@ -143,6 +149,7 @@ def python_register_toolchains(
             urls = urls,
             strip_prefix = strip_prefix,
             coverage_tool = coverage_tool,
+            free_threading = free_threading,
             **kwargs
         )
         if register_toolchains:

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -127,11 +127,11 @@ def _python_repository_impl(rctx):
         for patch in patches:
             rctx.patch(patch, strip = rctx.attr.patch_strip)
 
+    ft_postfix = "t" if free_threading else ""
     # Write distutils.cfg to the Python installation.
     if "windows" in platform:
         distutils_path = "Lib/distutils/distutils.cfg"
     else:
-        ft_postfix = "t" if free_threading else ""
         distutils_path = "lib/python{}{}/distutils/distutils.cfg".format(python_short_version, ft_postfix)
     if rctx.attr.distutils:
         rctx.file(distutils_path, rctx.read(rctx.attr.distutils))
@@ -145,7 +145,7 @@ def _python_repository_impl(rctx):
         # dyld lookup errors. To fix, set the full path to the dylib as
         # it appears in the Bazel workspace as its LC_ID_DYLIB using
         # the `install_name_tool` bundled with macOS.
-        dylib = "libpython{}.dylib".format(python_short_version)
+        dylib = "libpython{}{}.dylib".format(python_short_version, ft_postfix)
         repo_utils.execute_checked(
             rctx,
             op = "python_repository.FixUpDyldIdPath",


### PR DESCRIPTION
Description:
- Added free_threading argument to point to correct paths of the headers and the library.

Context:
- Related to https://github.com/google/jax/issues/23073 and building jaxlib with python 3.13 interpreter built with disabled GIL.


cc @vam-google


<!--
PR Instructions/requirements
* Title uses `type: description` format. See CONTRIBUTING.md for types.
  * Common types are: build, docs, feat, fix, refactor, revert, test
  * Update `CHANGELOG.md` as applicable
* Breaking changes include "!" after the type and a "BREAKING CHANGES:"
  section at the bottom.
  See CONTRIBUTING.md for our breaking changes process.
* Body text describes:
  * Why this change is being made, briefly.
  * Before and after behavior, as applicable
  * References issue number, as applicable
* Update docs and tests, as applicable
* Delete these instructions prior to sending the PR
-->