### PR TITLE
feat(rules): add build_data_file field to PyExecutableInfo

### DIFF
--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -426,7 +426,8 @@ def _get_base_runfiles_for_binary(
         * data_runfiles: The data runfiles
         * runfiles_without_exe: The default runfiles, but without the executable
           or files specific to the original program/executable.
-        * build_data_file: A file with build stamp information if stamping is enabled, otherwise None.
+        * build_data_file: A file with build stamp information if stamping is enabled, otherwise
+          None.
     """
     common_runfiles_depsets = [main_py_files]
 
@@ -466,12 +467,11 @@ def _get_base_runfiles_for_binary(
     data_runfiles = runfiles_with_exe
 
     if is_stamping_enabled(ctx, semantics) and semantics.should_include_build_data(ctx):
-        build_data_runfiles = _create_runfiles_with_build_data(
+        build_data_file, build_data_runfiles = _create_runfiles_with_build_data(
             ctx,
             semantics.get_central_uncachable_version_file(ctx),
             semantics.get_extra_write_build_data_env(ctx),
         )
-        build_data_file = build_data_runfiles.symlinks.to_list()[0].target_file
         default_runfiles = runfiles_with_exe.merge(build_data_runfiles)
     else:
         build_data_file = None
@@ -488,15 +488,15 @@ def _create_runfiles_with_build_data(
         ctx,
         central_uncachable_version_file,
         extra_write_build_data_env):
-    return ctx.runfiles(
-        symlinks = {
-            BUILD_DATA_SYMLINK_PATH: _write_build_data(
-                ctx,
-                central_uncachable_version_file,
-                extra_write_build_data_env,
-            ),
-        },
+    build_data_file = _write_build_data(
+        ctx,
+        central_uncachable_version_file,
+        extra_write_build_data_env,
     )
+    build_data_runfiles = ctx.runfiles(symlinks = {
+        BUILD_DATA_SYMLINK_PATH: build_data_file,
+    })
+    return build_data_file, build_data_runfiles
 
 def _write_build_data(ctx, central_uncachable_version_file, extra_write_build_data_env):
     # TODO: Remove this logic when a central file is always available

--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -10,6 +10,11 @@ This provider is for executable-specific information (e.g. tests and binaries).
 :::
 """,
     fields = {
+        "build_data_file": """
+:type: File
+
+A symlink to build_data.txt if stamping is enabled, otherwise None.
+""",
         "interpreter_path": """
 :type: None | str
 
@@ -30,11 +35,6 @@ file if precompiling is enabled.
 The runfiles the program needs, but without the original executable,
 files only added to support the original executable, or files specific to the
 original program.
-""",
-        "build_data_file": """
-:type: File
-
-A symlink to build_data.txt if stamping is enabled, otherwise None.
 """,
     },
 )

--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -11,7 +11,7 @@ This provider is for executable-specific information (e.g. tests and binaries).
 """,
     fields = {
         "build_data_file": """
-:type: File
+:type: None | File
 
 A symlink to build_data.txt if stamping is enabled, otherwise None.
 """,

--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -31,5 +31,10 @@ The runfiles the program needs, but without the original executable,
 files only added to support the original executable, or files specific to the
 original program.
 """,
+        "build_data_file": """
+:type: File
+
+A symlink to build_data.txt if stamping is enabled, otherwise None.
+""",
     },
 )


### PR DESCRIPTION
PyExecutableInfo was added in https://github.com/bazelbuild/rules_python/pull/2166 with the field `runfiles_without_exe` that intentionally excludes files that are specific to
that target/executable, such as the build data file (which may contain the target name,
or other target-specific information).

However, consuming tools (such as ones used within Google) may need to derive a file from
that build data, override it completely, or be happy with its content as is. To aid that
case, expose it via PyExecutableInfo.