### PR TITLE
docs: add stubs so Bazel docs link to a valid file

### DIFF
--- a/python/private/common/py_binary_rule_bazel.bzl
+++ b/python/private/common/py_binary_rule_bazel.bzl
@@ -1,0 +1,6 @@
+"""Stub file for Bazel docs to link to.
+
+The Bazel docs link to this file, but the implementation was moved.
+
+Please see: https://rules-python.readthedocs.io/en/latest/api/rules_python/python/defs.html#py_binary
+"""

--- a/python/private/common/py_library_rule_bazel.bzl
+++ b/python/private/common/py_library_rule_bazel.bzl
@@ -1,0 +1,6 @@
+"""Stub file for Bazel docs to link to.
+
+The Bazel docs link to this file, but the implementation was moved.
+
+Please see: https://rules-python.readthedocs.io/en/latest/api/rules_python/python/defs.html#py_library
+"""

--- a/python/private/common/py_runtime_rule.bzl
+++ b/python/private/common/py_runtime_rule.bzl
@@ -1,0 +1,6 @@
+"""Stub file for Bazel docs to link to.
+
+The Bazel docs link to this file, but the implementation was moved.
+
+Please see: https://rules-python.readthedocs.io/en/latest/api/rules_python/python/defs.html#py_runtime
+"""

--- a/python/private/common/py_test_rule_bazel.bzl
+++ b/python/private/common/py_test_rule_bazel.bzl
@@ -1,0 +1,6 @@
+"""Stub file for Bazel docs to link to.
+
+The Bazel docs link to this file, but the implementation was moved.
+
+Please see: https://rules-python.readthedocs.io/en/latest/api/rules_python/python/defs.html#py_test
+"""


### PR DESCRIPTION
The Bazel docs link to the implementation files, which were recently moved. To avoid users getting a 404, add stub files with some text to direct them somewhere useful.

Work towards https://github.com/bazelbuild/bazel/issues/24014