### PR TITLE
refactor(flags): return FeatureFlagInfo in --python_version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ A brief description of the categories of changes:
 
 ### Changed
 * (gazelle): Update error messages when unable to resolve a dependency to be more human-friendly.
+* (flags) The {obj}`--python_version` flag now also returns
+  {obj}`config_common.FeatureFlagInfo`.
 
 ### Fixed
 * (whl_library): Remove `--no-index` and add `--no-build-isolation` to the

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -7,6 +7,8 @@ File bzl:type 1 rules/lib/File -
 Label bzl:type 1 rules/lib/Label -
 Target bzl:type 1 rules/lib/builtins/Target -
 bool bzl:type 1 rules/lib/bool -
+config_common.FeatureFlagInfo bzl:type 1 rules/lib/toplevel/config_common#FeatureFlagInfo -
+config_common.toolchain_type bzl:function 1 rules/lib/toplevel/config_common#toolchain_type -
 ctx.actions bzl:obj 1 rules/lib/builtins/ctx#actions -
 ctx.aspect_ids bzl:obj 1 rules/lib/builtins/ctx#aspect_ids -
 ctx.attr bzl:obj 1 rules/lib/builtins/ctx#attr -
@@ -65,6 +67,7 @@ native.repo_name bzl:function 1 rules/lib/toplevel/native#repo_name -
 native.repository_name bzl:function 1 rules/lib/toplevel/native#repository_name -
 str bzl:type 1 rules/lib/string -
 struct bzl:type 1 rules/lib/builtins/struct -
+toolchain_type bzl:type 1 ules/lib/builtins/toolchain_type.html -
 Name bzl:type 1 concepts/labels#target-names -
 CcInfo bzl:provider 1 rules/lib/providers/CcInfo -
 CcInfo.linking_context bzl:provider-field 1 rules/lib/providers/CcInfo#linking_context -


### PR DESCRIPTION
Make the `--python_version` flag also return the `FeatureFlagInfo` provider.

There are two reasons to also return the FeatureFlagInfo provider:

First, it allows the flag implementation to change the value and have that value respected
by config_setting() later. This allows, for example, the rule to use custom logic (and
information from things it depends on) to determine the effective flag value.

Secondly, it makes the flag compatible with the Google fork of this rule, which is 
implemented using FeatureFlagInfo, to help eventually converge them.

Along the way, add config_common to the Sphinx Bazel inventory.