### PR TITLE
refactor(sphinxdocs): use bazel label format for internal object tracking

### DIFF
--- a/docs/api/rules_python/python/index.md
+++ b/docs/api/rules_python/python/index.md
@@ -30,7 +30,7 @@ Legacy toolchain; despite its name, it doesn't autodetect anything.
 
 :::{deprecated} 0.34.0
 
-Use {obj}`@rules_python//python/runtime_env_toolchain:all` instead.
+Use {obj}`@rules_python//python/runtime_env_toolchains:all` instead.
 :::
 ::::
 

--- a/docs/api/rules_python/python/runtime_env_toolchains/index.md
+++ b/docs/api/rules_python/python/runtime_env_toolchains/index.md
@@ -1,9 +1,9 @@
 :::{default-domain} bzl
 :::
-:::{bzl:currentfile} //python/runtime_env_toolchain:BUILD.bazel
+:::{bzl:currentfile} //python/runtime_env_toolchains:BUILD.bazel
 :::
 
-# //python/runtime_env_toolchain
+# //python/runtime_env_toolchains
 
 ::::{target} all
 

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -7,6 +7,7 @@ File bzl:type 1 rules/lib/File -
 Label bzl:type 1 rules/lib/Label -
 Target bzl:type 1 rules/lib/builtins/Target -
 bool bzl:type 1 rules/lib/bool -
+callable bzl:type 1 rules/lib/core/function -
 config_common.FeatureFlagInfo bzl:type 1 rules/lib/toplevel/config_common#FeatureFlagInfo -
 config_common.toolchain_type bzl:function 1 rules/lib/toplevel/config_common#toolchain_type -
 ctx.actions bzl:obj 1 rules/lib/builtins/ctx#actions -

--- a/sphinxdocs/private/sphinx.bzl
+++ b/sphinxdocs/private/sphinx.bzl
@@ -272,8 +272,9 @@ def _run_sphinx(ctx, format, source_path, inputs, output_prefix):
         # Not added to run_args because run_args is for debugging
         args.add("--quiet")  # Suppress stdout informational text
 
-    args.add("--jobs", "auto")  # Build in parallel, if possible
-    run_args.extend(("--jobs", "auto"))
+    # Build in parallel, if possible
+    # Don't add to run_args: parallel building breaks interactive debugging
+    args.add("--jobs", "auto")
     args.add("--fresh-env")  # Don't try to use cache files. Bazel can't make use of them.
     run_args.append("--fresh-env")
     args.add("--write-all")  # Write all files; don't try to detect "changed" files

--- a/sphinxdocs/tests/sphinx_stardoc/BUILD.bazel
+++ b/sphinxdocs/tests/sphinx_stardoc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//python:py_test.bzl", "py_test")
 load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
 load("//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 load("//sphinxdocs:sphinx_stardoc.bzl", "sphinx_stardoc", "sphinx_stardocs")
@@ -84,4 +85,11 @@ sphinx_build_binary(
         "@dev_pip//sphinx",
         "@dev_pip//typing_extensions",  # Needed by sphinx_stardoc
     ],
+)
+
+py_test(
+    name = "sphinx_output_test",
+    srcs = ["sphinx_output_test.py"],
+    data = [":docs"],
+    deps = ["@dev_pip//absl_py"],
 )

--- a/sphinxdocs/tests/sphinx_stardoc/bzl_rule.bzl
+++ b/sphinxdocs/tests/sphinx_stardoc/bzl_rule.bzl
@@ -14,7 +14,7 @@ P2 = provider()
 def _impl(ctx):
     _ = ctx  # @unused
 
