### PR TITLE
refactor(whl_library): split out a whl_archive library

### DIFF
--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "ofS5ggL4YnyCZejN3Rimf+XXWMSwuWypjGghv3fbAGY=",
+        "bzlTransitiveDigest": "1bDQNWpsT9RTKFESgSQhveFc1pJC3O2WR4Da72AxwHY=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "LJJOkml9ZwY4i0WJnh+pN5fZUQLciL7hPL27L8kNYeI=",
+        "bzlTransitiveDigest": "LYxwQlMd5T5/ElIYjfsAUrzT8PIJ5JOg4vyLIzcefH8=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "M3PPL9umTVP/yUC+67sXfG+eJZgN3kOQx0ySEMrkFM8=",
+        "bzlTransitiveDigest": "WDcraNnRJKLpmCPDflfOh3A9rKYAZHe4o2toCchdm1M=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -1282,8 +1282,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_musllinux_1_1_aarch64_b9b7a708": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1310,8 +1310,8 @@
             }
           },
           "pip_39_snowballstemmer_py2_none_any_c8e1716e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1338,8 +1338,8 @@
             }
           },
           "pip_39_astroid_py3_none_any_10e0ad5f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1417,8 +1417,8 @@
             }
           },
           "pip_39_tomlkit_py3_none_any_07de26b0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1540,8 +1540,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_manylinux_2_5_x86_64_40e7bc81": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1568,8 +1568,8 @@
             }
           },
           "pip_39_pygments_py3_none_any_13fc09fa": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1694,8 +1694,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_macosx_10_9_x86_64_9eb6caa9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1722,8 +1722,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_manylinux_2_17_x86_64_05fb2117": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1750,8 +1750,8 @@
             }
           },
           "pip_39_websockets_py3_none_any_6681ba9e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1778,8 +1778,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_macosx_10_9_universal2_8023faf4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1834,8 +1834,8 @@
             }
           },
           "pip_39_platformdirs_py3_none_any_1a89a123": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1899,8 +1899,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_win_amd64_510c9dee": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1954,8 +1954,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_manylinux_2_17_aarch64_5773183b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -1982,8 +1982,8 @@
             }
           },
           "pip_39_typing_extensions_py3_none_any_04e5ca03": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2061,8 +2061,8 @@
             }
           },
           "pip_39_yamllint_py2_none_any_89bb5b5a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2117,8 +2117,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_musllinux_1_1_aarch64_1fdf26fa": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2394,8 +2394,8 @@
             }
           },
           "pip_39_packaging_py3_none_any_8c491190": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2579,8 +2579,8 @@
             }
           },
           "pip_39_idna_py2_none_any_b97d804b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2607,8 +2607,8 @@
             }
           },
           "pip_39_pylint_py3_none_any_349c8cd3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2656,8 +2656,8 @@
             }
           },
           "pip_39_jinja2_py3_none_any_bc5dd2ab": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2722,8 +2722,8 @@
             }
           },
           "pip_39_pathspec_py3_none_any_3c95343a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2799,8 +2799,8 @@
             }
           },
           "pip_39_python_magic_py2_none_any_c212960a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2864,8 +2864,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_x86_64_9a3a87cf": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2920,8 +2920,8 @@
             }
           },
           "pip_39_tabulate_py3_none_any_024ca478": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2961,8 +2961,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_manylinux_2_17_aarch64_9dcdfd0e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -2989,8 +2989,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_win_amd64_dee60e1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3017,8 +3017,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_aarch64_21713819": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3094,8 +3094,8 @@
             }
           },
           "pip_39_sphinx_py3_none_any_1e09160a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3187,8 +3187,8 @@
             }
           },
           "pip_39_alabaster_py3_none_any_1ee19aca": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3215,8 +3215,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_musllinux_1_1_x86_64_34aa51c4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3243,8 +3243,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_musllinux_1_1_aarch64_ab4a0df4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3271,8 +3271,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_manylinux_2_17_aarch64_6f1a3f10": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3299,8 +3299,8 @@
             }
           },
           "pip_39_s3cmd_py2_none_any_49cd23d5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3432,8 +3432,8 @@
             }
           },
           "pip_39_imagesize_py2_none_any_0d8d18d0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3460,8 +3460,8 @@
             }
           },
           "pip_39_setuptools_py3_none_any_57f6f22b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3488,8 +3488,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_win_amd64_a899b10e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3516,8 +3516,8 @@
             }
           },
           "pip_39_sphinxcontrib_devhelp_py3_none_any_fe8009ae": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3581,8 +3581,8 @@
             }
           },
           "pip_39_colorama_py2_none_any_4f1d9991": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3609,8 +3609,8 @@
             }
           },
           "pip_39_chardet_py2_none_any_f864054d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3679,8 +3679,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_5_x86_64_18dd842b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3728,8 +3728,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_macosx_10_9_x86_64_6b2b5695": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3784,8 +3784,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_macosx_10_9_x86_64_366c32fe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3812,8 +3812,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_win_amd64_3fd4abcb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3840,8 +3840,8 @@
             }
           },
           "pip_39_wheel_py3_none_any_d236b20e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
               "dep_template": "@pip//{name}:{target}",
