### PR TITLE
wip: set the python_version_flag in the pythons_hub on bzlmod

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("//python:versions.bzl", "MINOR_MAPPING", "TOOL_VERSIONS")
+load("//python/private:config_settings.bzl", "construct_config_settings")
 load(
     "//python/private:flags.bzl",
     "BootstrapImplFlag",
@@ -8,6 +10,7 @@ load(
     "PrecompileSourceRetentionFlag",
     "PycCollectionFlag",
 )
+load("//python/private:python_version_flag.bzl", "flag_values")
 load(
     "//python/private/pypi:flags.bzl",
     "UniversalWhlFlag",
@@ -15,7 +18,11 @@ load(
     "WhlLibcFlag",
     "define_pypi_internal_flags",
 )
-load(":config_settings.bzl", "construct_config_settings")
+
+_VERSION_FLAG_VALUES = flag_values(
+    TOOL_VERSIONS.keys(),
+    MINOR_MAPPING,
+)
 
 filegroup(
     name = "distribution",
@@ -27,6 +34,7 @@ filegroup(
 
 construct_config_settings(
     name = "construct_config_settings",
+    version_flag_values = _VERSION_FLAG_VALUES,
 )
 
 string_flag(

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -79,7 +79,18 @@ bzl_library(
     srcs = ["config_settings.bzl"],
     deps = [
         "//python:versions_bzl",
+        ":bzlmod_enabled_bzl",
+        ":python_version_flag_bzl",
         "@bazel_skylib//lib:selects",
+    ],
+)
+
+bzl_library(
+    name = "python_version_flag_bzl",
+    srcs = ["python_version_flag.bzl"],
+    deps = [
+        "//python:versions_bzl",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 

--- a/python/private/pypi/config_settings.bzl
+++ b/python/private/pypi/config_settings.bzl
@@ -111,7 +111,7 @@ def config_settings(
         is_python = "is_python_{}".format(python_version or "version_unset")
         native.alias(
             name = is_python,
-            actual = Label("//python/config_settings:" + is_python),
+            actual = Label("@pythons_hub//:" + is_python),
             visibility = visibility,
         )
 

--- a/python/private/python_version_flag.bzl
+++ b/python/private/python_version_flag.bzl
@@ -1,0 +1,97 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""python_version related code.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _ver_key(s):
+    major, _, s = s.partition(".")
+    minor, _, s = s.partition(".")
+    micro, _, s = s.partition(".")
+    return (int(major), int(minor), int(micro))
+
+def flag_values(python_versions, minor_mapping):
+    """Construct a map of python_version to a list of toolchain values.
+
+    This mapping maps the concept of a config setting to a list of compatible toolchain versions.
+    For using this in the code, the VERSION_FLAG_VALUES should be used instead.
+
+    Args:
+        python_versions: list of strings; all X.Y.Z python versions.
+        minor_mapping: minor version to full version mapping.
+
+    Returns:
+        A `map[str, list[str]]`. Each key is a python_version flag value. Each value
+        is a list of the python_version flag values that should match when for the
+        `key`. For example:
+        ```
+         "3.8" -> ["3.8", "3.8.1", "3.8.2", ..., "3.8.19"]  # All 3.8 versions
+         "3.8.2" -> ["3.8.2"]  # Only 3.8.2
+         "3.8.19" -> ["3.8.19", "3.8"]  # The latest version should also match 3.8 so
+             as when the `3.8` toolchain is used we just use the latest `3.8` toolchain.
+             this makes the `select("is_python_3.8.19")` work no matter how the user
+             specifies the latest python version to use.
+        ```
+    """
+    ret = {}
+
+    for micro_version in sorted(python_versions, key = _ver_key):
+        minor_version, _, _ = micro_version.rpartition(".")
+
+        # This matches the raw flag value, e.g. --//python/config_settings:python_version=3.8
+        # It's private because matching the concept of e.g. "3.8" value is done
+        # using the `is_python_X.Y` config setting group, which is aware of the
+        # minor versions that could match instead.
+        ret.setdefault(minor_version, [minor_version]).append(micro_version)
+
+        # Ensure that is_python_3.9.8 is matched if python_version is set
+        # to 3.9 if MINOR_MAPPING points to 3.9.8
+        default_micro_version = minor_mapping[minor_version]
+        ret[micro_version] = [micro_version, minor_version] if default_micro_version == micro_version else [micro_version]
+
+    return ret
+
+def _python_version_flag_impl(ctx):
+    value = ctx.build_setting_value
+    if value not in ctx.attr.values:
+        fail((
+            "Invalid --python_version value: {actual}\nAllowed values {allowed}"
+        ).format(
+            actual = value,
+            allowed = ", ".join(sorted(ctx.attr.values)),
+        ))
+
+    return [
+        # BuildSettingInfo is the original provider returned, so continue to
+        # return it for compatibility
+        BuildSettingInfo(value = value),
+        # FeatureFlagInfo is returned so that config_setting respects the value
+        # as returned by this rule instead of as originally seen on the command
+        # line.
+        # It is also for Google compatibility, which expects the FeatureFlagInfo
+        # provider.
+        config_common.FeatureFlagInfo(value = value),
+    ]
+
+python_version_flag = rule(
+    implementation = _python_version_flag_impl,
+    build_setting = config.string(flag = True),
+    attrs = {
+        "values": attr.string_list(
+            doc = "Allowed values.",
+        ),
+    },
+)


### PR DESCRIPTION
This is a quick draft to discuss the structure where:
- `--python_version` is defined within `@rules_python` when `bzlmod` is disabled.
- `--python_version` is defined within `@pythons_hub` when `bzlmod` is enabled.

The later allows us to ensure that we can have the right value enforcement when
the user can add extra toolchains at will.

BREAKING: For backwards compatibility we still have the alias for the config
flag present in `//python/config_settings:python_version`, but we don't have
any `is_python_3.x` any more in there and they are moved to the `@python_hubs`
repository, users have to use those symbols instead.
