### PR TITLE
fix: correctly check the arg count in precompiler.py

### DIFF
--- a/tools/precompiler/precompiler.py
+++ b/tools/precompiler/precompiler.py
@@ -48,7 +48,7 @@ def _compile(options: "argparse.Namespace") -> None:
             f"Unknown PycInvalidationMode: {options.invalidation_mode}"
         ) from e
 
-    if len(options.srcs) != len(options.src_names) != len(options.pycs):
+    if not (len(options.srcs) == len(options.src_names) == len(options.pycs)):
         raise AssertionError(
             "Mismatched number of --src, --src_name, and/or --pyc args"
         )


### PR DESCRIPTION
This is supposed to check that all argument counts are equal, but due to an incorrect inversion of the conditional, it was checking that *any* pair of argument counts is equal