### PR TITLE
fix: allow detecting if `--precompile_source_retention` was specified on the command line

### DIFF
--- a/docs/api/rules_python/python/config_settings/index.md
+++ b/docs/api/rules_python/python/config_settings/index.md
@@ -36,7 +36,7 @@ except for the case of `force_enabled` and `forced_disabled`.
 
 Values:
 
-* `auto`: Automatically decide the effective value based on environment,
+* `auto`: (default) Automatically decide the effective value based on environment,
   target platform, etc.
 * `enabled`: Compile Python source files at build time. Note that
   {bzl:obj}`--precompile_add_to_runfiles` affects how the compiled files are included into
@@ -65,11 +65,17 @@ attribute.
 
 Values:
 
+* `auto`: (default) Automatically decide the effective value based on environment,
+  target platform, etc.
 * `keep_source`: Include the original Python source.
 * `omit_source`: Don't include the orignal py source.
 * `omit_if_generated_source`: Keep the original source if it's a regular source
   file, but omit it if it's a generated file.
+
 :::{versionadded} 0.33.0
+:::
+:::{versionadded} 0.36.0
+The `auto` value
 :::
 ::::
 

--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -58,7 +58,7 @@ string_flag(
 
 string_flag(
     name = "precompile_source_retention",
-    build_setting_default = PrecompileSourceRetentionFlag.KEEP_SOURCE,
+    build_setting_default = PrecompileSourceRetentionFlag.AUTO,
     values = sorted(PrecompileSourceRetentionFlag.__members__.values()),
     # NOTE: Only public because it's an implicit dependency
     visibility = ["//visibility:public"],

--- a/python/private/common/attributes.bzl
+++ b/python/private/common/attributes.bzl
@@ -16,7 +16,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("//python/private:enum.bzl", "enum")
-load("//python/private:flags.bzl", "PrecompileFlag")
+load("//python/private:flags.bzl", "PrecompileFlag", "PrecompileSourceRetentionFlag")
 load("//python/private:reexports.bzl", "BuiltinPyInfo")
 load(":common.bzl", "union_attrs")
 load(":providers.bzl", "PyInfo")
@@ -85,7 +85,7 @@ PrecompileInvalidationModeAttr = enum(
 def _precompile_source_retention_get_effective_value(ctx):
     attr_value = ctx.attr.precompile_source_retention
     if attr_value == PrecompileSourceRetentionAttr.INHERIT:
-        attr_value = ctx.attr._precompile_source_retention_flag[BuildSettingInfo].value
+        attr_value = PrecompileSourceRetentionFlag.get_effective_value(ctx)
 
     if attr_value not in (
         PrecompileSourceRetentionAttr.KEEP_SOURCE,

--- a/python/private/flags.bzl
+++ b/python/private/flags.bzl
@@ -74,10 +74,18 @@ PrecompileFlag = enum(
     get_effective_value = _precompile_flag_get_effective_value,
 )
 
+def _precompile_source_retention_flag_get_effective_value(ctx):
+    value = ctx.attr._precompile_source_retention_flag[BuildSettingInfo].value
+    if value == PrecompileSourceRetentionFlag.AUTO:
+        value = PrecompileSourceRetentionFlag.KEEP_SOURCE
+    return value
+
 # Determines if, when a source file is compiled, if the source file is kept
 # in the resulting output or not.
 # buildifier: disable=name-conventions
 PrecompileSourceRetentionFlag = enum(
+    # Automatically decide the effective value based on environment, etc.
+    AUTO = "auto",
     # Include the original py source in the output.
     KEEP_SOURCE = "keep_source",
     # Don't include the original py source.
@@ -85,6 +93,7 @@ PrecompileSourceRetentionFlag = enum(
     # Keep the original py source if it's a regular source file, but omit it
     # if it's a generated file.
     OMIT_IF_GENERATED_SOURCE = "omit_if_generated_source",
+    get_effective_value = _precompile_source_retention_flag_get_effective_value,
 )
 
 # Determines if a target adds its compiled files to its runfiles. When a target


### PR DESCRIPTION
This defaults the `--precompile_source_retention` flag to a new value, `auto`. The effective default remains the same (`keep_source`).

Having a separate value as the default allows detecting if the value was specified on the command line, which allows distinguishing between "pick for me" vs "I specifically want this behavior".