### PR TITLE
docs: fix rendering of python extension

### DIFF
--- a/python/extensions/python.bzl
+++ b/python/extensions/python.bzl
@@ -14,7 +14,7 @@
 
 """Python toolchain module extensions for use with bzlmod.
 
-:::{topic} Basic usage
+::::{topic} Basic usage
 
 The simplest way to configure the toolchain with `rules_python` is as follows.
 
@@ -27,22 +27,22 @@ python.toolchain(
 use_repo(python, "python_3_11")
 ```
 
-::::{seealso}
+:::{seealso}
 For more in-depth documentation see the {obj}`python.toolchain`.
-::::
 :::
+::::
 
-:::{topic} Overrides
+::::{topic} Overrides
 
 Overrides can be done at 3 different levels:
 * Overrides affecting all python toolchain versions on all platforms - {obj}`python.override`.
 * Overrides affecting a single toolchain versions on all platforms - {obj}`python.single_version_override`.
 * Overrides affecting a single toolchain versions on a single platforms - {obj}`python.single_version_platform_override`.
 
-::::{seealso}
+:::{seealso}
 The main documentation page on registering [toolchains](/toolchains).
-::::
 :::
+::::
 """
 
 load("//python/private:python.bzl", _python = "python")


### PR DESCRIPTION
The file doc string used increasing colon-counts for directives (a 3-colon directive contained a 4-colon directive), which messes up subsequent nesting later on the page.

To fix, use 4 colons for the outer topic and 3 for the inner topic.
