### PR TITLE
doc: clarify the precompile attribute affects the local target

### DIFF
--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -278,9 +278,7 @@ attribute.
         ),
         "precompile": attr.string(
             doc = """
-Whether py source files should be precompiled.
-
-See also: {flag}`--precompile` flag, which can override this attribute in some cases.
+Whether py source files **for this target** should be precompiled.
 
 Values:
 
@@ -291,6 +289,15 @@ Values:
 * `disabled`: Don't compile Python source files at build time.
 * `if_generated_source`: Compile Python source files, but only if they're a
   generated file.
+
+:::{seealso}
+
+* The {flag}`--precompile` flag, which can override this attribute in some cases
+  and will affect all targets when building.
+* The {obj}`pyc_collection` attribute for transitively enabling precompiling on
+  a per-target basis.
+* The [Precompiling](precompiling) docs for a guide about using precompiling.
+:::
 """,
             default = PrecompileAttr.INHERIT,
             values = sorted(PrecompileAttr.__members__.values()),


### PR DESCRIPTION
Also mention the pyc_collection attribute and precompiling guide to better guide users on how to use precompiling and use binary-level opt-in.