### PR TITLE
feat: allow overriding rules in `whl_library` repository rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,13 @@ A brief description of the categories of changes:
 * (gazelle): Fix incorrect use of `t.Fatal`/`t.Fatalf` in tests.
 
 ### Added
-* Nothing yet
+* (pypi): Add macro wrappers for all of the publicly exposed targets in the
+  `whl_library` repository_rule. This allows users to override rules used to
+  extract whl targets from the `.whl` distributions. This allows `WORKSPACE`
+  and `bzlmod` users to override the load statements. The `WORKSPACE` can pass
+  an extra argument named `override_loads` to the `pip_install` macro from the
+  hub repository, whereas `bzlmod` users have a new attribute `load_symbols` in
+  the `pip.override` tag class. TODO: link to the ticket and add documentation.
 
 ### Removed
 * Nothing yet

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -195,6 +195,12 @@ pip.parse(
 # The patches have to be in the unified-diff format.
 pip.override(
     file = "requests-2.25.1-py2.py3-none-any.whl",
+    # One can also override the loads for better support of using alternative implementations
+    # For allowed values, inspect the error message when typing any unsupported
+    # value as the key of the dictionary.
+    library_symbols = {
+        "py_binary": "@rules_python//python:defs.bzl",
+    },
     patch_strip = 1,
     patches = [
         "@//patches:empty.patch",

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -333,6 +333,7 @@ def _whl_library_impl(rctx):
         group_name = rctx.attr.group_name,
         group_deps = rctx.attr.group_deps,
         data_exclude = rctx.attr.pip_data_exclude,
+        override_loads = rctx.attr.override_loads,
         tags = [
             "pypi_name=" + metadata["name"],
             "pypi_version=" + metadata["version"],
@@ -397,6 +398,15 @@ and the target that we need respectively.
     ),
     "group_name": attr.string(
         doc = "Name of the group, if any.",
+    ),
+    "override_loads": attr.string_dict(
+        doc = """
+The string dictionary for symbols to be used when defining targets within the `whl_library`.
+
+This allows users to override the rules used for particular wheels for better
+support of generating `py_library` from an `sdist` or potentially improve how
+the `whl_filegroup` defines providers.
+""",
     ),
     "repo": attr.string(
         mandatory = True,

--- a/python/private/pypi/whl_library_macros.bzl
+++ b/python/private/pypi/whl_library_macros.bzl
@@ -1,0 +1,114 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate targets for the whl_library macro."""
+
+load("//python:py_library.bzl", "py_library")
+load(":labels.bzl", "DATA_LABEL", "DIST_INFO_LABEL")
+
+def dist_info_filegroup(
+        *,
+        name = DIST_INFO_LABEL,
+        visibility = ["//visibility:public"],
+        native = native):
+    """Generate the dist-info target.
+
+    Args:
+        name: The name for the `dist_info` target.
+        visibility: The visibility of the target.
+        native: The native struct for unit testing.
+    """
+    native.filegroup(
+        name = name,
+        srcs = native.glob(["site-packages/*.dist-info/**"], allow_empty = True),
+        visibility = visibility,
+    )
+
+def data_filegroup(
+        *,
+        name = DATA_LABEL,
+        visibility = ["//visibility:public"],
+        native = native):
+    """Generate the data target.
+
+    Args:
+        name: The name for the `data` target.
+        visibility: The visibility of the target.
+        native: The native struct for unit testing.
+    """
+    native.filegroup(
+        name = name,
+        srcs = native.glob(["data/**"], allow_empty = True),
+        visibility = visibility,
+    )
+
+def whl_file(
+        *,
+        name,
+        deps,
+        srcs,
+        visibility = [],
+        native = native):
+    """Generate the whl target.
+
+    Args:
+        name: None, unused.
+        deps: The whl deps.
+        srcs: The list of whl sources.
+        visibility: The visibility passed to the whl target in order
+            to group dependencies.
+        native: The native struct for unit testing.
+    """
+    native.filegroup(
+        name = name,
+        srcs = srcs,
+        data = deps,
+        visibility = visibility,
+    )
+
+def whl_library(
+        *,
+        name,
+        data,
+        deps,
+        srcs,
+        tags = [],
+        visibility = [],
+        py_library = py_library,
+        native = native):
+    """Generate the targets that are exposed by an extracted whl library.
+
+    Args:
+        name: the name of the library target.
+        data: The py_library data.
+        deps: The py_library dependencies.
+        srcs: The python srcs.
+        tags: The tags set to the py_library target to force rebuilding when
+            the version of the dependencies changes.
+        visibility: The visibility passed to the whl and py_library targets in order
+            to group dependencies.
+        py_library: The py_library rule to use for defining the targets.
+        native: The native struct for unit testing.
+    """
+    py_library(
+        name = name,
+        srcs = srcs,
+        data = data,
+        # This makes this directory a top-level in the python import
+        # search path for anything that depends on this.
+        imports = ["site-packages"],
+        deps = deps,
+        tags = tags,
+        visibility = visibility,
+    )


### PR DESCRIPTION
WIP - this is to discuss an interface for allowing users to better customize
the build process. Once this is defined, we can then implement something for
allowing users to build from source in the build context. That would require
the following missing pieces that should be implemented in other PRs:
- [ ] Using `http_archive` or implement a new `sdist_library` repository rule
  for handling `sdist`.
- [ ] A rudimentary `py_sdist_library` that allows invoking a [PEP518] build
  backend in the build phase.

Related to the discussion in #2118.

[pep518]: https://peps.python.org/pep-0518/
