### PR TITLE
fix: pass `extra_pip_args` to `parse_requirements`

### DIFF
--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -182,6 +182,7 @@ def _create_whl_repos(module_ctx, pip_attr, whl_map, whl_overrides, group_map, s
             python_version = major_minor,
             logger = logger,
         ),
+        extra_pip_args = pip_attr.extra_pip_args,
         get_index_urls = get_index_urls,
         # NOTE @aignas 2024-08-02: , we will execute any interpreter that we find either
         # in the PATH or if specified as a label. We will configure the env


### PR DESCRIPTION
Bug fix for #2239.

The `extra_pip_args` variable was not being correctly passed to `parse_requirements()`, causing further calls to ignore anything that was set here. 

This was a problem if, for example, the `--trusted-host` argument was needed to talk to the index set by `experimental_index_url`.
