### PR TITLE
docs: fix some doc warnings and xrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -767,8 +767,7 @@ Breaking changes:
 
 ### Added
 
-* (bzlmod, entry_point) Added
-  [`py_console_script_binary`](./docs/py_console_script_binary.md), which
+* (bzlmod, entry_point) Added {obj}`py_console_script_binary`, which
   allows adding custom dependencies to a package's entry points and customizing
   the `py_binary` rule used to build it.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,6 +2,5 @@
 
 ```{toctree}
 :glob:
-*
 */index
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ This page contains auto-generated API reference documentation [#f1]_.
 autodoc2_docstring_parser_regexes = [
     (".*", "myst"),
 ]
-
+ 
 # NOTE: The redirects generation will clobber existing files.
 redirects = {
     "api/tools/precompiler/index": "/api/rules_python/tools/precompiler/index.html",

--- a/python/private/pypi/pip_repository.bzl
+++ b/python/private/pypi/pip_repository.bzl
@@ -326,7 +326,9 @@ alias(
 )
 ```
 
-### Vendoring the requirements.bzl file
+:::{rubric} Vendoring the requirements.bzl file
+:heading-level: 3
+:::
 
 In some cases you may not want to generate the requirements.bzl file as a repository rule
 while Bazel is fetching dependencies. For example, if you produce a reusable Bazel module

--- a/sphinxdocs/docs/sphinx-bzl.md
+++ b/sphinxdocs/docs/sphinx-bzl.md
@@ -140,6 +140,16 @@ Refer to a target.
 
 :::{rst:role} bzl:type
 Refer to a type or type expression; can also be used in argument documentation.
+
+```
+def func(arg):
+    """Do stuff
+
+    Args:
+      arg: {type}`int | str` the arg
+    """
+    print(arg + 1)
+```
 :::
 
 ## Special roles
@@ -184,22 +194,6 @@ def func():
       {return-type}`int`
     """
     return 1
-```
-:::
-
-:::{rst:role} bzl:type
-
-Indicates the type of an argument for a function. Use it in the Args doc of
-a function.
-
-```
-def func(arg):
-    """Do stuff
-
-    Args:
-      arg: {type}`int`
-    """
-    print(arg + 1)
 ```
 :::
 


### PR DESCRIPTION
This fixes a few warnings Sphinx emits when processing docs

* Fix py_console_script_binary reference in changelog
* Remove `*` that doesn't match anything in index
* Replace heading with rubric to remove warning about non-consecutive indent
* Remove duplicate bzl:type role definition