### PR TITLE
fix: Fix incorrectly generated `Required-Dist` when specifying requirements with markers in extra_requires in py_wheel rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ A brief description of the categories of changes:
   {obj}`--bootstrap_impl=script`. This fixes invocations using non-sandboxed
   test execution with `--enable_runfiles=false --build_runfile_manifests=true`.
   ([#2186](https://github.com/bazelbuild/rules_python/issues/2186)).
+* (py_wheel) Fix incorrectly generated `Required-Dist` when specifying requirements with markers
+  in extra_requires in py_wheel rule.
 
 
 ### Added

--- a/examples/wheel/BUILD.bazel
+++ b/examples/wheel/BUILD.bazel
@@ -333,6 +333,27 @@ py_wheel(
     version = "0.0.1",
 )
 
+py_wheel(
+    name = "extra_requires",
+    distribution = "extra_requires",
+    extra_requires = {"example": [
+        "pyyaml>=6.0.0,!=6.0.1",
+        'toml; (python_version == "3.11" or python_version == "3.12") and python_version != "3.8"',
+        'wheel; python_version == "3.11" or python_version == "3.12" ',
+    ]},
+    python_tag = "py3",
+    # py_wheel can use text files to specify their requirements. This
+    # can be convenient for users of `compile_pip_requirements` who have
+    # granular `requirements.in` files per package.
+    requires = [
+        "tomli>=2.0.0",
+        "starlark",
+        'pytest; python_version != "3.8"',
+    ],
+    version = "0.0.1",
+    deps = [":example_pkg"],
+)
+
 py_test(
     name = "wheel_test",
     srcs = ["wheel_test.py"],
@@ -341,6 +362,7 @@ py_test(
         ":custom_package_root_multi_prefix",
         ":custom_package_root_multi_prefix_reverse_order",
         ":customized",
+        ":extra_requires",
         ":filename_escaping",
         ":minimal_data_files",
         ":minimal_with_py_library",

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -489,6 +489,36 @@ Tag: cp38-abi3-{os_string}_{arch}
                 ],
             )
 
+    def test_extra_requires(self):
+        filename = self._get_path("extra_requires-0.0.1-py3-none-any.whl")
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertAllEntriesHasReproducibleMetadata(zf)
+            metadata_file = None
+            for f in zf.namelist():
+                if os.path.basename(f) == "METADATA":
+                    metadata_file = f
+            self.assertIsNotNone(metadata_file)
+
+            requires = []
+            with zf.open(metadata_file) as fp:
+                for line in fp:
+                    if line.startswith(b"Requires-Dist:"):
+                        requires.append(line.decode("utf-8").strip())
+
+            print(requires)
+            self.assertEqual(
+                [
+                    "Requires-Dist: tomli>=2.0.0",
+                    "Requires-Dist: starlark",
+                    'Requires-Dist: pytest; python_version != "3.8"',
+                    "Requires-Dist: pyyaml!=6.0.1,>=6.0.0; extra == 'example'",
+                    'Requires-Dist: toml; ((python_version == "3.11" or python_version == "3.12") and python_version != "3.8") and extra == \'example\'',
+                    'Requires-Dist: wheel; (python_version == "3.11" or python_version == "3.12") and extra == \'example\'',
+                ],
+                requires,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently, if extra requirements are provided via a file, it is allowed to contain markers, but if it is passed via extra_requires field, it will run into error since the extra in this case is blindly added in the following line in `py_wheel.bzl`
```
metadata_contents.append(
    "Requires-Dist: %s; extra == '%s'" % (requirement, option),
)
```

Thus, this PR adds a post-process for this case, to make it possible to pass something like
```
    extra_requires = {"example": [
        "pyyaml>=6.0.0,!=6.0.1",
        'toml; (python_version == "3.11" or python_version == "3.12") and python_version != "3.8"',
        'wheel; python_version == "3.11" or python_version == "3.12" ',
    ]},
```
to `py_wheel`
