### PR TITLE
fix(whl_filegroup): Make RECORD from wheel available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ A brief description of the categories of changes:
 * Nothing yet
 
 ### Fixed
-* Nothing yet
+* (whl_filegroup): Provide per default also the `RECORD` file
 
 ### Added
 * Nothing yet
@@ -82,7 +82,6 @@ A brief description of the categories of changes:
   bootstrap .py file when using {obj}`--bootstrap_impl=script`
 * (toolchain) The {bzl:obj}`gen_python_config_settings` has been fixed to include
   the flag_values from the platform definitions.
-
 
 ### Added
 * (bzlmod): Toolchain overrides can now be done using the new

--- a/tests/whl_filegroup/extract_wheel_files_test.py
+++ b/tests/whl_filegroup/extract_wheel_files_test.py
@@ -10,34 +10,17 @@ _WHEEL = Path("examples/wheel/example_minimal_package-0.0.1-py3-none-any.whl")
 class WheelRecordTest(unittest.TestCase):
     def test_get_wheel_record(self) -> None:
         record = extract_wheel_files.get_record(_WHEEL)
-        expected = {
-            "examples/wheel/lib/data.txt": (
-                "sha256=9vJKEdfLu8bZRArKLroPZJh1XKkK3qFMXiM79MBL2Sg",
-                12,
-            ),
-            "examples/wheel/lib/module_with_data.py": (
-                "sha256=8s0Khhcqz3yVsBKv2IB5u4l4TMKh7-c_V6p65WVHPms",
-                637,
-            ),
-            "examples/wheel/lib/simple_module.py": (
-                "sha256=z2hwciab_XPNIBNH8B1Q5fYgnJvQTeYf0ZQJpY8yLLY",
-                637,
-            ),
-            "examples/wheel/main.py": (
-                "sha256=sgg5iWN_9inYBjm6_Zw27hYdmo-l24fA-2rfphT-IlY",
-                909,
-            ),
-            "example_minimal_package-0.0.1.dist-info/WHEEL": (
-                "sha256=sobxWSyDDkdg_rinUth-jxhXHqoNqlmNMJY3aTZn2Us",
-                91,
-            ),
-            "example_minimal_package-0.0.1.dist-info/METADATA": (
-                "sha256=cfiQ2hFJhCKCUgbwtAwWG0fhW6NTzw4cr1uKOBcV_IM",
-                76,
-            ),
-        }
+        expected = (
+            "examples/wheel/lib/data.txt",
+            "examples/wheel/lib/module_with_data.py",
+            "examples/wheel/lib/simple_module.py",
+            "examples/wheel/main.py",
+            "example_minimal_package-0.0.1.dist-info/WHEEL",
+            "example_minimal_package-0.0.1.dist-info/METADATA",
+            "example_minimal_package-0.0.1.dist-info/RECORD",
+        )
         self.maxDiff = None
-        self.assertDictEqual(record, expected)
+        self.assertEqual(list(record), list(expected))
 
     def test_get_files(self) -> None:
         pattern = "(examples/wheel/lib/.*\.txt$|.*main)"


### PR DESCRIPTION
Why this change is being made, briefly.
 * We need to also get the `RECORD` file from a wheel in order to package everything
 * It seems a bit weird to me that the `RECORD` file is *not part* of `whl_filegroup` even no pattern filtering was applied (or I am misunderstanding something)
 * Further: neither `hash` nor `filelen` have been used in the code, so why are only files considered with those attributes?