-my_rule = rule(
+bzl_rule = rule(
     implementation = _impl,
     attrs = {
         "srcs": attr.label(

--- a/sphinxdocs/tests/sphinx_stardoc/index.md
+++ b/sphinxdocs/tests/sphinx_stardoc/index.md
@@ -21,6 +21,6 @@ ibazel build //sphinxdocs/tests/sphinx_stardoc:docs
 :hidden:
 :glob:
 
-*
+**
 genindex
 :::

--- a/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
+++ b/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
@@ -1,0 +1,73 @@
+import importlib.resources
+from xml.etree import ElementTree
+
+from absl.testing import absltest, parameterized
+
+from sphinxdocs.tests import sphinx_stardoc
+
+
+class SphinxOutputTest(parameterized.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._docs = {}
+        self._xmls = {}
+
+    def assert_xref(self, doc, *, text, href):
+        match = self._doc_element(doc).find(f".//*[.='{text}']")
+        if not match:
+            self.fail(f"No element found with {text=}")
+        actual = match.attrib.get("href", "<UNSET>")
+        self.assertEqual(
+            href,
+            actual,
+            msg=f"Unexpected href for {text=}: "
+            + ElementTree.tostring(match).decode("utf8"),
+        )
+
+    def _read_doc(self, doc):
+        doc += ".html"
+        if doc not in self._docs:
+            self._docs[doc] = (
+                importlib.resources.files(sphinx_stardoc)
+                .joinpath("docs/_build/html")
+                .joinpath(doc)
+                .read_text()
+            )
+        return self._docs[doc]
+
+    def _doc_element(self, doc):
+        xml = self._read_doc(doc)
+        if doc not in self._xmls:
+            self._xmls[doc] = ElementTree.fromstring(xml)
+        return self._xmls[doc]
+
+    @parameterized.named_parameters(
+        # fmt: off
+        ("short_func", "myfunc", "function.html#myfunc"),
+        ("short_func_arg", "myfunc.arg1", "function.html#myfunc.arg1"),
+        ("short_rule", "my_rule", "rule.html#my_rule"),
+        ("short_rule_attr", "my_rule.ra1", "rule.html#my_rule.ra1"),
+        ("short_provider", "LangInfo", "provider.html#LangInfo"),
+        ("short_tag_class", "myext.mytag", "module_extension.html#myext.mytag"),
+        ("full_norepo_func", "//lang:function.bzl%myfunc", "function.html#myfunc"),
+        ("full_norepo_func_arg", "//lang:function.bzl%myfunc.arg1", "function.html#myfunc.arg1"),
+        ("full_norepo_rule", "//lang:rule.bzl%my_rule", "rule.html#my_rule"),
+        ("full_norepo_rule_attr", "//lang:rule.bzl%my_rule.ra1", "rule.html#my_rule.ra1"),
+        ("full_norepo_provider", "//lang:provider.bzl%LangInfo", "provider.html#LangInfo"),
+        ("full_norepo_aspect", "//lang:aspect.bzl%myaspect", "aspect.html#myaspect"),
+        ("full_norepo_target", "//lang:relativetarget", "target.html#relativetarget"),
+        ("full_repo_func", "@testrepo//lang:function.bzl%myfunc", "function.html#myfunc"),
+        ("full_repo_func_arg", "@testrepo//lang:function.bzl%myfunc.arg1", "function.html#myfunc.arg1"),
+        ("full_repo_rule", "@testrepo//lang:rule.bzl%my_rule", "rule.html#my_rule"),
+        ("full_repo_rule_attr", "@testrepo//lang:rule.bzl%my_rule.ra1", "rule.html#my_rule.ra1"),
+        ("full_repo_provider", "@testrepo//lang:provider.bzl%LangInfo", "provider.html#LangInfo"),
+        ("full_repo_aspect", "@testrepo//lang:aspect.bzl%myaspect", "aspect.html#myaspect"),
+        ("full_repo_target", "@testrepo//lang:relativetarget", "target.html#relativetarget"),
+        # fmt: on
+    )
+    def test_xrefs(self, text, href):
+        self.assert_xref("xrefs", text=text, href=href)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/sphinxdocs/tests/sphinx_stardoc/xrefs.md
+++ b/sphinxdocs/tests/sphinx_stardoc/xrefs.md
@@ -12,13 +12,14 @@ Various tests of cross referencing support
 * rule: {obj}`my_rule`
 * rule attr: {obj}`my_rule.ra1`
 * provider: {obj}`LangInfo`
+* tag class: {obj}`myext.mytag`
 
 ## Fully qualified label without repo
 
 * function: {obj}`//lang:function.bzl%myfunc`
 * function arg: {obj}`//lang:function.bzl%myfunc.arg1`
 * rule: {obj}`//lang:rule.bzl%my_rule`
-* function: {obj}`//lang:rule.bzl%my_rule.ra1`
+* rule attr: {obj}`//lang:rule.bzl%my_rule.ra1`
 * provider: {obj}`//lang:provider.bzl%LangInfo`
 * aspect: {obj}`//lang:aspect.bzl%myaspect`
 * target: {obj}`//lang:relativetarget`
@@ -32,22 +33,6 @@ Various tests of cross referencing support
 * provider: {obj}`@testrepo//lang:provider.bzl%LangInfo`
 * aspect: {obj}`@testrepo//lang:aspect.bzl%myaspect`
 * target: {obj}`@testrepo//lang:relativetarget`
-
-## Fully qualified dotted name with repo
-
-* function: {obj}`testrepo.lang.function.myfunc`
-* function arg: {obj}`testrepo.lang.function.myfunc.arg1`
-* rule: {obj}`testrepo.lang.rule.my_rule`
-* function: {obj}`testrepo.lang.rule.my_rule.ra1`
-* provider: {obj}`testrepo.lang.provider.LangInfo`
-
-## Fully qualified dotted name without repo
-
-* function: {obj}`lang.function.myfunc`
-* function arg: {obj}`lang.function.myfunc.arg1`
-* rule: {obj}`lang.rule.my_rule`
-* rule attr: {obj}`lang.rule.my_rule.ra1`
-* provider: {obj}`lang.provider.LangInfo`
 
 ## Using origin keys
 


### PR DESCRIPTION
This changes the way objects are tracked to use Bazel label format instead of dotted notation.

The dotted notation was problematic because it was ambiguous. For example, `foo.bar.baz`
could mean `@foo//bar:baz` or `@foo//:bar.bzl%baz`. It also required various internal hacks
to try and "unparse" the dotted notation into the "meaningful" part of an object to use
in various contexts. For example, `//foo:bar` usually means `bar` is the key term to
show, and `//foo:bar.bzl%baz.qux` usually means `qux` or `baz.qux` is the meaningful part.

Also:
* Make referring to things by the bzl-relative symbol names work. e.g. `baz.qux` can be
  used to reference `//foo:bar.bzl%baz.qux`
* Fix the name/referencing of runtime_env_toolchains (it was using singular in the docs)
* Add some more references to bazel inventory
* Omit `--jobs=auto` for `sphinx_run`; multi-job invocations of Sphinx make it difficult
  to interactively run Sphinx for debugging, which is the point of `sphinx_run`
* Add a basic test of cross-references
* Make xrefs for `--name` format force looking in the flag object type. This avoids finding
  objects of a matching name of another object type; e.g "precompile" is both a flag and
  attribute name.
* Cleanup the index entries: now the base name is displayed instead of the full name;
  e.g. "foo (target in //bar)" instead of "//foo:bar (target in //bar:BUILD.bazel)"