### PR TITLE
feat(toolchains): default py_runtime.implementation_name to cpython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ A brief description of the categories of changes:
 [x.x.x]: https://github.com/bazelbuild/rules_python/releases/tag/x.x.x
 
 ### Changed
-* Nothing yet
+* (toolchains) `py_runtime.implementation_name` now defaults to `cpython`
+  (previously it defaulted to None).
 
 ### Fixed
 * (bzlmod) correctly wire the {attr}`pip.parse.extra_pip_args` all the

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -226,6 +226,7 @@ runtime. For a platform runtime this attribute must not be set.
         ),
         "implementation_name": attr.string(
             doc = "The Python implementation name (`sys.implementation.name`)",
+            default = "cpython",
         ),
         "interpreter": attr.label(
             # We set `allow_files = True` to allow specifying executable


### PR DESCRIPTION
This defaults `py_runtime.implementation_name` to `cpython`, the value that is most likely
to be used. This is done not only because it's the most likely value, but because of how
it affects whether precompiling works.

Within py_runtime, automatically computing `pyc_tag` requires both `implementation_name`
and Python version information. With upcoming changes to make `--python_version` always
set to the correct value, it'll make enabling precompiling easier, especially if there
are custom toolchains defined.