### PR TITLE
fix(whl_library): avoid excessive report_progress() messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ A brief description of the categories of changes:
 * (whl_filegroup): Provide per default also the `RECORD` file
 * (py_wheel): `RECORD` file entry elements are now quoted if necessary when a
   wheel is created
+* (whl_library) truncate progress messages from the repo rule to better handle
+  case where a requirement has many `--hash=sha256:...` flags
 
 ### Added
 * (py_wheel) Now supports `compress = (True|False)` to allow disabling

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1231,7 +1231,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "SY5Kzq6Z7CG9q0dbCVrOHK8FFnVC6YTXBqGE4ZfNNbo=",
+        "bzlTransitiveDigest": "kPvx0u6SR68H+8BqqEfxd3NpVZjuMOyzI9Xml01rdrQ=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6138,7 +6138,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "BLXk2JiegzzGfis5XuIaAVMg5WUUhmsofn99NgeBDEQ=",
+        "bzlTransitiveDigest": "c3OA6iewVGq8nz0o3iI2AtIQhsRZIg/E/PDq2vuAQTw=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -244,7 +244,10 @@ def _whl_library_impl(rctx):
 
         repo_utils.execute_checked(
             rctx,
-            op = op_tmpl.format(name = rctx.attr.name, requirement = rctx.attr.requirement),
+            # truncate the requirement value when logging it / reporting
+            # progress since it may contain several ' --hash=sha256:...
+            # --hash=sha256:...' substrings that fill up the console
+            op = op_tmpl.format(name = rctx.attr.name, requirement = rctx.attr.requirement.split(" ", 1)[0]),
             arguments = args,
             environment = environment,
             quiet = rctx.attr.quiet,


### PR DESCRIPTION
With the current behavior, we see really long progress messages in the console like

```
Running whl_library.ResolveRequirement(foobar_pip_deps_regex, regex==2023.12.25     --hash=sha256:0694219a1d54336fd0445ea3\
82d49d36882415c0134ee1e8332afd1529f0baa5
<many more lines of --hash values>
```

This spams the console and isn't very useful.

To fix, only print up to the first white space, which captures the important information
(e.g. "regex==2024.12.25") and is brief.

Closes https://github.com/bazelbuild/rules_python/issues/2206
