### PR TITLE
fix(py_wheel): Avoid reliance on bash in `py_wheel` macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ A brief description of the categories of changes:
 * (gazelle) Correctly resolve deps that have top-level module overlap with a gazelle_python.yaml dep module
 
 ### Added
-* Nothing yet
+* (py_wheel) Removed use of bash to avoid failures on Windows machines which do not
+  have it installed.
 
 ### Removed
 * Nothing yet

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -440,6 +440,12 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "py_wheel_dist",
+    srcs = ["py_wheel_dist.py"],
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "py_console_script_gen_lib",
     srcs = ["py_console_script_gen.py"],

--- a/python/private/py_wheel_dist.py
+++ b/python/private/py_wheel_dist.py
@@ -1,0 +1,41 @@
+"""A utility for generating the output directory for `py_wheel_dist`."""
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--wheel", type=Path, required=True, help="The path to a wheel."
+    )
+    parser.add_argument(
+        "--name_file",
+        type=Path,
+        required=True,
+        help="A file containing the sanitized name of the wheel.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="The output location to copy the wheel to.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """The main entrypoint."""
+    args = parse_args()
+
+    wheel_name = args.name_file.read_text(encoding="utf-8").strip()
+    args.output.mkdir(exist_ok=True, parents=True)
+    shutil.copyfile(args.wheel, args.output / wheel_name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
While trying to modernize an older repo I tried building wheels on windows and ran into a failure:
```
Windows Subsystem for Linux has no installed distributions.

Use 'wsl.exe --list --online' to list available distributions
and 'wsl.exe --install <Distro>' to install.

Distributions can also be installed by visiting the Microsoft Store:
https://aka.ms/wlstore
Errorcode: Bash/Service/CreateInstance/GetDefaultDistro/WSL_E_DEFAULT_DISTRO_NOT_FOUND
```

This appears to be caused by the `py_wheel_dist` rule which gets caught by `//...`. This target should be considered a side-effect/optional target of `py_wheel`. To fix:
1. Mark the target as `manual`, so it's only built when explicitly requested.
2. Implement copying to the directory with a Python program instead of shell, so bash
   isn't required.