### PR TITLE
feat(toolchains): expose the //python/config_settings:python_version_major_minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ A brief description of the categories of changes:
 ### Added
 * (py_wheel) Now supports `compress = (True|False)` to allow disabling
   compression to speed up development.
+* (toolchains): A public `//python/config_settings:python_version_major_minor` has
+  been exposed for users to be able to match on the `X.Y` version of a Python
+  interpreter.
 
 ### Removed
 * Nothing yet

--- a/docs/api/rules_python/python/config_settings/index.md
+++ b/docs/api/rules_python/python/config_settings/index.md
@@ -10,6 +10,10 @@ Determines the default hermetic Python toolchain version. This can be set to
 one of the values that `rules_python` maintains.
 :::
 
+:::{bzl:target} python_version_major_minor
+Parses the value of the `python_version` and transforms it into a `X.Y` value.
+:::
+
 ::::{bzl:flag} exec_tools_toolchain
 Determines if the {obj}`exec_tools_toolchain_type` toolchain is enabled.
 

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "vHagWYWcU/mNBRAz0GLQ3uxZZsgz/7/7i2GEWboxKd0=",
+        "bzlTransitiveDigest": "SY5Kzq6Z7CG9q0dbCVrOHK8FFnVC6YTXBqGE4ZfNNbo=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6138,7 +6138,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "qRRffSjIlTY99Raninpbkvh1elRwuufP+ZZaGb00rdo=",
+        "bzlTransitiveDigest": "BLXk2JiegzzGfis5XuIaAVMg5WUUhmsofn99NgeBDEQ=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -20,7 +20,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":semver.bzl", "semver")
 
 _PYTHON_VERSION_FLAG = Label("//python/config_settings:python_version")
-_PYTHON_VERSION_MAJOR_MINOR_FLAG = Label("//python/config_settings:_python_version_major_minor")
+_PYTHON_VERSION_MAJOR_MINOR_FLAG = Label("//python/config_settings:python_version_major_minor")
 
 def construct_config_settings(*, name, default_version, versions, minor_mapping):  # buildifier: disable=function-docstring
     """Create a 'python_version' config flag and construct all config settings used in rules_python.

--- a/python/private/pypi/config_settings.bzl
+++ b/python/private/pypi/config_settings.bzl
@@ -116,7 +116,7 @@ def config_settings(
         native.config_setting(
             name = is_python,
             flag_values = {
-                Label("//python/config_settings:_python_version_major_minor"): python_version,
+                Label("//python/config_settings:python_version_major_minor"): python_version,
             },
             visibility = visibility,
         )

--- a/python/private/pypi/generate_whl_library_build_bazel.bzl
+++ b/python/private/pypi/generate_whl_library_build_bazel.bzl
@@ -162,7 +162,7 @@ def _render_config_settings(dependencies_by_platform):
 config_setting(
     name = "is_{name}",
     flag_values = {{
-        "@rules_python//python/config_settings:_python_version_major_minor": "3.{minor_version}",
+        "@rules_python//python/config_settings:python_version_major_minor": "3.{minor_version}",
     }},
     constraint_values = {constraint_values},
     visibility = ["//visibility:private"],

--- a/tests/config_settings/construct_config_settings_tests.bzl
+++ b/tests/config_settings/construct_config_settings_tests.bzl
@@ -167,7 +167,7 @@ def construct_config_settings_test_suite(name):  # buildifier: disable=function-
                 "@platforms//os:" + os,
             ],
             flag_values = {
-                "//python/config_settings:_python_version_major_minor": "3.11",
+                "//python/config_settings:python_version_major_minor": "3.11",
             },
         )
 
@@ -178,7 +178,7 @@ def construct_config_settings_test_suite(name):  # buildifier: disable=function-
                 "@platforms//cpu:" + cpu,
             ],
             flag_values = {
-                "//python/config_settings:_python_version_major_minor": "3.11",
+                "//python/config_settings:python_version_major_minor": "3.11",
             },
         )
 
@@ -198,7 +198,7 @@ def construct_config_settings_test_suite(name):  # buildifier: disable=function-
                 "@platforms//os:" + os,
             ],
             flag_values = {
-                "//python/config_settings:_python_version_major_minor": "3.11",
+                "//python/config_settings:python_version_major_minor": "3.11",
             },
         )
 

--- a/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
+++ b/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
@@ -160,7 +160,7 @@ py_library(
 config_setting(
     name = "is_python_3.10_linux_ppc",
     flag_values = {
-        "@rules_python//python/config_settings:_python_version_major_minor": "3.10",
+        "@rules_python//python/config_settings:python_version_major_minor": "3.10",
     },
     constraint_values = [
         "@platforms//cpu:ppc",
@@ -172,7 +172,7 @@ config_setting(
 config_setting(
     name = "is_python_3.9_anyos_aarch64",
     flag_values = {
-        "@rules_python//python/config_settings:_python_version_major_minor": "3.9",
+        "@rules_python//python/config_settings:python_version_major_minor": "3.9",
     },
     constraint_values = ["@platforms//cpu:aarch64"],
     visibility = ["//visibility:private"],
@@ -181,7 +181,7 @@ config_setting(
 config_setting(
     name = "is_python_3.9_linux_anyarch",
     flag_values = {
-        "@rules_python//python/config_settings:_python_version_major_minor": "3.9",
+        "@rules_python//python/config_settings:python_version_major_minor": "3.9",
     },
     constraint_values = ["@platforms//os:linux"],
     visibility = ["//visibility:private"],


### PR DESCRIPTION
With this change the users can simply reuse our internal flag that will
correctly report the `X.Y` version in `select` statements. If users
previously depended on now removed `is_python_config_setting` now they
have an alternative.

Followup to #2253