@@ -3869,8 +3869,8 @@
             }
           },
           "pip_39_certifi_py3_none_any_92d60375": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3897,8 +3897,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_macosx_11_0_arm64_988635d1": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3946,8 +3946,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_musllinux_1_1_x86_64_97b52894": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -3995,8 +3995,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_macosx_10_9_x86_64_3232822c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4023,8 +4023,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_musllinux_1_1_x86_64_04ac92ad": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4051,8 +4051,8 @@
             }
           },
           "pip_39_sphinxcontrib_jsmath_py2_none_any_2ec2eaeb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4158,8 +4158,8 @@
             }
           },
           "pip_39_importlib_metadata_py3_none_any_66f342cc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4330,8 +4330,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_manylinux_2_17_x86_64_bc1bf292": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4386,8 +4386,8 @@
             }
           },
           "pip_39_tomli_py3_none_any_939de3e7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4414,8 +4414,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_win_amd64_c792ea4e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4442,8 +4442,8 @@
             }
           },
           "pip_39_sphinxcontrib_qthelp_py3_none_any_bf76886e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4598,8 +4598,8 @@
             }
           },
           "pip_39_pylint_print_py3_none_any_a2b2599e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4709,8 +4709,8 @@
             }
           },
           "pip_39_six_py2_none_any_8abb2f1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4737,8 +4737,8 @@
             }
           },
           "pip_39_urllib3_py2_none_any_34b97092": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4765,8 +4765,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_macosx_11_0_arm64_3580dd9c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4863,8 +4863,8 @@
             }
           },
           "pip_39_mccabe_py2_none_any_6c2d30ab": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -4989,8 +4989,8 @@
             }
           },
           "pip_39_wrapt_cp39_cp39_manylinux_2_17_aarch64_9cca3c2c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5017,8 +5017,8 @@
             }
           },
           "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_17_aarch64_2297f08f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5094,8 +5094,8 @@
             }
           },
           "pip_39_python_dateutil_py2_none_any_961d03dc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5266,8 +5266,8 @@
             }
           },
           "pip_39_sphinxcontrib_serializinghtml_py3_none_any_9b36e503": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5313,8 +5313,8 @@
             }
           },
           "pip_39_markupsafe_cp39_cp39_musllinux_1_1_x86_64_0a4e4a1a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5369,8 +5369,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_manylinux_2_5_x86_64_279e5de4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5397,8 +5397,8 @@
             }
           },
           "pip_39_sphinxcontrib_applehelp_py3_none_any_094c4d56": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5434,8 +5434,8 @@
             }
           },
           "pip_39_zipp_py3_none_any_58da6168": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5504,8 +5504,8 @@
             }
           },
           "pip_39_requests_py2_none_any_c210084e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
               "dep_template": "@pip//{name}:{target}",
@@ -5538,8 +5538,8 @@
             }
           },
           "pip_39_docutils_py3_none_any_96f387a2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5566,8 +5566,8 @@
             }
           },
           "pip_39_isort_py3_none_any_c033fd0e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5622,8 +5622,8 @@
             }
           },
           "pip_39_sphinxcontrib_htmlhelp_py3_none_any_8001661c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5659,8 +5659,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_macosx_10_9_universal2_777354ee": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5708,8 +5708,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_manylinux_2_17_s390x_b786eecb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5764,8 +5764,8 @@
             }
           },
           "pip_39_websockets_cp39_cp39_macosx_10_9_x86_64_8c82f119": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5862,8 +5862,8 @@
             }
           },
           "pip_39_pyyaml_cp39_cp39_macosx_11_0_arm64_c8098ddc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5912,8 +5912,8 @@
             }
           },
           "pip_39_dill_py3_none_any_a07ffd23": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -5940,8 +5940,8 @@
             }
           },
           "pip_39_babel_py3_none_any_7077a498": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "zJFm0kuM8gFhTHrwS0DUDjlxIhgwMjQUyJiC5F0wmCc=",
