### PR TITLE
feat(toolchain) Add coveragepy configuration attribute

### DIFF
--- a/examples/bzlmod/.coveragerc
+++ b/examples/bzlmod/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+include_namespace_packages=True
+skip_covered = True
+[run]
+relative_files = True
+branch = True
+omit =
+	*/external/*

--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -82,3 +82,5 @@ build_test(
     name = "all_requirements",
     targets = all_requirements,
 )
+
+exports_files([".coveragerc"])

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -22,6 +22,7 @@ bazel_dep(name = "protobuf", version = "24.4", repo_name = "com_google_protobuf"
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     configure_coverage_tool = True,
+    coverage_rc = "//:.coveragerc",
     # Only set when you have mulitple toolchain versions.
     is_default = True,
     python_version = "3.9",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "3vqCp6yUy32HDgpZG9L+zqedcsEnHZu0Y7hfoRk3owY=",
+        "bzlTransitiveDigest": "uln2/mVyKSDe5S6G8Bslk9/GkxJJKjwa1ZWjyzpU4OM=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6140,7 +6140,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "DdkE6u15ketmEdOGiZ1UcHX7sZV/xpVbFQLWBKjOAYM=",
+        "bzlTransitiveDigest": "eiKB8jVk9Knk2R9QpLZMWvTwJPlNReuz8rknDMhmzRE=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/common/providers.bzl
+++ b/python/private/common/providers.bzl
@@ -73,6 +73,7 @@ def _PyRuntimeInfo_init(
         interpreter = None,
         files = None,
         coverage_tool = None,
+        coverage_rc = None,
         coverage_files = None,
         pyc_tag = None,
         python_version,
@@ -121,6 +122,7 @@ def _PyRuntimeInfo_init(
         "bootstrap_template": bootstrap_template,
         "coverage_files": coverage_files,
         "coverage_tool": coverage_tool,
+        "coverage_rc": coverage_rc,
         "files": files,
         "implementation_name": implementation_name,
         "interpreter": interpreter,
@@ -201,6 +203,12 @@ The files required at runtime for using `coverage_tool`. Will be `None` if no
 :type: File | None
 
 If set, this field is a `File` representing tool used for collecting code
+coverage information from python tests. Otherwise, this is `None`.
+""",
+        "coverage_rc": """
+:type: File | None
+
+If set, this field is a `File` representing the configuration file used by the
 coverage information from python tests. Otherwise, this is `None`.
 """,
         "files": """

--- a/python/private/common/py_executable.bzl
+++ b/python/private/common/py_executable.bzl
@@ -320,6 +320,8 @@ def _get_runtime_details(ctx, semantics):
                 direct.append(effective_runtime.coverage_tool)
             if effective_runtime.coverage_files:
                 transitive.append(effective_runtime.coverage_files)
+            if effective_runtime.coverage_rc:
+                direct.append(effective_runtime.coverage_rc)
         runtime_files = depset(direct = direct, transitive = transitive)
     else:
         runtime_files = depset()

--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -343,6 +343,10 @@ def _create_stage2_bootstrap(
         )
     else:
         coverage_tool_runfiles_path = ""
+    if runtime and runtime.coverage_rc:
+        coverage_rc_path = runtime.coverage_rc.path
+    else:
+        coverage_rc_path = ""
 
     template = runtime.stage2_bootstrap_template
 
@@ -351,6 +355,7 @@ def _create_stage2_bootstrap(
         output = output,
         substitutions = {
             "%coverage_tool%": coverage_tool_runfiles_path,
+            "%coverage_rc%": coverage_rc_path,
             "%import_all%": "True" if ctx.fragments.bazel_py.python_import_all_repositories else "False",
             "%imports%": ":".join(imports.to_list()),
             "%main%": "{}/{}".format(ctx.workspace_name, main_py.short_path),
@@ -403,6 +408,12 @@ def _create_stage1_bootstrap(
             subs["%shebang%"] = DEFAULT_STUB_SHEBANG
             template = ctx.file._bootstrap_template
 
+        if runtime and runtime.coverage_rc:
+            coverage_rc_path = runtime.coverage_rc.path
+        else:
+            coverage_rc_path = ""
+
+        subs["%coverage_rc%"] = coverage_rc_path
         subs["%coverage_tool%"] = coverage_tool_runfiles_path
         subs["%import_all%"] = ("True" if ctx.fragments.bazel_py.python_import_all_repositories else "False")
         subs["%imports%"] = ":".join(imports.to_list())

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -77,6 +77,10 @@ def _py_runtime_impl(ctx):
     else:
         coverage_tool = None
         coverage_files = None
+    if ctx.attr.coverage_rc:
+        coverage_rc = ctx.attr.coverage_rc.files.to_list()[0]
+    else:
+        coverage_rc = None
 
     python_version = ctx.attr.python_version
 
@@ -117,6 +121,7 @@ def _py_runtime_impl(ctx):
     py_runtime_info_kwargs.update(dict(
         implementation_name = ctx.attr.implementation_name,
         interpreter_version_info = interpreter_version_info,
+        coverage_rc = coverage_rc,
         pyc_tag = pyc_tag,
         stage2_bootstrap_template = ctx.file.stage2_bootstrap_template,
         zip_main_template = ctx.file.zip_main_template,
@@ -215,6 +220,12 @@ The entry point for the tool must be loadable by a Python interpreter (e.g. a
 of coverage.py (https://coverage.readthedocs.io), at least including
 the `run` and `lcov` subcommands.
 """,
+        ),
+        "coverage_rc": attr.label(
+            allow_single_file = True,
+            doc = ".converage or pyproject.toml or " +
+                  "for configure coverage tool",
+            mandatory = False,
         ),
         "files": attr.label_list(
             allow_files = True,

--- a/python/private/hermetic_runtime_repo_setup.bzl
+++ b/python/private/hermetic_runtime_repo_setup.bzl
@@ -27,7 +27,8 @@ def define_hermetic_runtime_toolchain_impl(
         extra_files_glob_exclude,
         python_version,
         python_bin,
-        coverage_tool):
+        coverage_tool,
+        coverage_rc):
     """Define a toolchain implementation for a python-build-standalone repo.
 
     It expected this macro is called in the top-level package of an extracted
@@ -46,6 +47,8 @@ def define_hermetic_runtime_toolchain_impl(
         python_bin: {type}`str` The path to the Python binary within the
             repositoroy.
         coverage_tool: {type}`str` optional target to the coverage tool to
+            use.
+        coverage_rc: {type}`str` optional target to the coverage rc file to
             use.
     """
     _ = name  # @unused
@@ -134,6 +137,7 @@ def define_hermetic_runtime_toolchain_impl(
         },
         # Convert empty string to None
         coverage_tool = coverage_tool or None,
+        coverage_rc = coverage_rc or None,
         python_version = "PY3",
         implementation_name = "cpython",
         # See https://peps.python.org/pep-3147/ for pyc tag infix format

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -319,6 +319,7 @@ def _create_toolchain_attrs_struct(*, tag = None, python_version = None, toolcha
         python_version = python_version if python_version else tag.python_version,
         configure_coverage_tool = getattr(tag, "configure_coverage_tool", False),
         ignore_root_user_error = getattr(tag, "ignore_root_user_error", False),
+        coverage_rc = getattr(tag, "coverage_rc", None),
     )
 
 def _get_bazel_version_specific_kwargs():
@@ -374,6 +375,10 @@ A toolchain's repository name uses the format `python_{major}_{minor}`, e.g.
                 "configure_coverage_tool": attr.bool(
                     mandatory = False,
                     doc = "Whether or not to configure the default coverage tool for the toolchains.",
+                ),
+                "coverage_rc": attr.label(
+                    mandatory = False,
+                    doc = "The coverage configuration file to use for the toolchains.",
                 ),
                 "ignore_root_user_error": attr.bool(
                     default = False,

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -402,9 +402,11 @@ def _RunForCoverage(python_program, main_filename, args, env,
   """
   # We need for coveragepy to use relative paths.  This can only be configured
   unique_id = uuid.uuid4()
-  rcfile_name = os.path.join(os.environ['COVERAGE_DIR'], ".coveragerc_{}".format(unique_id))
-  with open(rcfile_name, "w") as rcfile:
-    rcfile.write('''[run]
+  rcfile_name = "%coverage_rc%"
+  if not rcfile_name:
+    rcfile_name = os.path.join(os.environ['COVERAGE_DIR'], ".coveragerc_{}".format(unique_id))
+    with open(rcfile_name, "w") as rcfile:
+      rcfile.write('''[run]
 relative_files = True
 ''')
   PrintVerboseCoverage('Coverage entrypoint:', coverage_entrypoint)

--- a/python/private/python_repositories.bzl
+++ b/python/private/python_repositories.bzl
@@ -313,6 +313,7 @@ define_hermetic_runtime_toolchain_impl(
   python_version = {python_version},
   python_bin = {python_bin},
   coverage_tool = {coverage_tool},
+  coverage_rc = {coverage_rc},
 )
 """.format(
         extra_files_glob_exclude = render.list(glob_exclude),
@@ -320,6 +321,7 @@ define_hermetic_runtime_toolchain_impl(
         python_bin = render.str(python_bin),
         python_version = render.str(rctx.attr.python_version),
         coverage_tool = render.str(coverage_tool),
+        coverage_rc = rctx.attr.coverage_rc,
     )
     rctx.delete("python")
     rctx.symlink(python_bin, "python")
@@ -329,6 +331,7 @@ define_hermetic_runtime_toolchain_impl(
     attrs = {
         "auth_patterns": rctx.attr.auth_patterns,
         "coverage_tool": rctx.attr.coverage_tool,
+        "coverage_rc": rctx.attr.coverage_rc,
         "distutils": rctx.attr.distutils,
         "distutils_content": rctx.attr.distutils_content,
         "ignore_root_user_error": rctx.attr.ignore_root_user_error,
@@ -380,6 +383,12 @@ the context of the toolchain repository.
 For more information see the official bazel docs
 (https://bazel.build/reference/be/python#py_runtime.coverage_tool).
 """,
+        ),
+        "coverage_rc": attr.label(
+            allow_single_file = True,
+            doc = ".converage or pyproject.toml or " +
+                  "for configure coverage tool",
+            mandatory = False,
         ),
         "distutils": attr.label(
             allow_single_file = True,
@@ -465,6 +474,7 @@ def python_register_toolchains(
         python_version,
         register_toolchains = True,
         register_coverage_tool = False,
+        coverage_rc = None,
         set_python_version_constraint = False,
         tool_versions = None,
         minor_mapping = None,
@@ -564,6 +574,7 @@ def python_register_toolchains(
             urls = urls,
             strip_prefix = strip_prefix,
             coverage_tool = coverage_tool,
+            coverage_rc = coverage_rc,
             **kwargs
         )
         if register_toolchains:

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -32,6 +32,7 @@ WORKSPACE_NAME = "%workspace_name%"
 IMPORT_ALL = True if "%import_all%" == "True" else False
 # Runfiles-relative path to the coverage tool entry point, if any.
 COVERAGE_TOOL = "%coverage_tool%"
+COVERAGE_RCFILE = "%coverage_rc%"
 
 # ===== Template substitutions end =====
 
@@ -344,14 +345,16 @@ def _maybe_collect_coverage(enable):
     coverage_dir = os.environ["COVERAGE_DIR"]
     unique_id = uuid.uuid4()
 
-    # We need for coveragepy to use relative paths.  This can only be configured
-    rcfile_name = os.path.join(coverage_dir, ".coveragerc_{}".format(unique_id))
-    with open(rcfile_name, "w") as rcfile:
-        rcfile.write(
-            """[run]
-relative_files = True
-"""
-        )
+    rcfile_name = COVERAGE_RCFILE
+    if not rcfile_name:
+        # We need for coveragepy to use relative paths.  This can only be configured
+        rcfile_name = os.path.join(coverage_dir, ".coveragerc_{}".format(unique_id))
+        with open(rcfile_name, "w") as rcfile:
+            rcfile.write(
+                """[run]
+    relative_files = True
+    """
+            )
     try:
         cov = coverage.Coverage(
             config_file=rcfile_name,


### PR DESCRIPTION
  * Why this change is being made, briefly.
  The PR makes it possible to configure python code coverage through `.coveragerc` file or any other accepted config file
  * Before and after behavior, as applicable
    Before this PR it was not possible to configure code coverage since the configuration was hardcoded within the ruleset. After the PR, users can pass the label to a configuration file 
  [Reference issue](https://github.com/bazelbuild/rules_python/issues/1434)
close https://github.com/bazelbuild/rules_python/issues/1434
