### PR TITLE
fix(platforms): include flag_values in config_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ A brief description of the categories of changes:
   in extra_requires in py_wheel rule.
 * (rules) Prevent pytest from trying run the generated stage2
   bootstrap .py file when using {obj}`--bootstrap_impl=script`
+* (toolchain) The {bzl:obj}`gen_python_config_settings` has been fixed to include
+  the flag_values from the platform definitions.
 
 
 ### Added

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -722,5 +722,6 @@ def gen_python_config_settings(name = ""):
     for platform in PLATFORMS.keys():
         native.config_setting(
             name = "{name}{platform}".format(name = name, platform = platform),
+            flag_values = PLATFORMS[platform].flag_values,
             constraint_values = PLATFORMS[platform].compatible_with,
         )


### PR DESCRIPTION
This function that allows us to generate config settings for
supported platforms did not get the flag_values addition.
