### PR TITLE
feat(rules): add PyExecutableInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ A brief description of the categories of changes:
 * (gazelle) Correctly resolve deps that have top-level module overlap with a gazelle_python.yaml dep module
 
 ### Added
-* Nothing yet
+* (rules) Executables provide {obj}`PyExecutableInfo`, which contains
+  executable-specific information useful for packaging an executable or
+  or deriving a new one from the original.
 
 ### Removed
 * Nothing yet

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -84,6 +84,7 @@ sphinx_stardocs(
         "//python:pip_bzl",
         "//python:py_binary_bzl",
         "//python:py_cc_link_params_info_bzl",
+        "//python:py_executable_info_bzl",
         "//python:py_library_bzl",
         "//python:py_runtime_bzl",
         "//python:py_runtime_info_bzl",

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -140,6 +140,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "py_executable_info_bzl",
+    srcs = ["py_executable_info.bzl"],
+    deps = ["//python/private:py_executable_info_bzl"],
+)
+
+bzl_library(
     name = "py_import_bzl",
     srcs = ["py_import.bzl"],
     deps = [":py_info_bzl"],

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -221,6 +221,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "py_executable_info_bzl",
+    srcs = ["py_executable_info.bzl"],
+)
+
+bzl_library(
     name = "py_interpreter_program_bzl",
     srcs = ["py_interpreter_program.bzl"],
     deps = ["@bazel_skylib//rules:common_settings"],

--- a/python/private/common/BUILD.bazel
+++ b/python/private/common/BUILD.bazel
@@ -132,9 +132,11 @@ bzl_library(
         ":providers_bzl",
         ":py_internal_bzl",
         "//python/private:flags_bzl",
+        "//python/private:py_executable_info_bzl",
         "//python/private:rules_cc_srcs_bzl",
         "//python/private:toolchain_types_bzl",
         "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:structs",
         "@bazel_skylib//rules:common_settings",
     ],
 )

--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -1,0 +1,35 @@
+"""Implementation of PyExecutableInfo provider."""
+
+PyExecutableInfo = provider(
+    doc = """
+Information about an executable.
+
+This provider is for executable-specific information (e.g. tests and binaries).
+
+:::{versionadded} 0.36.0
+:::
+""",
+    fields = {
+        "interpreter_path": """
+:type: None | str
+
+Path to the Python interpreter to use for running the executable itself (not the
+bootstrap script). Either an absolute path (which means it is
+platform-specific), or a runfiles-relative path (which means the interpreter
+should be within `runtime_files`)
+""",
+        "main": """
+:type: File
+
+The user-level entry point file. Usually a `.py` file, but may also be `.pyc`
+file if precompiling is enabled.
+""",
+        "runfiles_without_exe": """
+:type: runfiles
+
+The runfiles the program needs, but without the original executable,
+files only added to support the original executable, or files specific to the
+original program.
+""",
+    },
+)

--- a/python/py_executable_info.bzl
+++ b/python/py_executable_info.bzl
@@ -1,0 +1,12 @@
+"""Provider for executable-specific information.
+
+The `PyExecutableInfo` provider contains information about an executable that
+isn't otherwise available from its public attributes or other providers.
+
+It exposes information primarily useful for consumers to package the executable,
+or derive a new executable from the base binary.
+"""
+
+load("//python/private:py_executable_info.bzl", _PyExecutableInfo = "PyExecutableInfo")
+
+PyExecutableInfo = _PyExecutableInfo

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -65,6 +65,13 @@ native.package_name bzl:function 1 rules/lib/toplevel/native#package_name -
 native.package_relative_label bzl:function 1 rules/lib/toplevel/native#package_relative_label -
 native.repo_name bzl:function 1 rules/lib/toplevel/native#repo_name -
 native.repository_name bzl:function 1 rules/lib/toplevel/native#repository_name -
+runfiles bzl:type 1 rules/lib/builtins/runfiles -
+runfiles.empty_filenames bzl:type 1 rules/lib/builtins/runfiles#empty_filenames -
+runfiles.files bzl:type 1 rules/lib/builtins/runfiles#files -
+runfiles.merge bzl:type 1 rules/lib/builtins/runfiles#merge -
+runfiles.merge_all bzl:type 1 rules/lib/builtins/runfiles#merge_all -
+runfiles.root_symlinks bzl:type 1 rules/lib/builtins/runfiles#root_symlinks -
+runfiles.symlinks bzl:type 1 rules/lib/builtins/runfiles#symlinks -
 str bzl:type 1 rules/lib/string -
 struct bzl:type 1 rules/lib/builtins/struct -
 toolchain_type bzl:type 1 ules/lib/builtins/toolchain_type.html -

--- a/tests/support/py_executable_info_subject.bzl
+++ b/tests/support/py_executable_info_subject.bzl
@@ -1,0 +1,70 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyExecutableInfo testing subject."""
+
+load("@rules_testing//lib:truth.bzl", "subjects")
+
+def _py_executable_info_subject_new(info, *, meta):
+    """Creates a new `PyExecutableInfoSubject` for a PyExecutableInfo provider instance.
+
+    Method: PyExecutableInfoSubject.new
+
+    Args:
+        info: The PyExecutableInfo object
+        meta: ExpectMeta object.
+
+    Returns:
+        A `PyExecutableInfoSubject` struct
+    """
+
+    # buildifier: disable=uninitialized
+    public = struct(
+        # go/keep-sorted start
+        actual = info,
+        interpreter_path = lambda *a, **k: _py_executable_info_subject_interpreter_path(self, *a, **k),
+        main = lambda *a, **k: _py_executable_info_subject_main(self, *a, **k),
+        runfiles_without_exe = lambda *a, **k: _py_executable_info_subject_runfiles_without_exe(self, *a, **k),
+        # go/keep-sorted end
+    )
+    self = struct(
+        actual = info,
+        meta = meta,
+    )
+    return public
+
+def _py_executable_info_subject_interpreter_path(self):
+    """Returns a subject for `PyExecutableInfo.interpreter_path`."""
+    return subjects.str(
+        self.actual.interpreter_path,
+        meta = self.meta.derive("interpreter_path()"),
+    )
+
+def _py_executable_info_subject_main(self):
+    """Returns a subject for `PyExecutableInfo.main`."""
+    return subjects.file(
+        self.actual.main,
+        meta = self.meta.derive("main()"),
+    )
+
+def _py_executable_info_subject_runfiles_without_exe(self):
+    """Returns a subject for `PyExecutableInfo.runfiles_without_exe`."""
+    return subjects.runfiles(
+        self.actual.runfiles_without_exe,
+        meta = self.meta.derive("runfiles_without_exe()"),
+    )
+
+# buildifier: disable=name-conventions
+PyExecutableInfoSubject = struct(
+    new = _py_executable_info_subject_new,
+)


### PR DESCRIPTION
The PyExecutableInfo provider exposes executable-specific information that isn't easily accessible outside the target. The main purpose of this provider is to facilitate packaging a binary or deriving a new binary based upon the original.

Within rules_python, this will be used to pull the zip-building logic out of executables and into separate rules. Within Google, this will be used for a similar "package a binary" tool.

Along the way:
* Add runfiles references to sphinx inventory