### PR TITLE
docs: document py_cc_toolchain and py_runtime_pair

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -72,6 +72,8 @@ sphinx_docs(
     deps = [
         ":bzl_api_docs",
         ":py_api_srcs",
+        ":py_cc_toolchain",
+        ":py_runtime_pair",
         "//sphinxdocs/docs:docs_lib",
     ],
 )
@@ -123,8 +125,7 @@ sphinx_stardoc(
 sphinx_stardoc(
     name = "py_runtime_pair",
     src = "//python/private:py_runtime_pair_rule_bzl",
-    prefix = "api/rules_python",
-    public_load_path = "//python:py_runtime_pair.bzl",
+    prefix = "api/rules_python/",
     tags = ["docs"],
     target_compatible_with = _TARGET_COMPATIBLE_WITH,
 )

--- a/python/py_runtime_pair.bzl
+++ b/python/py_runtime_pair.bzl
@@ -25,6 +25,8 @@ _py_runtime_pair = _starlark_impl if IS_BAZEL_6_OR_HIGHER else _bazel_tools_impl
 def py_runtime_pair(name, py2_runtime = None, py3_runtime = None, **attrs):
     """A toolchain rule for Python.
 
+    This is a macro around the underlying {rule}`py_runtime_pair` rule.
+
     This used to wrap up to two Python runtimes, one for Python 2 and one for Python 3.
     However, Python 2 is no longer supported, so it now only wraps a single Python 3
     runtime.


### PR DESCRIPTION
Their doc targets weren't included in the main docs deps list, so they weren't showing up.

Also xref from the py_runtime_pair macro to the underlying rule.
