### PR TITLE
cleanup: remove commented out debug statement in precompile tests

### DIFF
--- a/tests/base_rules/precompile/precompile_tests.bzl
+++ b/tests/base_rules/precompile/precompile_tests.bzl
@@ -302,7 +302,6 @@ def _test_precompiler_action(name):
 _tests.append(_test_precompiler_action)
 
 def _test_precompiler_action_impl(env, target):
-    #env.expect.that_target(target).runfiles().contains_exactly([])
     action = env.expect.that_target(target).action_named("PyCompile")
     action.contains_flag_values([
         ("--optimize", "2"),


### PR DESCRIPTION
This is a stray commented out line that was left over from debugging.