### PR TITLE
feat: default `py_runtime` version info to `--python_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ A brief description of the categories of changes:
 * (gazelle): Update error messages when unable to resolve a dependency to be more human-friendly.
 * (flags) The {obj}`--python_version` flag now also returns
   {obj}`config_common.FeatureFlagInfo`.
+* (toolchains) When {obj}`py_runtime.interpreter_version_info` isn't specified,
+  the {obj}`--python_version` flag will determine the value. This allows
+  specifying the build-time Python version for the
+  {obj}`runtime_env_toolchains`.
 
 ### Fixed
 * (whl_library): Remove `--no-index` and add `--no-build-isolation` to the

--- a/tests/py_runtime/py_runtime_tests.bzl
+++ b/tests/py_runtime/py_runtime_tests.bzl
@@ -22,6 +22,7 @@ load("//python:py_runtime.bzl", "py_runtime")
 load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
 load("//tests/base_rules:util.bzl", br_util = "util")
 load("//tests/support:py_runtime_info_subject.bzl", "py_runtime_info_subject")
+load("//tests/support:support.bzl", "PYTHON_VERSION")
 
 _tests = []
 
@@ -527,6 +528,31 @@ def _test_interpreter_version_info_parses_values_to_struct_impl(env, target):
     version_info.serial().equals(1)
 
 _tests.append(_test_interpreter_version_info_parses_values_to_struct)
+
+def _test_version_info_from_flag(name):
+    py_runtime(
+        name = name + "_subject",
+        interpreter_version_info = None,
+        interpreter_path = "/bogus",
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_version_info_from_flag_impl,
+        config_settings = {
+            PYTHON_VERSION: "3.12",
+        },
+    )
+
+def _test_version_info_from_flag_impl(env, target):
+    version_info = env.expect.that_target(target).provider(PyRuntimeInfo, factory = py_runtime_info_subject).interpreter_version_info()
+    version_info.major().equals(3)
+    version_info.minor().equals(12)
+    version_info.micro().equals(None)
+    version_info.releaselevel().equals(None)
+    version_info.serial().equals(None)
+
+_tests.append(_test_version_info_from_flag)
 
 def py_runtime_test_suite(name):
     test_suite(

--- a/tests/py_runtime/py_runtime_tests.bzl
+++ b/tests/py_runtime/py_runtime_tests.bzl
@@ -530,6 +530,9 @@ def _test_interpreter_version_info_parses_values_to_struct_impl(env, target):
 _tests.append(_test_interpreter_version_info_parses_values_to_struct)
 
 def _test_version_info_from_flag(name):
+    if not config.enable_pystar:
+        rt_util.skip_test(name)
+        return
     py_runtime(
         name = name + "_subject",
         interpreter_version_info = None,


### PR DESCRIPTION
This changes `py_runtime` to get its interpreter version from the `--python_version` flag if
it wasn't explicitly specified. This is useful in two contexts:

For the runtime env toolchains, a local toolchain, or platform interpreter (basically any
py_runtime without a known version), it allows getting some Python version into the
analysis phase, which allows e.g. precompiling.

For environments using embedded Python, it allows defining fewer (e.g. 1) `py_runtime`
target instead of one for every Python version. This is because `py_runtime` serves a minor
role in such builds.