### PR TITLE
fix(bzlmod): let workspace-invoked python_register_toolchains to register toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ A brief description of the categories of changes:
 * (rules) `compile_pip_requirements` passes `env` to the `X.update` target (and
   not only to the `X_test` target, a bug introduced in
   [#1067](https://github.com/bazelbuild/rules_python/pull/1067)).
+* (bzlmod) In hybrid bzlmod with WORKSPACE builds,
+  `python_register_toolchains(register_toolchains=True)` is respected
+  ([#1675](https://github.com/bazelbuild/rules_python/issues/1675)).
 
 ### Added
 * (py_wheel) Now supports `compress = (True|False)` to allow disabling

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -177,7 +177,6 @@ bzl_library(
     deps = [
         ":auth_bzl",
         ":bazel_tools_bzl",
-        ":bzlmod_enabled_bzl",
         ":coverage_deps_bzl",
         ":full_version_bzl",
         ":internal_config_repo_bzl",

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -228,7 +228,11 @@ def _python_impl(module_ctx):
         kwargs.update(py.config.kwargs.get(toolchain_info.python_version, {}))
         kwargs.update(py.config.kwargs.get(full_python_version, {}))
         kwargs.update(py.config.default)
-        python_register_toolchains(name = toolchain_info.name, **kwargs)
+        python_register_toolchains(
+            name = toolchain_info.name,
+            _internal_bzlmod_toolchain_call = True,
+            **kwargs
+        )
 
     # Create the pythons_hub repo for the interpreter meta data and the
     # the various toolchains.

--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -23,7 +23,6 @@ load(
     "TOOL_VERSIONS",
     "get_release_info",
 )
-load(":bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load(":coverage_deps.bzl", "coverage_dep")
 load(":full_version.bzl", "full_version")
 load(":python_repository.bzl", "python_repository")
@@ -75,9 +74,8 @@ def python_register_toolchains(
             version.
         **kwargs: passed to each {obj}`python_repository` call.
     """
-
-    if BZLMOD_ENABLED:
-        # you cannot used native.register_toolchains when using bzlmod.
+    bzlmod_toolchain_call = kwargs.pop("_internal_bzlmod_toolchain_call", False)
+    if bzlmod_toolchain_call:
         register_toolchains = False
 
     base_url = kwargs.pop("base_url", DEFAULT_RELEASE_BASE_URL)
@@ -169,7 +167,7 @@ def python_register_toolchains(
     )
 
     # in bzlmod we write out our own toolchain repos
-    if BZLMOD_ENABLED:
+    if bzlmod_toolchain_call:
         return
 
     toolchains_repo(


### PR DESCRIPTION
While migrating to bzlmod, users may have a hybrid build where WORKSPACE contains
python_register_toolchain() calls. Because these calls originate from WORKSPACE files,
the `native.register_toolchain` APIs are still available. At the same time, we still
detect that bzlmod is enabled, and thus disable calling those functions. The net
effect is, users aren't able to register toolchains in such a hybrid setup. At the
same time, because the code path is shared, we can't have the bzlmod toolchain code
try to call them, as it'll fail.

To accomodate both cases, have the bzlmod toolchain code pass a special arg so that
`python_register_toolchains` knows to skip parts that don't apply to the bzlmod toolchain
invocation.

This was all unwound by some users and pointed out in a Slack thread. A few people are
manually carrying an equivalent patch for a working hybrid mode.

Fixes https://github.com/bazelbuild/rules_python/issues/1675