+        "bzlTransitiveDigest": "gSr0uL+iZLkosMvngSbzbnNCpUPE6OjZsxWQcYSZRto=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",
@@ -6154,8 +6154,8 @@
         },
         "generatedRepoSpecs": {
           "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_3548db28": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6220,8 +6220,8 @@
             }
           },
           "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_91fc98ad": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6242,8 +6242,8 @@
             }
           },
           "rules_python_publish_deps_311_requests_py3_none_any_64299f49": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6289,8 +6289,8 @@
             }
           },
           "rules_python_publish_deps_311_readme_renderer_py3_none_any_f67a16ca": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6336,8 +6336,8 @@
             }
           },
           "rules_python_publish_deps_311_idna_py3_none_any_82fee1fc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6356,8 +6356,8 @@
             }
           },
           "rules_python_publish_deps_311_certifi_py3_none_any_c198e21b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6376,8 +6376,8 @@
             }
           },
           "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_18565aa5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6401,8 +6401,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_802fe99c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6421,8 +6421,8 @@
             }
           },
           "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_94411f22": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6443,8 +6443,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_1_x86_64_6d0fbe73": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6465,8 +6465,8 @@
             }
           },
           "rules_python_publish_deps_311_pygments_py3_none_any_fa7bd7bd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6490,8 +6490,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_1_aarch64_3c6048f2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6512,8 +6512,8 @@
             }
           },
           "rules_python_publish_deps_311_bleach_py3_none_any_33c16e33": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6537,8 +6537,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_a1327f28": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6559,8 +6559,8 @@
             }
           },
           "rules_python_publish_deps_311_keyring_py3_none_any_771ed2a9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6609,8 +6609,8 @@
             }
           },
           "rules_python_publish_deps_311_rich_py3_none_any_7c963f0d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6634,8 +6634,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_6ffb03d4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6656,8 +6656,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8c7fe7af": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6700,8 +6700,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_ppc64le_5995f016": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6722,8 +6722,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_887623fe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6769,8 +6769,8 @@
             }
           },
           "rules_python_publish_deps_311_importlib_metadata_py3_none_any_7efb448e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6819,8 +6819,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_x86_64_761e8904": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6841,8 +6841,8 @@
             }
           },
           "rules_python_publish_deps_311_certifi_py3_none_any_4ad3232f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6863,8 +6863,8 @@
             }
           },
           "rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6885,8 +6885,8 @@
             }
           },
           "rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6907,8 +6907,8 @@
             }
           },
           "rules_python_publish_deps_311_idna_py3_none_any_90b77e79": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6929,8 +6929,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_44a64043": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6951,8 +6951,8 @@
             }
           },
           "rules_python_publish_deps_311_urllib3_py2_none_any_75edcdc2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -6993,8 +6993,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_py3_none_any_7e189e2e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7040,8 +7040,8 @@
             }
           },
           "rules_python_publish_deps_311_pywin32_ctypes_py2_none_any_9dc2d991": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7058,8 +7058,8 @@
             }
           },
           "rules_python_publish_deps_311_pkginfo_py3_none_any_4b7a555a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7083,8 +7083,8 @@
             }
           },
           "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_cc4d65ae": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7167,8 +7167,8 @@
             }
           },
           "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7192,8 +7192,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_ce8613be": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7214,8 +7214,8 @@
             }
           },
           "rules_python_publish_deps_311_more_itertools_py3_none_any_250e83d7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7314,8 +7314,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_549a3a73": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7334,8 +7334,8 @@
             }
           },
           "rules_python_publish_deps_311_six_py2_none_any_8abb2f1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7359,8 +7359,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_py3_none_any_3e4d1f65": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7379,8 +7379,8 @@
             }
           },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_1df6fcbf": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7401,8 +7401,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_14e76c0f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7448,8 +7448,8 @@
             }
           },
           "rules_python_publish_deps_311_markdown_it_py_py3_none_any_93de681e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7518,8 +7518,8 @@
             }
           },
           "rules_python_publish_deps_311_twine_py3_none_any_929bc3c2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7568,8 +7568,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_s390x_4a8fcf28": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7615,8 +7615,8 @@
             }
           },
           "rules_python_publish_deps_311_urllib3_py2_none_any_37a03444": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7635,8 +7635,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_79909e27": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7679,8 +7679,8 @@
             }
           },
           "rules_python_publish_deps_311_jaraco_classes_py3_none_any_2353de32": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7704,8 +7704,8 @@
             }
           },
           "rules_python_publish_deps_311_pycparser_py2_none_any_8ee45429": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7819,8 +7819,8 @@
             }
           },
           "rules_python_publish_deps_311_zipp_py3_none_any_83a28fcb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7841,8 +7841,8 @@
             }
           },
           "rules_python_publish_deps_311_docutils_py3_none_any_5e1de4d8": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7891,8 +7891,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_66394663": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7953,8 +7953,8 @@
             }
           },
           "rules_python_publish_deps_311_zipp_py3_none_any_f091755f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -7998,8 +7998,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_0c0a5902": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -8020,8 +8020,8 @@
             }
           },
           "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -8135,8 +8135,8 @@
             }
           },
           "rules_python_publish_deps_311_webencodings_py2_none_any_a0af1213": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -8182,8 +8182,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_aarch64_72966d1b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
@@ -8204,8 +8204,8 @@
             }
           },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_573f6eac": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_archive.bzl",
+            "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,13 +1231,13 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "WDcraNnRJKLpmCPDflfOh3A9rKYAZHe4o2toCchdm1M=",
+        "bzlTransitiveDigest": "MLO1syEGRSULaLo53Waond83pK6lJ02Xuuts7r4ZGUc=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
           "@@rules_python~//python/private/pypi/whl_installer/platform.py": "b944b908b25a2f97d6d9f491504ad5d2507402d7e37c802ee878783f87f2aa11",
           "@@//requirements_lock_3_10.txt": "5e7083982a7e60f34998579a0ae83b520d46ab8f2552cc51337217f024e6def5",
-          "@@rules_python~~internal_deps~pypi__packaging//BUILD.bazel": "8d36246aeefaab4b26fb9c1175cfaf13df5b6f1587e6753f1e78b132bad74795",
+          "@@rules_python~~internal_deps~pypi__packaging//BUILD.bazel": "a9b949c6c578b3a3b2210ac227a226c0118c49df14feed705ae05b513c0c859d",
           "@@//whl_mods/appended_build_content.BUILD": "87745b00382c66e5efbd7cb44a08fc3edbf7fd5099cf593f87599188f1557a9e",
           "@@//requirements_lock_3_9.txt": "6a4990586366467d1e7d56d9f2ec9bafdd7e17fb29dc959aa5a6b0395c22eac7",
           "@@rules_python~~internal_deps~pypi__packaging//packaging-24.0.dist-info/RECORD": "be1aea790359b4c2c9ea83d153c1a57c407742a35b95ee36d00723509f5ed5dd",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "gSr0uL+iZLkosMvngSbzbnNCpUPE6OjZsxWQcYSZRto=",
