### PR TITLE
fix: Prefix bootstrap file to prevent pytest reentrance

### DIFF
--- a/python/private/common/py_executable_bazel.bzl
+++ b/python/private/common/py_executable_bazel.bzl
@@ -330,7 +330,7 @@ def _create_stage2_bootstrap(
         imports,
         runtime_details):
     output = ctx.actions.declare_file(
-        "{}_stage2_bootstrap.py".format(output_prefix),
+        "_{}_stage2_bootstrap.py".format(output_prefix),
         sibling = output_sibling,
     )
     runtime = runtime_details.effective_runtime


### PR DESCRIPTION
Pytest will, by default, discover tests in files named `test_*.py`. The existing behaviour of the bootstrap setup is to create a file named e.g. `test_foo_stage2_bootstrap.py` for a target named `test_foo`. This causes pytest to reenter, leading to a crash.