### PR TITLE
refactor(internal): make the usage of MINOR_MAPPING variable explicit in full_version

### DIFF
--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "X5mAzRTQVEblHlQ3C6fQ5P2dKhhI1botl80drDbpYd8=",
+        "bzlTransitiveDigest": "QxV2PiqVV2B5LpnSrlzLgYyKNbUEXyVc1u+ahMrefws=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "izcO4fumi7/gLahZx0w1QGqPMKtNdbFpL+ixwYJtnLk=",
+        "bzlTransitiveDigest": "P0W31OsSgVVNQ3oRHHFiRWK7NLBLyI+KbQQBCPhou7w=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "vzdh1M3LRVqyF10AVUO1+FOE7CZwlZaFT+7RgQ4OKXg=",
+        "bzlTransitiveDigest": "X5mAzRTQVEblHlQ3C6fQ5P2dKhhI1botl80drDbpYd8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "TgRegkReKbGzK4VxYz9up697gcf5Q8NFuZYnZHryck8=",
+        "bzlTransitiveDigest": "izcO4fumi7/gLahZx0w1QGqPMKtNdbFpL+ixwYJtnLk=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -114,7 +114,6 @@ bzl_library(
 bzl_library(
     name = "full_version_bzl",
     srcs = ["full_version.bzl"],
-    deps = ["//python:versions_bzl"],
 )
 
 bzl_library(
@@ -132,6 +131,7 @@ bzl_library(
     name = "python_bzl",
     srcs = ["python.bzl"],
     deps = [
+        ":full_version_bzl",
         ":pythons_hub_bzl",
         ":repo_utils_bzl",
         ":toolchains_repo_bzl",
@@ -164,7 +164,6 @@ bzl_library(
     deps = [
         ":full_version_bzl",
         ":py_toolchain_suite_bzl",
-        "//python:versions_bzl",
     ],
 )
 

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -27,14 +27,15 @@ def _ver_key(s):
     micro, _, s = s.partition(".")
     return (int(major), int(minor), int(micro))
 
-def _flag_values(python_versions):
+def _flag_values(*, python_versions, minor_mapping):
     """Construct a map of python_version to a list of toolchain values.
 
     This mapping maps the concept of a config setting to a list of compatible toolchain versions.
     For using this in the code, the VERSION_FLAG_VALUES should be used instead.
 
     Args:
-        python_versions: list of strings; all X.Y.Z python versions
+        python_versions: {type}`list[str]` X.Y.Z` python versions.
+        minor_mapping: {type}`dict[str, str]` `X.Y` to `X.Y.Z` mapping.
 
     Returns:
         A `map[str, list[str]]`. Each key is a python_version flag value. Each value
@@ -61,13 +62,13 @@ def _flag_values(python_versions):
         ret.setdefault(minor_version, [minor_version]).append(micro_version)
 
         # Ensure that is_python_3.9.8 is matched if python_version is set
-        # to 3.9 if MINOR_MAPPING points to 3.9.8
-        default_micro_version = MINOR_MAPPING[minor_version]
+        # to 3.9 if minor_mapping points to 3.9.8
+        default_micro_version = minor_mapping[minor_version]
         ret[micro_version] = [micro_version, minor_version] if default_micro_version == micro_version else [micro_version]
 
     return ret
 
-VERSION_FLAG_VALUES = _flag_values(TOOL_VERSIONS.keys())
+VERSION_FLAG_VALUES = _flag_values(python_versions = TOOL_VERSIONS.keys(), minor_mapping = MINOR_MAPPING)
 
 def is_python_config_setting(name, *, python_version, reuse_conditions = None, **kwargs):
     """Create a config setting for matching 'python_version' configuration flag.

--- a/python/private/full_version.bzl
+++ b/python/private/full_version.bzl
@@ -14,20 +14,19 @@
 
 """A small helper to ensure that we are working with full versions."""
 
-load("//python:versions.bzl", "MINOR_MAPPING")
-
-def full_version(version):
+def full_version(*, version, minor_mapping):
     """Return a full version.
 
     Args:
-        version: the version in `X.Y` or `X.Y.Z` format.
+        version: {type}`str` the version in `X.Y` or `X.Y.Z` format.
+        minor_mapping: {type}`dict[str, str]` mapping between `X.Y` to `X.Y.Z` format.
 
     Returns:
         a full version given the version string. If the string is already a
         major version then we return it as is.
     """
-    if version in MINOR_MAPPING:
-        return MINOR_MAPPING[version]
+    if version in minor_mapping:
+        return minor_mapping[version]
 
     parts = version.split(".")
     if len(parts) == 3:
@@ -36,7 +35,7 @@ def full_version(version):
         fail(
             "Unknown Python version '{}', available values are: {}".format(
                 version,
-                ",".join(MINOR_MAPPING.keys()),
+                ",".join(minor_mapping.keys()),
             ),
         )
     else:

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -287,6 +287,7 @@ bzl_library(
     srcs = ["whl_library_alias.bzl"],
     deps = [
         ":render_pkg_aliases_bzl",
+        "//python:versions_bzl",
         "//python/private:full_version_bzl",
     ],
 )

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -156,7 +156,10 @@ bzl_library(
 bzl_library(
     name = "multi_pip_parse_bzl",
     srcs = ["multi_pip_parse.bzl"],
-    deps = ["pip_repository_bzl"],
+    deps = [
+        "pip_repository_bzl",
+        "//python/private:text_util_bzl",
+    ],
 )
 
 bzl_library(
@@ -287,7 +290,6 @@ bzl_library(
     srcs = ["whl_library_alias.bzl"],
     deps = [
         ":render_pkg_aliases_bzl",
-        "//python:versions_bzl",
         "//python/private:full_version_bzl",
     ],
 )

--- a/python/private/pypi/whl_library_alias.bzl
+++ b/python/private/pypi/whl_library_alias.bzl
@@ -14,7 +14,6 @@
 
 """whl_library aliases for multi_pip_parse."""
 
-load("//python:versions.bzl", "MINOR_MAPPING")
 load("//python/private:full_version.bzl", "full_version")
 load(":render_pkg_aliases.bzl", "NO_MATCH_ERROR_MESSAGE_TEMPLATE")
 
@@ -96,7 +95,7 @@ whl_library_alias = repository_rule(
                   "not specified, then the default rules won't be able to " +
                   "resolve a wheel and an error will occur.",
         ),
-        "minor_mapping": attr.string_dict(mandatory = True, default = MINOR_MAPPING),
+        "minor_mapping": attr.string_dict(mandatory = True),
         "version_map": attr.string_dict(mandatory = True),
         "wheel_name": attr.string(mandatory = True),
         "_rules_python_workspace": attr.label(default = Label("//:WORKSPACE")),

--- a/python/private/pypi/whl_library_alias.bzl
+++ b/python/private/pypi/whl_library_alias.bzl
@@ -29,7 +29,7 @@ def _whl_library_alias_impl(rctx):
         build_content.append(_whl_library_render_alias_target(
             alias_name = alias_name,
             default_repo_prefix = default_repo_prefix,
-            minor_mapping = rctx.minor_mapping,
+            minor_mapping = rctx.attr.minor_mapping,
             rules_python = rules_python,
             version_map = version_map,
             wheel_name = rctx.attr.wheel_name,

--- a/python/private/python_repositories.bzl
+++ b/python/private/python_repositories.bzl
@@ -721,6 +721,7 @@ def python_register_multi_toolchains(
         name,
         python_versions,
         default_version = None,
+        minor_mapping = None,
         **kwargs):
     """Convenience macro for registering multiple Python toolchains.
 
@@ -729,10 +730,14 @@ def python_register_multi_toolchains(
         python_versions: {type}`list[str]` the Python versions.
         default_version: {type}`str` the default Python version. If not set,
             the first version in python_versions is used.
+        minor_mapping: {type}`dict[str, str]` mapping between `X.Y` to `X.Y.Z`
+            format. Defaults to the value in `//python:versions.bzl`.
         **kwargs: passed to each {obj}`python_register_toolchains` call.
     """
     if len(python_versions) == 0:
         fail("python_versions must not be empty")
+
+    minor_mapping = minor_mapping or MINOR_MAPPING
 
     if not default_version:
         default_version = python_versions.pop(0)
@@ -747,12 +752,14 @@ def python_register_multi_toolchains(
             name = name + "_" + python_version.replace(".", "_"),
             python_version = python_version,
             set_python_version_constraint = True,
+            minor_mapping = minor_mapping,
             **kwargs
         )
     python_register_toolchains(
         name = name + "_" + default_version.replace(".", "_"),
         python_version = default_version,
         set_python_version_constraint = False,
+        minor_mapping = minor_mapping,
         **kwargs
     )
 
@@ -762,4 +769,5 @@ def python_register_multi_toolchains(
             python_version: name + "_" + python_version.replace(".", "_")
             for python_version in (python_versions + [default_version])
         },
+        minor_mapping = minor_mapping,
     )

--- a/python/private/python_repositories.bzl
+++ b/python/private/python_repositories.bzl
@@ -22,6 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(
     "//python:versions.bzl",
     "DEFAULT_RELEASE_BASE_URL",
+    "MINOR_MAPPING",
     "PLATFORMS",
     "TOOL_VERSIONS",
     "get_release_info",
@@ -583,6 +584,7 @@ def python_register_toolchains(
         register_coverage_tool = False,
         set_python_version_constraint = False,
         tool_versions = None,
+        minor_mapping = None,
         **kwargs):
     """Convenience macro for users which does typical setup.
 
@@ -607,6 +609,8 @@ def python_register_toolchains(
         tool_versions: {type}`dict` contains a mapping of version with SHASUM
             and platform info. If not supplied, the defaults in
             python/versions.bzl will be used.
+        minor_mapping: {type}`dict[str, str]` contains a mapping from `X.Y` to `X.Y.Z`
+            version.
         **kwargs: passed to each {obj}`python_repository` call.
     """
 
@@ -616,8 +620,9 @@ def python_register_toolchains(
 
     base_url = kwargs.pop("base_url", DEFAULT_RELEASE_BASE_URL)
     tool_versions = tool_versions or TOOL_VERSIONS
+    minor_mapping = minor_mapping or MINOR_MAPPING
 
-    python_version = full_version(python_version)
+    python_version = full_version(version = python_version, minor_mapping = minor_mapping)
 
     toolchain_repo_name = "{name}_toolchains".format(name = name)
 

--- a/python/private/pythons_hub.bzl
+++ b/python/private/pythons_hub.bzl
@@ -14,7 +14,6 @@
 
 "Repo rule used by bzlmod extension to create a repo that has a map of Python interpreters and their labels"
 
-load("//python/private:full_version.bzl", "full_version")
 load(
     "//python/private:toolchains_repo.bzl",
     "python_toolchain_build_file_content",
@@ -59,7 +58,7 @@ def _hub_build_file_content(
         [
             python_toolchain_build_file_content(
                 prefix = prefixes[i],
-                python_version = full_version(python_versions[i]),
+                python_version = python_versions[i],
                 set_python_version_constraint = set_python_version_constraints[i],
                 user_repository_name = user_repository_names[i],
             )
@@ -123,7 +122,7 @@ This rule also writes out the various toolchains for the different Python versio
     implementation = _hub_repo_impl,
     attrs = {
         "default_python_version": attr.string(
-            doc = "Default Python version for the build.",
+            doc = "Default Python version for the build in `X.Y` or `X.Y.Z` format.",
             mandatory = True,
         ),
         "toolchain_prefixes": attr.string_list(
@@ -131,7 +130,7 @@ This rule also writes out the various toolchains for the different Python versio
             mandatory = True,
         ),
         "toolchain_python_versions": attr.string_list(
-            doc = "List of Python versions for the toolchains",
+            doc = "List of Python versions for the toolchains. In `X.Y.Z` format.",
             mandatory = True,
         ),
         "toolchain_set_python_version_constraints": attr.string_list(

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -358,11 +358,13 @@ def multi_pip_parse(name, requirements_lock, **kwargs):
         name = name,
         python_versions = {python_versions},
         requirements_lock = requirements_lock,
+        minor_mapping = {minor_mapping},
         **kwargs
     )
 
 """.format(
         python_versions = rctx.attr.python_versions.keys(),
+        minor_mapping = render.indent(render.dict(rctx.attr.minor_mapping), indent = " " * 8).lstrip(),
         rules_python = rules_python,
     )
     rctx.file("pip.bzl", content = pip_bzl)
@@ -371,6 +373,7 @@ def multi_pip_parse(name, requirements_lock, **kwargs):
 multi_toolchain_aliases = repository_rule(
     _multi_toolchain_aliases_impl,
     attrs = {
+        "minor_mapping": attr.string_dict(doc = "The mapping between `X.Y` and `X.Y.Z` python version values"),
         "python_versions": attr.string_dict(doc = "The Python versions."),
         "_rules_python_workspace": attr.label(default = Label("//:WORKSPACE")),
     },


### PR DESCRIPTION
This PR just makes the `MINOR_MAPPING` overridable and explicit in
many macros/rules that we own. Even though technically new API is
exposed, I am not sure if it is possible to use it and I am not sure
if we should advertise it.

Explicit minor_mapping results in easier wiring of `python.override`
`bzlmod` extension tag class planned for #2081.