+        "bzlTransitiveDigest": "+lhcK2Arrl32I8pLn5MbLKD3467Q5Q28NiDlEu+6/ck=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "aRN8izvoiRjhPOf7aNtgRNV1zmpxgD3Hro9oLFjq4XU=",
+        "bzlTransitiveDigest": "3A3ryCt54i3V8X09+w5Qi++pJy8r+TktraCvQjhLmXI=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -5765,7 +5765,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "9Um0aPDQ0+IHxKFh921W9+P3ydelvT3X2BNlh+aVq/Q=",
+        "bzlTransitiveDigest": "AMTh2O7maPRCJ8yIvM7b0bU5uz3pJOv+gtM48FjD0BQ=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "1bDQNWpsT9RTKFESgSQhveFc1pJC3O2WR4Da72AxwHY=",
+        "bzlTransitiveDigest": "M3PPL9umTVP/yUC+67sXfG+eJZgN3kOQx0ySEMrkFM8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "LYxwQlMd5T5/ElIYjfsAUrzT8PIJ5JOg4vyLIzcefH8=",
+        "bzlTransitiveDigest": "zJFm0kuM8gFhTHrwS0DUDjlxIhgwMjQUyJiC5F0wmCc=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "3A3ryCt54i3V8X09+w5Qi++pJy8r+TktraCvQjhLmXI=",
+        "bzlTransitiveDigest": "4930SgGhRFEgB4BtkSYXkHOpotidOWRShVej1pFhi2U=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -5657,11 +5657,6 @@
           ],
           [
             "rules_python~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "rules_python~",
             "bazel_tools",
             "bazel_tools"
           ],
@@ -5765,7 +5760,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "AMTh2O7maPRCJ8yIvM7b0bU5uz3pJOv+gtM48FjD0BQ=",
+        "bzlTransitiveDigest": "5SzV3MKyZjOI7Rv2Of+4aLrFwWy5f2XPXIjTu44wYV0=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",
@@ -7911,11 +7906,6 @@
             "rules_python~",
             "bazel_features",
             "bazel_features~"
