### PR TITLE
feat: allow py_cc_toolchain libs to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ A brief description of the categories of changes:
 * (gazelle): Update error messages when unable to resolve a dependency to be more human-friendly.
 * (flags) The {obj}`--python_version` flag now also returns
   {obj}`config_common.FeatureFlagInfo`.
+* (toolchains) {obj}`py_cc_toolchain.libs` and {obj}`PyCcToolchainInfo.libs` is
+  optional. This is to support situations where only the Python headers are
+  available.
 
 ### Fixed
 * (whl_library): Remove `--no-index` and add `--no-build-isolation` to the

--- a/python/private/py_cc_toolchain_info.bzl
+++ b/python/private/py_cc_toolchain_info.bzl
@@ -41,9 +41,9 @@ Information about the header files, struct with fields:
     represents).
 """,
         "libs": """\
-:type: struct
+:type: struct | None
 
-Information about C libraries, struct with fields:
+If available, information about C libraries, struct with fields:
   * providers_map: A dict of string to provider instances. The key should be
     a fully qualified name (e.g. `@rules_foo//bar:baz.bzl#MyInfo`) of the
     provider to uniquely identify its type.

--- a/python/private/py_cc_toolchain_rule.bzl
+++ b/python/private/py_cc_toolchain_rule.bzl
@@ -23,6 +23,16 @@ load("@rules_cc//cc:defs.bzl", "CcInfo")
 load(":py_cc_toolchain_info.bzl", "PyCcToolchainInfo")
 
 def _py_cc_toolchain_impl(ctx):
+    if ctx.attr.libs:
+        libs = struct(
+            providers_map = {
+                "CcInfo": ctx.attr.libs[CcInfo],
+                "DefaultInfo": ctx.attr.libs[DefaultInfo],
+            },
+        )
+    else:
+        libs = None
+
     py_cc_toolchain = PyCcToolchainInfo(
         headers = struct(
             providers_map = {
@@ -30,12 +40,7 @@ def _py_cc_toolchain_impl(ctx):
                 "DefaultInfo": ctx.attr.headers[DefaultInfo],
             },
         ),
-        libs = struct(
-            providers_map = {
-                "CcInfo": ctx.attr.libs[CcInfo],
-                "DefaultInfo": ctx.attr.libs[DefaultInfo],
-            },
-        ),
+        libs = libs,
         python_version = ctx.attr.python_version,
     )
     extra_kwargs = {}
@@ -59,7 +64,6 @@ py_cc_toolchain = rule(
             doc = ("Target that provides the Python runtime libraries for linking. " +
                    "Typically this is a cc_library target of `.so` files."),
             providers = [CcInfo],
-            mandatory = True,
         ),
         "python_version": attr.string(
             doc = "The Major.minor Python version, e.g. 3.11",


### PR DESCRIPTION
This is for cases when shared libraries aren't available.
