### PR TITLE
feat: add py_wheel.compress to control using compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ A brief description of the categories of changes:
 * Nothing yet
 
 ### Added
-* Nothing yet
+* (py_wheel) Now supports `compress = (True|False)` to allow disabling
+  compression to speed up development.
 
 ### Removed
 * Nothing yet

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -34,6 +34,10 @@ _distribution_attrs = {
         default = "none",
         doc = "Python ABI tag. 'none' for pure-Python wheels.",
     ),
+    "compress": attr.bool(
+        default = True,
+        doc = "Enable compression of the final archive.",
+    ),
     "distribution": attr.string(
         mandatory = True,
         doc = """\
@@ -465,6 +469,9 @@ def _py_wheel_impl(ctx):
         description_file = ctx.file.description_file
         args.add("--description_file", description_file)
         other_inputs.append(description_file)
+
+    if not ctx.attr.compress:
+        args.add("--no_compress")
 
     for target, filename in ctx.attr.extra_distinfo_files.items():
         target_files = target.files.to_list()

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -102,9 +102,9 @@ class _WhlFile(zipfile.ZipFile):
         filename,
         *,
         mode,
-        compression,
         distribution_prefix: str,
         strip_path_prefixes=None,
+        compression=zipfile.ZIP_DEFLATED,
         **kwargs,
     ):
         self._distribution_prefix = distribution_prefix


### PR DESCRIPTION
This is useful for development where, for large wheels, a significant
portion of the time can be spent compression native binaries

Fixes https://github.com/bazelbuild/rules_python/issues/2240