-          ],
-          [
-            "rules_python~",
-            "bazel_skylib",
-            "bazel_skylib~"
           ],
           [
             "rules_python~",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "i/gPpKGupvoZ+7kLWS87kovxSn2HFqNYO5BeYBQ7fB8=",
+        "bzlTransitiveDigest": "aRN8izvoiRjhPOf7aNtgRNV1zmpxgD3Hro9oLFjq4XU=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -1258,9 +1258,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1286,9 +1283,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1314,9 +1308,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1342,9 +1333,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1421,9 +1409,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1449,9 +1434,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1486,9 +1468,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1544,9 +1523,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1572,9 +1548,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1621,9 +1594,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1670,9 +1640,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1698,9 +1665,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1726,9 +1690,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1754,9 +1715,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1782,9 +1740,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1810,9 +1765,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1838,9 +1790,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1866,9 +1815,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1903,9 +1849,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1958,9 +1901,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -1986,9 +1926,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2065,9 +2002,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2093,9 +2027,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2121,9 +2052,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2149,9 +2077,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2186,9 +2111,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2256,9 +2178,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2284,9 +2203,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2312,9 +2228,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2349,9 +2262,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2398,9 +2308,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2447,9 +2354,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2527,9 +2431,6 @@
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2555,9 +2456,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2583,9 +2481,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2611,9 +2506,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2660,9 +2552,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2688,9 +2577,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2726,9 +2612,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2775,9 +2658,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2803,9 +2683,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2831,9 +2708,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2868,9 +2742,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2896,9 +2767,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2924,9 +2792,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2965,9 +2830,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -2993,9 +2855,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3021,9 +2880,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3070,9 +2926,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3098,9 +2951,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3135,9 +2985,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3163,9 +3010,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3191,9 +3035,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3219,9 +3060,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3247,9 +3085,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3275,9 +3110,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3303,9 +3135,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3331,9 +3160,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3359,9 +3185,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3387,9 +3210,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3436,9 +3256,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3464,9 +3281,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3492,9 +3306,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3520,9 +3331,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3557,9 +3365,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3585,9 +3390,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3613,9 +3415,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3683,9 +3482,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3732,9 +3528,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3760,9 +3553,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3788,9 +3578,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3816,9 +3603,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3845,9 +3629,6 @@
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3873,9 +3654,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3901,9 +3679,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3950,9 +3725,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -3999,9 +3771,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4027,9 +3796,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4055,9 +3821,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4134,9 +3897,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4162,9 +3922,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4190,9 +3947,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4334,9 +4088,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4362,9 +4113,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4390,9 +4138,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4418,9 +4163,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4446,9 +4188,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4546,9 +4285,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4574,9 +4310,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4602,9 +4335,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4630,9 +4360,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4659,9 +4386,6 @@
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4713,9 +4437,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4741,9 +4462,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4769,9 +4487,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4818,9 +4533,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4867,9 +4579,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4937,9 +4646,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4965,9 +4671,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -4993,9 +4696,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5021,9 +4721,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5070,9 +4767,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5098,9 +4792,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5156,9 +4847,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5184,9 +4872,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5242,9 +4927,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5270,9 +4952,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5317,9 +4996,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5345,9 +5021,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5373,9 +5046,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5401,9 +5071,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5438,9 +5105,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5509,9 +5173,6 @@
             "attributes": {
               "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5542,9 +5203,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5570,9 +5228,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5598,9 +5253,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5626,9 +5278,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5663,9 +5312,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5712,9 +5358,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5740,9 +5383,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5768,9 +5408,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5838,9 +5475,6 @@
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5866,9 +5500,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5916,9 +5547,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -5944,9 +5572,6 @@
             "ruleClassName": "whl_archive",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
                 "cp39_linux_aarch64",
                 "cp39_linux_arm",
@@ -6140,7 +5765,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "fLE942C4vKZ4x5Nkd5YIehIi72vwxlmQkBXXnHNGj0A=",
+        "bzlTransitiveDigest": "9Um0aPDQ0+IHxKFh921W9+P3ydelvT3X2BNlh+aVq/Q=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "MLO1syEGRSULaLo53Waond83pK6lJ02Xuuts7r4ZGUc=",
+        "bzlTransitiveDigest": "i/gPpKGupvoZ+7kLWS87kovxSn2HFqNYO5BeYBQ7fB8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "+lhcK2Arrl32I8pLn5MbLKD3467Q5Q28NiDlEu+6/ck=",
+        "bzlTransitiveDigest": "fLE942C4vKZ4x5Nkd5YIehIi72vwxlmQkBXXnHNGj0A=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -283,6 +283,24 @@ bzl_library(
 )
 
 bzl_library(
+    name = "whl_archive_bzl",
+    srcs = ["whl_archive.bzl"],
+    deps = [
+        ":attrs_bzl",
+        ":deps_bzl",
+        ":generate_whl_library_build_bazel_bzl",
+        ":parse_whl_name_bzl",
+        ":patch_whl_bzl",
+        ":pypi_repo_utils_bzl",
+        ":whl_target_platforms_bzl",
+        "//python/private:auth_bzl",
+        "//python/private:envsubst_bzl",
+        "//python/private:python_repositories_bzl",
+        "//python/private:repo_utils_bzl",
+    ],
+)
+
+bzl_library(
     name = "whl_library_alias_bzl",
     srcs = ["whl_library_alias.bzl"],
     deps = [
@@ -297,14 +315,11 @@ bzl_library(
     deps = [
         ":attrs_bzl",
         ":deps_bzl",
-        ":generate_whl_library_build_bazel_bzl",
-        ":parse_whl_name_bzl",
-        ":patch_whl_bzl",
         ":pypi_repo_utils_bzl",
-        ":whl_target_platforms_bzl",
-        "//python:repositories_bzl",
+        ":whl_archive_bzl",
         "//python/private:auth_bzl",
         "//python/private:envsubst_bzl",
+        "//python/private:python_repositories_bzl",
         "//python/private:repo_utils_bzl",
     ],
 )

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -245,7 +245,6 @@ bzl_library(
     srcs = ["pypi_repo_utils.bzl"],
     deps = [
         "//python/private:repo_utils_bzl",
-        "@bazel_skylib//lib:types",
     ],
 )
 

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -86,6 +86,7 @@ bzl_library(
     name = "deps_bzl",
     srcs = ["deps.bzl"],
     deps = [
+        ":whl_archive_bzl",
         "//python/private:bazel_tools_bzl",
     ],
 )
@@ -214,7 +215,6 @@ bzl_library(
     name = "pip_compile_bzl",
     srcs = ["pip_compile.bzl"],
     deps = [
-        ":deps_bzl",
         "//python:defs_bzl",
     ],
 )
@@ -287,15 +287,12 @@ bzl_library(
     srcs = ["whl_archive.bzl"],
     deps = [
         ":attrs_bzl",
-        ":deps_bzl",
         ":generate_whl_library_build_bazel_bzl",
         ":parse_whl_name_bzl",
         ":patch_whl_bzl",
         ":pypi_repo_utils_bzl",
         ":whl_target_platforms_bzl",
         "//python/private:auth_bzl",
-        "//python/private:envsubst_bzl",
-        "//python/private:python_repositories_bzl",
         "//python/private:repo_utils_bzl",
     ],
 )

--- a/python/private/pypi/dependency_resolver/BUILD.bazel
+++ b/python/private/pypi/dependency_resolver/BUILD.bazel
@@ -1,7 +1,20 @@
+load("//python:py_library.bzl", "py_library")
+
 exports_files(["dependency_resolver.py"])
 
 filegroup(
     name = "distribution",
     srcs = glob(["**"]),
     visibility = ["//python/private/pypi:__subpackages__"],
+)
+
+py_library(
+    name = "dependency_resolver",
+    srcs = ["dependency_resolver.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//python/runfiles",
+        "@pypi__click//:pkg",
+        "@pypi__pip_tools//:pkg",
+    ],
 )

--- a/python/private/pypi/deps.bzl
+++ b/python/private/pypi/deps.bzl
@@ -104,7 +104,7 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
-    name = "lib",
+    name = "pkg",
     srcs = glob(["**/*.py"]),
     data = glob(["**/*"], exclude=[
         # These entries include those put into user-installed dependencies by
@@ -155,7 +155,8 @@ def pypi_deps():
                     "linux_s390x",
                     "linux_ppc",
                     "osx_x86_64",
-                    "osx_arch64",
+                    "osx_aarch64",
                     "windows_x86_64",
                 ],
+                dep_template = "@pypi__{name}//:{target}",
             )

--- a/python/private/pypi/deps.bzl
+++ b/python/private/pypi/deps.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load(":whl_archive.bzl", "whl_archive")
 
 _RULE_DEPS = [
     # START: maintained by 'bazel run //tools/private/update_deps:update_pip_deps'
@@ -130,11 +131,31 @@ def pypi_deps():
     Fetch dependencies these rules depend on. Workspaces that use the pip_parse rule can call this.
     """
     for (name, url, sha256) in _RULE_DEPS:
-        maybe(
-            http_archive,
-            name,
-            url = url,
-            sha256 = sha256,
-            type = "zip",
-            build_file_content = _GENERIC_WHEEL,
-        )
+        if name in ["pypi__installer", "pypi__packaging"]:
+            maybe(
+                http_archive,
+                name,
+                url = url,
+                sha256 = sha256,
+                type = "zip",
+                build_file_content = _GENERIC_WHEEL,
+            )
+        else:
+            maybe(
+                whl_archive,
+                name,
+                urls = [url],
+                sha256 = sha256,
+                requirement = name.split("_")[-1],
+                repo = "pypi_",
+                experimental_target_platforms = [
+                    "linux_x86_64",
+                    "linux_aarch64",
+                    "linux_i386",
+                    "linux_s390x",
+                    "linux_ppc",
+                    "osx_x86_64",
+                    "osx_arch64",
+                    "windows_x86_64",
+                ],
+            )

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -29,6 +29,7 @@ load(":pip_repository_attrs.bzl", "ATTRS")
 load(":render_pkg_aliases.bzl", "whl_alias")
 load(":requirements_files_by_platform.bzl", "requirements_files_by_platform")
 load(":simpleapi_download.bzl", "simpleapi_download")
+load(":whl_archive.bzl", "whl_archive")
 load(":whl_library.bzl", "whl_library")
 load(":whl_repo_name.bzl", "whl_repo_name")
 
@@ -307,7 +308,10 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides, group_map, s
                         if len(requirements) > 1:
                             target_platforms = requirement.target_platforms
 
-                    whl_library(name = repo_name, **dict(sorted(whl_library_args.items())))
+                    if distribution.filename.endswith(".whl"):
+                        whl_archive(name = repo_name, **dict(sorted(whl_library_args.items())))
+                    else:
+                        whl_library(name = repo_name, **dict(sorted(whl_library_args.items())))
 
                     whl_map[hub_name].setdefault(whl_name, []).append(
                         whl_alias(

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -309,6 +309,8 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides, group_map, s
                             target_platforms = requirement.target_platforms
 
                     if distribution.filename.endswith(".whl"):
+                        # This is not used by the rule
+                        whl_library_args.pop("envsubst", None)
                         whl_archive(name = repo_name, **dict(sorted(whl_library_args.items())))
                     else:
                         whl_library(name = repo_name, **dict(sorted(whl_library_args.items())))

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -124,19 +124,19 @@ def pip_compile(
     args.extend(extra_args)
 
     deps = [
-        Label("@pypi__build//:lib"),
-        Label("@pypi__click//:lib"),
-        Label("@pypi__colorama//:lib"),
-        Label("@pypi__importlib_metadata//:lib"),
-        Label("@pypi__more_itertools//:lib"),
         Label("@pypi__packaging//:lib"),
-        Label("@pypi__pep517//:lib"),
-        Label("@pypi__pip//:lib"),
-        Label("@pypi__pip_tools//:lib"),
-        Label("@pypi__pyproject_hooks//:lib"),
-        Label("@pypi__setuptools//:lib"),
-        Label("@pypi__tomli//:lib"),
-        Label("@pypi__zipp//:lib"),
+        Label("@pypi__build//:pkg"),
+        Label("@pypi__click//:pkg"),
+        Label("@pypi__colorama//:pkg"),
+        Label("@pypi__importlib_metadata//:pkg"),
+        Label("@pypi__more_itertools//:pkg"),
+        Label("@pypi__pep517//:pkg"),
+        Label("@pypi__pip//:pkg"),
+        Label("@pypi__pip_tools//:pkg"),
+        Label("@pypi__pyproject_hooks//:pkg"),
+        Label("@pypi__setuptools//:pkg"),
+        Label("@pypi__tomli//:pkg"),
+        Label("@pypi__zipp//:pkg"),
         Label("//python/runfiles:runfiles"),
     ] + extra_deps
 

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -103,7 +103,8 @@ def pip_compile(
 
     # Use the Label constructor so this is expanded in the context of the file
     # where it appears, which is to say, in @rules_python
-    pip_compile = Label("//python/private/pypi/dependency_resolver:dependency_resolver.py")
+    pip_compile_lib = Label("//python/private/pypi/dependency_resolver")
+    pip_compile_main = Label("//python/private/pypi/dependency_resolver:dependency_resolver.py")
 
     loc = "$(rlocationpath {})"
 
@@ -124,20 +125,7 @@ def pip_compile(
     args.extend(extra_args)
 
     deps = [
-        Label("@pypi__packaging//:lib"),
-        Label("@pypi__build//:pkg"),
-        Label("@pypi__click//:pkg"),
-        Label("@pypi__colorama//:pkg"),
-        Label("@pypi__importlib_metadata//:pkg"),
-        Label("@pypi__more_itertools//:pkg"),
-        Label("@pypi__pep517//:pkg"),
-        Label("@pypi__pip//:pkg"),
-        Label("@pypi__pip_tools//:pkg"),
-        Label("@pypi__pyproject_hooks//:pkg"),
-        Label("@pypi__setuptools//:pkg"),
-        Label("@pypi__tomli//:pkg"),
-        Label("@pypi__zipp//:pkg"),
-        Label("//python/runfiles:runfiles"),
+        pip_compile_lib,
     ] + extra_deps
 
     tags = tags or []
@@ -148,8 +136,8 @@ def pip_compile(
         "args": args,
         "data": data,
         "deps": deps,
-        "main": pip_compile,
-        "srcs": [pip_compile],
+        "main": pip_compile_main,
+        "srcs": [pip_compile_main],
         "tags": tags,
         "visibility": visibility,
     }

--- a/python/private/pypi/pypi_repo_utils.bzl
+++ b/python/private/pypi/pypi_repo_utils.bzl
@@ -14,7 +14,6 @@
 
 ""
 
-load("@bazel_skylib//lib:types.bzl", "types")
 load("//python/private:repo_utils.bzl", "repo_utils")
 
 def _get_python_interpreter_attr(mrctx, *, python_interpreter = None):
@@ -127,7 +126,10 @@ def _execute_checked(mrctx, *, srcs, **kwargs):
 
     env = kwargs.pop("environment", {})
     pythonpath = env.get("PYTHONPATH", "")
-    if pythonpath and not types.is_string(pythonpath):
+
+    # NOTE @aignas 2024-09-11: Not using `bazel_skylib` `types` module to avoid
+    # a circular dependency in WORKSPACE
+    if pythonpath and not type(pythonpath) == type(""):
         env["PYTHONPATH"] = _construct_pypath(mrctx, entries = pythonpath)
 
     return repo_utils.execute_checked(

--- a/python/private/pypi/whl_archive.bzl
+++ b/python/private/pypi/whl_archive.bzl
@@ -89,7 +89,7 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
             # deps when reused from `whl_library`.
             entries = _PYTHON_PATH_ENTRIES,
         ),
-    }
+    } | rctx.attr.environment
 
     whl_path = whl_path
     if not whl_path and rctx.attr.whl_file:
@@ -309,7 +309,17 @@ The list of urls of the whl to be downloaded using bazel downloader.
         default = _PYTHON_PATH_ENTRIES,
     ),
     "_rule_name": attr.string(default = "whl_library"),
-}, **ATTRS)
+}, **{
+    k: v
+    for k, v in ATTRS.items()
+    if k not in [
+        # These only apply to when we use `pip` to download packages
+        "download_only",
+        "enable_implicit_namespace_pkgs",
+        "extra_pip_args",
+        "isolated",
+    ]
+})
 whl_archive_attrs.update(AUTH_ATTRS)
 
 whl_archive = repository_rule(

--- a/python/private/pypi/whl_archive.bzl
+++ b/python/private/pypi/whl_archive.bzl
@@ -313,9 +313,8 @@ The list of urls of the whl to be downloaded using bazel downloader.
     k: v
     for k, v in ATTRS.items()
     if k not in [
-        # These only apply to when we use `pip` to download packages
         "download_only",
-        "enable_implicit_namespace_pkgs",
+        "envsubst",
         "extra_pip_args",
         "isolated",
     ]

--- a/python/private/pypi/whl_archive.bzl
+++ b/python/private/pypi/whl_archive.bzl
@@ -91,6 +91,7 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
         ),
     }
 
+    whl_path = whl_path
     if not whl_path and rctx.attr.whl_file:
         whl_path = rctx.path(rctx.attr.whl_file)
 
@@ -118,6 +119,10 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
 
         if not result.success:
             fail("could not download the '{}' from {}:\n{}".format(filename, urls, result))
+
+        whl_path = rctx.path(filename)
+    else:
+        fail("Either 'whl_path', 'whl_file' or 'urls' point to a wheel need to be specified")
 
     if rctx.attr.whl_patches:
         patches = {}

--- a/python/private/pypi/whl_archive.bzl
+++ b/python/private/pypi/whl_archive.bzl
@@ -63,7 +63,7 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
 
     Args:
         rctx: {type}`repository_ctx` The repository context.
-        whl_path: {type}`path` The whl path.
+        whl_path: {type}`path | None` The whl path.
         logger: {type}`struct` The logger.
     """
     python_interpreter = pypi_repo_utils.resolve_python_interpreter(
@@ -91,8 +91,9 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
         ),
     } | rctx.attr.environment
 
-    whl_path = whl_path
-    if not whl_path and rctx.attr.whl_file:
+    if whl_path:
+        pass
+    elif rctx.attr.whl_file:
         whl_path = rctx.path(rctx.attr.whl_file)
 
         # Simulate the behaviour where the whl is present in the current directory.
@@ -101,7 +102,7 @@ def whl_archive_impl(*, rctx, logger, whl_path = None):
 
         if not whl_path.basename.endswith(".whl"):
             fail("only whls are supported by this rule")
-    elif not whl_path and rctx.attr.urls:
+    elif rctx.attr.urls:
         filename = rctx.attr.filename
         urls = rctx.attr.urls
         if not filename:

--- a/python/private/pypi/whl_installer/BUILD.bazel
+++ b/python/private/pypi/whl_installer/BUILD.bazel
@@ -13,10 +13,10 @@ py_library(
         "//:__subpackages__",
     ],
     deps = [
-        "@pypi__installer//:lib",
-        "@pypi__packaging//:lib",
-        "@pypi__pip//:lib",
-        "@pypi__setuptools//:lib",
+        "@pypi__installer//:pkg",
+        "@pypi__packaging//:pkg",
+        "@pypi__pip//:pkg",
+        "@pypi__setuptools//:pkg",
     ],
 )
 

--- a/python/private/pypi/whl_installer/BUILD.bazel
+++ b/python/private/pypi/whl_installer/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//python:defs.bzl", "py_binary", "py_library")
 
 py_library(
-    name = "lib",
+    name = "pkg",
     srcs = [
         "arguments.py",
         "namespace_pkgs.py",

--- a/python/private/pypi/whl_installer/BUILD.bazel
+++ b/python/private/pypi/whl_installer/BUILD.bazel
@@ -25,7 +25,7 @@ py_binary(
     srcs = [
         "wheel_installer.py",
     ],
-    deps = [":lib"],
+    deps = [":pkg"],
 )
 
 filegroup(

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -257,10 +257,7 @@ def _whl_library_impl(rctx):
 
     whl_archive_impl(
         rctx = rctx,
-        args = args,
-        environment = environment,
         logger = logger,
-        python_interpreter = python_interpreter,
         whl_path = whl_path,
     )
 

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -252,7 +252,7 @@ def _whl_library_impl(rctx):
 
     args = _parse_optional_attrs(rctx, args, extra_pip_args)
 
-    if not need_to_build_to_use_pip:
+    if need_to_build_to_use_pip:
         whl_path = _build_or_download_wheel(rctx = rctx, args = args, environment = environment, logger = logger)
 
     whl_archive_impl(

--- a/tests/pypi/whl_installer/BUILD.bazel
+++ b/tests/pypi/whl_installer/BUILD.bazel
@@ -2,7 +2,7 @@ load("//python:defs.bzl", "py_test")
 
 alias(
     name = "lib",
-    actual = "//python/private/pypi/whl_installer:lib",
+    actual = "//python/private/pypi/whl_installer:pkg",
 )
 
 py_test(

--- a/tests/pypi/whl_installer/BUILD.bazel
+++ b/tests/pypi/whl_installer/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//python:defs.bzl", "py_test")
 
 alias(
-    name = "lib",
+    name = "pkg",
     actual = "//python/private/pypi/whl_installer:pkg",
 )
 
@@ -12,7 +12,7 @@ py_test(
         "arguments_test.py",
     ],
     deps = [
-        ":lib",
+        ":pkg",
     ],
 )
 
@@ -23,7 +23,7 @@ py_test(
         "namespace_pkgs_test.py",
     ],
     deps = [
-        ":lib",
+        ":pkg",
     ],
 )
 
@@ -35,7 +35,7 @@ py_test(
     ],
     data = ["//examples/wheel:minimal_with_py_package"],
     deps = [
-        ":lib",
+        ":pkg",
     ],
 )
 
@@ -47,7 +47,7 @@ py_test(
     ],
     data = ["//examples/wheel:minimal_with_py_package"],
     deps = [
-        ":lib",
+        ":pkg",
     ],
 )
 
@@ -59,6 +59,6 @@ py_test(
     ],
     data = ["//examples/wheel:minimal_with_py_package"],
     deps = [
-        ":lib",
+        ":pkg",
     ],
 )

--- a/third_party/rules_pycross/pycross/private/tools/BUILD.bazel
+++ b/third_party/rules_pycross/pycross/private/tools/BUILD.bazel
@@ -20,7 +20,8 @@ py_binary(
     srcs = ["wheel_installer.py"],
     visibility = ["//visibility:public"],
     deps = [
-        "//python/private/pypi/whl_installer:lib",
-        "@pypi__installer//:lib",
+        "//python/private/pypi/whl_installer:pkg",
+        "@pypi__installer//:pkg",
+        "@pypi__packaging//:pkg",
     ],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -21,7 +21,7 @@ licenses(["notice"])
 py_binary(
     name = "wheelmaker",
     srcs = ["wheelmaker.py"],
-    deps = ["@pypi__packaging//:lib"],
+    deps = ["@pypi__packaging//:pkg"],
 )
 
 filegroup(


### PR DESCRIPTION
Before this PR users would need to download unused dependencies to just extract
the wheels. The minimum list of deps are - `packaging` and `installer` for our
`whl_installer` tool to properly work. This also means that we could not
dogfood our `whl_installer` tool in the `pip-tools` implementation.

With this PR we start using `whl_archive` which just patches, extracts the
wheel and parses `METADATA` where possible and this is the first step towards
separating how `sdists` are treated.

Summary:
- refactor: split out whl_archive_impl function for just whls
- refactor: make the implementation of the 'whl_archive' more minimal
- use `whl_archive` in internal deps
- use a `py_library` in `pip_compile` rule.
- remove unused attrs from 'whl_archive'
