### PR TITLE
docs: add `testing.*` Bazel objects to Sphinx inventory and xref in docs

### DIFF
--- a/python/private/py_exec_tools_info.bzl
+++ b/python/private/py_exec_tools_info.bzl
@@ -48,7 +48,7 @@ when constructing the action invocation for running the precompiler program
 (typically `exec_interpreter`). See the `PyInterpreterProgramInfo` provider docs
 for details on how to construct an invocation.
 
-If `testing.ExecutionInfo` is provided, it will be used to set execution
+If {obj}`testing.ExecutionInfo` is provided, it will be used to set execution
 requirements. This can be used to control persistent worker settings.
 
 The precompiler command line API is:

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -3,9 +3,17 @@
 # Version: 7.3.0
 # The remainder of this file is compressed using zlib
 Action bzl:type 1 rules/lib/Action -
+ExecutionInfo bzl:type 1 rules/lib/providers/ExecutionInfo -
 File bzl:type 1 rules/lib/File -
 Label bzl:type 1 rules/lib/Label -
+RunEnvironmentInfo bzl:type 1 rules/lib/providers/RunEnvironmentInfo -
 Target bzl:type 1 rules/lib/builtins/Target -
+attr.bool bzl:type 1 rules/lib/toplevel/attr#bool -
+attr.int bzl:type 1 rules/lib/toplevel/attr#int -
+attr.label bzl:type 1 rules/lib/toplevel/attr#label -
+attr.label_list bzl:type 1 rules/lib/toplevel/attr#label_list -
+attr.string bzl:type 1 rules/lib/toplevel/attr#string -
+attr.string_list bzl:type 1 rules/lib/toplevel/attr#string_list -
 bool bzl:type 1 rules/lib/bool -
 callable bzl:type 1 rules/lib/core/function -
 config_common.FeatureFlagInfo bzl:type 1 rules/lib/toplevel/config_common#FeatureFlagInfo -
@@ -48,12 +56,6 @@ int bzl:type 1 rules/lib/int -
 depset bzl:type 1 rules/lib/depset -
 dict bzl:type 1 rules/lib/dict -
 label bzl:type 1 concepts/labels -
-attr.bool bzl:type 1 rules/lib/toplevel/attr#bool -
-attr.int bzl:type 1 rules/lib/toplevel/attr#int -
-attr.label bzl:type 1 rules/lib/toplevel/attr#label -
-attr.label_list bzl:type 1 rules/lib/toplevel/attr#label_list -
-attr.string bzl:type 1 rules/lib/toplevel/attr#string -
-attr.string_list bzl:type 1 rules/lib/toplevel/attr#string_list -
 list bzl:type 1 rules/lib/list -
 native.existing_rule bzl:function 1 rules/lib/toplevel/native#existing_rule -
 native.existing_rules bzl:function 1 rules/lib/toplevel/native#existing_rules -
@@ -75,6 +77,10 @@ runfiles.root_symlinks bzl:type 1 rules/lib/builtins/runfiles#root_symlinks -
 runfiles.symlinks bzl:type 1 rules/lib/builtins/runfiles#symlinks -
 str bzl:type 1 rules/lib/string -
 struct bzl:type 1 rules/lib/builtins/struct -
+testing bzl:obj 1 rules/lib/toplevel/testing -
+testing.analysis_test bzl:rule 1 rules/lib/toplevel/testing#analysis_test -
+testing.ExecutionInfo bzl:function 1 rules/lib/toplevel/testing#ExecutionInfo -
+testing.TestEnvironment bzl:function 1 rules/lib/toplevel/testing#TestEnvironment -
 toolchain_type bzl:type 1 ules/lib/builtins/toolchain_type.html -
 Name bzl:type 1 concepts/labels#target-names -
 CcInfo bzl:provider 1 rules/lib/providers/CcInfo -


### PR DESCRIPTION
Also sorts the names in the inventory.
