### PR TITLE
refactor(bzlmod): refactor pip_parse to make it more testable

### DIFF
--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "k/+n1K+lR7V3oZYLaIPq01fzV+hf+ZjgKgoMmH60bLE=",
+        "bzlTransitiveDigest": "ElpL66yqFHKxwNnE0c/xGw9vh40iCQT0Whz9XdPkydA=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "ypj88aXgIp+DKZHFpQVlB3GJPIr+0MBVql9vxef5E9w=",
+        "bzlTransitiveDigest": "9uxFBLt5C2maO2dUYrWGFn3cAx5Rzt9Ha8y0siUl2oM=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "iikkSIkMsBiM/vadkEf9xEoVbaxZqrkUg08hiHr/LKk=",
+        "bzlTransitiveDigest": "+F6sV3YAo/qldTLeU0MTvh5nK4Vr1gCZSWzoX+v0qH0=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "WPfU9gogl29lCI8A/N2aYn7RAhsCpZikVU1Hw7nMtAc=",
+        "bzlTransitiveDigest": "1uBC9tJDPdn7Ubmb5CUjscK+gb/nYP7elM49ue6TLB0=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "3cYaCQDhttUZKjzfZoSptfBKZH9yYtxmPZQ6ycEbfLc=",
+        "bzlTransitiveDigest": "e1+X/9IKZ8eQhPc3DoqYNszOgUqmM8CmAAbRDgEHwJ8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "NiyhO0XmUxwNKj0NZjUOTgnoSs3viXLL8v5nxY867BU=",
+        "bzlTransitiveDigest": "+HuSSvhxT759qeNhZXLfFx+eVx/YT41sYZl1Wht2qr8=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "LyeBT3IHuv5aM4EnUFYgt7Jf2RlvtBr/WlIAX3cy44g=",
+        "bzlTransitiveDigest": "MAC3yqD4bm+sEAuyzLatQjVxFCk+gvfTTLmdhCcldCI=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "UvrP/CAjGKFBB93blIhN3hlokUjfGCXOWAbAKcpsnyg=",
+        "bzlTransitiveDigest": "5PwHGCCkG7Tg9nkAaRxh0YtwB3FuFPNymaV6mjyQO/g=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "hJ7eKsoEMeWHFRSZTVOIUp6MuIW+j8o0kWoQVhEuqmU=",
+        "bzlTransitiveDigest": "k/+n1K+lR7V3oZYLaIPq01fzV+hf+ZjgKgoMmH60bLE=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "qzmXF5mOOAUh9/YsfU7yBaX1cvNUWD61alQXaKPT6co=",
+        "bzlTransitiveDigest": "ypj88aXgIp+DKZHFpQVlB3GJPIr+0MBVql9vxef5E9w=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "MAC3yqD4bm+sEAuyzLatQjVxFCk+gvfTTLmdhCcldCI=",
+        "bzlTransitiveDigest": "3cYaCQDhttUZKjzfZoSptfBKZH9yYtxmPZQ6ycEbfLc=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "5PwHGCCkG7Tg9nkAaRxh0YtwB3FuFPNymaV6mjyQO/g=",
+        "bzlTransitiveDigest": "NiyhO0XmUxwNKj0NZjUOTgnoSs3viXLL8v5nxY867BU=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "ElpL66yqFHKxwNnE0c/xGw9vh40iCQT0Whz9XdPkydA=",
+        "bzlTransitiveDigest": "LyeBT3IHuv5aM4EnUFYgt7Jf2RlvtBr/WlIAX3cy44g=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -1414,7 +1414,7 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
-          "pip_39_zipp_sdist_0145e43d": {
+          "pip_39_snowballstemmer_py2_none_any_c8e1716e": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1432,13 +1432,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "zipp-3.20.0.tar.gz",
+              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
-              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
+              "requirement": "snowballstemmer==2.2.0",
+              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
+                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -1470,7 +1470,7 @@
               ]
             }
           },
-          "pip_39_snowballstemmer_py2_none_any_c8e1716e": {
+          "pip_39_zipp_sdist_0145e43d": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1488,13 +1488,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
+              "filename": "zipp-3.20.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "snowballstemmer==2.2.0",
-              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
+              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
+              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
               "urls": [
-                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
               ]
             }
           },
@@ -1526,6 +1526,27 @@
               ]
             }
           },
+          "pip_310_docutils": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "docutils==0.20.1     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6     --hash=sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
+            }
+          },
           "pip_310_sphinx": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -1554,27 +1575,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "sphinx==7.2.6     --hash=sha256:1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560     --hash=sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"
-            }
-          },
-          "pip_310_docutils": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "docutils==0.20.1     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6     --hash=sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
             }
           },
           "pip_39_tomlkit_py3_none_any_07de26b0": {
@@ -1642,34 +1642,6 @@
               ]
             }
           },
-          "pip_39_s3cmd_sdist_966b0a49": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "s3cmd-2.1.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "s3cmd==2.1.0",
-              "sha256": "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
-              ]
-            }
-          },
           "pip_310_sphinxcontrib_serializinghtml": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -1700,7 +1672,7 @@
               "requirement": "sphinxcontrib-serializinghtml==1.1.9     --hash=sha256:0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54     --hash=sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
             }
           },
-          "pip_39_wrapt_cp39_cp39_manylinux_2_5_x86_64_40e7bc81": {
+          "pip_39_s3cmd_sdist_966b0a49": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1718,13 +1690,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "filename": "s3cmd-2.1.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+              "requirement": "s3cmd==2.1.0",
+              "sha256": "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03",
               "urls": [
-                "https://files.pythonhosted.org/packages/e0/6a/3c660fa34c8106aa9719f2a6636c1c3ea7afd5931ae665eb197fdf4def84/wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
               ]
             }
           },
@@ -1756,6 +1728,34 @@
               ]
             }
           },
+          "pip_39_wrapt_cp39_cp39_manylinux_2_5_x86_64_40e7bc81": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e0/6a/3c660fa34c8106aa9719f2a6636c1c3ea7afd5931ae665eb197fdf4def84/wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
           "pip_310_idna": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -1775,6 +1775,27 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "idna==2.10     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            }
+          },
+          "pip_310_astroid": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "astroid==2.13.5     --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501     --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"
             }
           },
           "pip_39_lazy_object_proxy_sdist_78247b6d": {
@@ -1805,27 +1826,6 @@
               ]
             }
           },
-          "pip_310_astroid": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "astroid==2.13.5     --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501     --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"
-            }
-          },
           "pip_39_websockets_sdist_88fc51d9": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -1854,34 +1854,6 @@
               ]
             }
           },
-          "pip_39_pyyaml_cp39_cp39_macosx_10_9_x86_64_9eb6caa9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
           "pip_39_markupsafe_cp39_cp39_manylinux_2_17_x86_64_05fb2117": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -1907,6 +1879,34 @@
               "sha256": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
               "urls": [
                 "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_cp39_cp39_macosx_10_9_x86_64_9eb6caa9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
               ]
             }
           },
@@ -2059,6 +2059,33 @@
               ]
             }
           },
+          "pip_310_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "requests==2.25.1     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
+              "whl_patches": {
+                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
+              }
+            }
+          },
           "pip_39_pyyaml_cp39_cp39_win_amd64_510c9dee": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2085,33 +2112,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/84/4d/82704d1ab9290b03da94e6425f5e87396b999fd7eb8e08f3a92c158402bf/PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
               ]
-            }
-          },
-          "pip_310_requests": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "requests==2.25.1     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
-              "whl_patches": {
-                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
-              }
             }
           },
           "pip_39_pyyaml_cp39_cp39_manylinux_2_17_aarch64_5773183b": {
@@ -2277,34 +2277,6 @@
               ]
             }
           },
-          "pip_39_websockets_cp39_cp39_musllinux_1_1_aarch64_1fdf26fa": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
           "pip_39_sphinxcontrib_qthelp_sdist_62b9d1a1": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2342,6 +2314,55 @@
               ]
             }
           },
+          "pip_39_websockets_cp39_cp39_musllinux_1_1_aarch64_1fdf26fa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_310_alabaster": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "alabaster==0.7.13     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2"
+            }
+          },
           "pip_39_setuptools_sdist_a7620757": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2370,27 +2391,6 @@
               ]
             }
           },
-          "pip_310_alabaster": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "alabaster==0.7.13     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2"
-            }
-          },
           "pip_310_python_magic": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2410,34 +2410,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "python-magic==0.4.27     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"
-            }
-          },
-          "pip_39_mccabe_sdist_348e0240": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "mccabe-0.7.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "mccabe==0.7.0",
-              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
-              ]
             }
           },
           "pip_39_chardet_sdist_0d6f53a1": {
@@ -2465,6 +2437,34 @@
               "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
               "urls": [
                 "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_mccabe_sdist_348e0240": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "mccabe-0.7.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "mccabe==0.7.0",
+              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
               ]
             }
           },
@@ -2505,6 +2505,27 @@
               ]
             }
           },
+          "pip_310_tabulate": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "tabulate==0.9.0     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
+            }
+          },
           "pip_39_docutils_sdist_f08a4e27": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2533,7 +2554,7 @@
               ]
             }
           },
-          "pip_310_tabulate": {
+          "pip_310_lazy_object_proxy": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2551,7 +2572,7 @@
               ],
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
-              "requirement": "tabulate==0.9.0     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
+              "requirement": "lazy-object-proxy==1.9.0     --hash=sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382     --hash=sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82     --hash=sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9     --hash=sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494     --hash=sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46     --hash=sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30     --hash=sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63     --hash=sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4     --hash=sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae     --hash=sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be     --hash=sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701     --hash=sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd     --hash=sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006     --hash=sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a     --hash=sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586     --hash=sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8     --hash=sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821     --hash=sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07     --hash=sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b     --hash=sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171     --hash=sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b     --hash=sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2     --hash=sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7     --hash=sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4     --hash=sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8     --hash=sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e     --hash=sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f     --hash=sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda     --hash=sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4     --hash=sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e     --hash=sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671     --hash=sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11     --hash=sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455     --hash=sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734     --hash=sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb     --hash=sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
             }
           },
           "pip_39_packaging_py3_none_any_8c491190": {
@@ -2580,27 +2601,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl"
               ]
-            }
-          },
-          "pip_310_lazy_object_proxy": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "lazy-object-proxy==1.9.0     --hash=sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382     --hash=sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82     --hash=sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9     --hash=sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494     --hash=sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46     --hash=sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30     --hash=sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63     --hash=sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4     --hash=sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae     --hash=sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be     --hash=sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701     --hash=sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd     --hash=sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006     --hash=sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a     --hash=sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586     --hash=sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8     --hash=sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821     --hash=sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07     --hash=sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b     --hash=sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171     --hash=sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b     --hash=sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2     --hash=sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7     --hash=sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4     --hash=sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8     --hash=sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e     --hash=sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f     --hash=sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda     --hash=sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4     --hash=sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e     --hash=sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671     --hash=sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11     --hash=sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455     --hash=sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734     --hash=sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb     --hash=sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
             }
           },
           "pip_39_tomli_sdist_de526c12": {
@@ -2682,6 +2682,34 @@
               "requirement": "pylint==2.15.10     --hash=sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e     --hash=sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
             }
           },
+          "pip_39_pygments_sdist_1daff049": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "Pygments-2.16.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pygments==2.16.1",
+              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
+              ]
+            }
+          },
           "pip_39_wheel_sdist_cd1196f3": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2708,34 +2736,6 @@
               "sha256": "cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
               "urls": [
                 "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_pygments_sdist_1daff049": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "Pygments-2.16.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pygments==2.16.1",
-              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
               ]
             }
           },
@@ -2767,6 +2767,27 @@
               ]
             }
           },
+          "pip_310_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "babel==2.13.1     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"
+            }
+          },
           "pip_39_pylint_py3_none_any_349c8cd3": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2795,53 +2816,14 @@
               ]
             }
           },
-          "pip_310_babel": {
+          "other_module_pip_311_absl_py": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "babel==2.13.1     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"
-            }
-          },
-          "pip_39_jinja2_py3_none_any_bc5dd2ab": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "jinja2-3.1.4-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "jinja2==3.1.4",
-              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
-              ]
+              "dep_template": "@other_module_pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "other_module_pip_311",
+              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
             }
           },
           "pip_39_colorama_sdist_08695f5c": {
@@ -2872,14 +2854,53 @@
               ]
             }
           },
-          "other_module_pip_311_absl_py": {
+          "pip_39_jinja2_py3_none_any_bc5dd2ab": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
-              "dep_template": "@other_module_pip//{name}:{target}",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "other_module_pip_311",
-              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "jinja2-3.1.4-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "jinja2==3.1.4",
+              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_yamllint": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
             }
           },
           "pip_39_pathspec_py3_none_any_3c95343a": {
@@ -2908,27 +2929,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
               ]
-            }
-          },
-          "pip_310_yamllint": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
             }
           },
           "pip_39_markupsafe_sdist_af598ed3": {
@@ -3148,34 +3148,6 @@
               ]
             }
           },
-          "pip_39_wrapt_cp39_cp39_win_amd64_dee60e1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
           "pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_aarch64_21713819": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -3201,6 +3173,34 @@
               "sha256": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
               "urls": [
                 "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_cp39_cp39_win_amd64_dee60e1d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
               ]
             }
           },
@@ -3458,34 +3458,6 @@
               ]
             }
           },
-          "pip_39_s3cmd_py2_none_any_49cd23d5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "s3cmd==2.1.0",
-              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
           "pip_39_packaging_sdist_048fb0e9": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -3511,6 +3483,34 @@
               "sha256": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
               "urls": [
                 "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
+              ]
+            }
+          },
+          "pip_39_s3cmd_py2_none_any_49cd23d5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "s3cmd==2.1.0",
+              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -3542,6 +3542,27 @@
               ]
             }
           },
+          "pip_310_s3cmd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
+            }
+          },
           "pip_39_snowballstemmer_sdist_09b16deb": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -3568,27 +3589,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz"
               ]
-            }
-          },
-          "pip_310_s3cmd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
             }
           },
           "pip_39_imagesize_py2_none_any_0d8d18d0": {
@@ -3838,6 +3838,27 @@
               "requirement": "colorama==0.4.6     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             }
           },
+          "pip_310_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pathspec==0.11.1     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
+            }
+          },
           "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_5_x86_64_18dd842b": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -3864,27 +3885,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/ab/be/d0a76dd4404ee68c7dd611c9b48e58b5c70ac5458e4c951b2c8923c24dd9/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
               ]
-            }
-          },
-          "pip_310_pathspec": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pathspec==0.11.1     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
             }
           },
           "pip_39_markupsafe_cp39_cp39_macosx_10_9_x86_64_6b2b5695": {
@@ -4105,6 +4105,27 @@
               "requirement": "typing-extensions==4.6.3     --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26     --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
             }
           },
+          "pip_310_isort": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "isort==5.12.0     --hash=sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504     --hash=sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
+            }
+          },
           "pip_39_websockets_cp39_cp39_musllinux_1_1_x86_64_97b52894": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4133,7 +4154,7 @@
               ]
             }
           },
-          "pip_310_isort": {
+          "pip_310_sphinxcontrib_qthelp": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4149,37 +4170,18 @@
                 "--extra-index-url",
                 "https://pypi.org/simple/"
               ],
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
-              "requirement": "isort==5.12.0     --hash=sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504     --hash=sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_macosx_10_9_x86_64_3232822c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
+              "requirement": "sphinxcontrib-qthelp==1.0.6     --hash=sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d     --hash=sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             }
           },
           "pip_39_pyyaml_cp39_cp39_musllinux_1_1_x86_64_04ac92ad": {
@@ -4238,34 +4240,32 @@
               ]
             }
           },
-          "pip_310_sphinxcontrib_qthelp": {
+          "pip_39_wrapt_cp39_cp39_macosx_10_9_x86_64_3232822c": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
               "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
               ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "sphinxcontrib-qthelp==1.0.6     --hash=sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d     --hash=sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
+              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
             }
           },
           "pip_310_wrapt": {
@@ -4287,34 +4287,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "wrapt==1.15.0     --hash=sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0     --hash=sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420     --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a     --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c     --hash=sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079     --hash=sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923     --hash=sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f     --hash=sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1     --hash=sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8     --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86     --hash=sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0     --hash=sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364     --hash=sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e     --hash=sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c     --hash=sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e     --hash=sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c     --hash=sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727     --hash=sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff     --hash=sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e     --hash=sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29     --hash=sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7     --hash=sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72     --hash=sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475     --hash=sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a     --hash=sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317     --hash=sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2     --hash=sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd     --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640     --hash=sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98     --hash=sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248     --hash=sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e     --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d     --hash=sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec     --hash=sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1     --hash=sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e     --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9     --hash=sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92     --hash=sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb     --hash=sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094     --hash=sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46     --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29     --hash=sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd     --hash=sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705     --hash=sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8     --hash=sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975     --hash=sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb     --hash=sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e     --hash=sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b     --hash=sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418     --hash=sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019     --hash=sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1     --hash=sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba     --hash=sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6     --hash=sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2     --hash=sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3     --hash=sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7     --hash=sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752     --hash=sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416     --hash=sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f     --hash=sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1     --hash=sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc     --hash=sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145     --hash=sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee     --hash=sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a     --hash=sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7     --hash=sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b     --hash=sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653     --hash=sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0     --hash=sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90     --hash=sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29     --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6     --hash=sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034     --hash=sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09     --hash=sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559     --hash=sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
-            }
-          },
-          "pip_39_yamllint_sdist_9e3d8ddd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "yamllint-1.28.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "yamllint==1.28.0",
-              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
-              ]
             }
           },
           "pip_39_importlib_metadata_py3_none_any_66f342cc": {
@@ -4342,6 +4314,34 @@
               "sha256": "66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
               "urls": [
                 "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_yamllint_sdist_9e3d8ddd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "yamllint-1.28.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "yamllint==1.28.0",
+              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
               ]
             }
           },
@@ -4488,34 +4488,6 @@
               }
             }
           },
-          "pip_39_pyyaml_cp39_cp39_manylinux_2_17_x86_64_bc1bf292": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
           "pip_39_importlib_metadata_sdist_9a547d3b": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4544,6 +4516,34 @@
               ]
             }
           },
+          "pip_39_pyyaml_cp39_cp39_manylinux_2_17_x86_64_bc1bf292": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
           "pip_39_tomli_py3_none_any_939de3e7": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4569,34 +4569,6 @@
               "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
               "urls": [
                 "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_cp39_cp39_win_amd64_c792ea4e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "c792ea4eabc0159535608fc5658a74d1a81020eb35195dd63214dcf07556f67e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f4/3f/65dfa50084a06ab0a05f3ca74195c2c17a1c075b8361327d831ccce0a483/websockets-11.0.3-cp39-cp39-win_amd64.whl"
               ]
             }
           },
@@ -4637,6 +4609,34 @@
               ]
             }
           },
+          "pip_39_websockets_cp39_cp39_win_amd64_c792ea4e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "c792ea4eabc0159535608fc5658a74d1a81020eb35195dd63214dcf07556f67e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f4/3f/65dfa50084a06ab0a05f3ca74195c2c17a1c075b8361327d831ccce0a483/websockets-11.0.3-cp39-cp39-win_amd64.whl"
+              ]
+            }
+          },
           "pip_310_python_dateutil": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4658,27 +4658,6 @@
               "requirement": "python-dateutil==2.8.2     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             }
           },
-          "pip_310_tomli": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            }
-          },
           "pip_310_imagesize": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4698,6 +4677,27 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "imagesize==1.4.1     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"
+            }
+          },
+          "pip_310_tomli": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             }
           },
           "pip_39_sphinxcontrib_jsmath_sdist_a9925e4a": {
@@ -4895,6 +4895,27 @@
               ]
             }
           },
+          "pip_310_dill": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "dill==0.3.6     --hash=sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0     --hash=sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
+            }
+          },
           "pip_39_urllib3_py2_none_any_34b97092": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4949,27 +4970,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/a0/1a/3da73e69ebc00649d11ed836541c92c1a2df0b8a8aa641a2c8746e7c2b9c/websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl"
               ]
-            }
-          },
-          "pip_310_dill": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "dill==0.3.6     --hash=sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0     --hash=sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             }
           },
           "pip_39_babel_sdist_33e0952d": {
@@ -5147,34 +5147,6 @@
               ]
             }
           },
-          "pip_39_wrapt_cp39_cp39_manylinux_2_17_aarch64_9cca3c2c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
-              "urls": [
-                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
           "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_17_aarch64_2297f08f": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5200,6 +5172,34 @@
               "sha256": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
               "urls": [
                 "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_cp39_cp39_manylinux_2_17_aarch64_9cca3c2c": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
@@ -5252,34 +5252,6 @@
               ]
             }
           },
-          "pip_39_python_dateutil_py2_none_any_961d03dc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-dateutil==2.8.2",
-              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
-              ]
-            }
-          },
           "pip_310_sphinxcontrib_applehelp": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5308,6 +5280,34 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "sphinxcontrib-applehelp==1.0.7     --hash=sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d     --hash=sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
+            }
+          },
+          "pip_39_python_dateutil_py2_none_any_961d03dc": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-dateutil==2.8.2",
+              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
+              ]
             }
           },
           "pip_39_pyyaml_sdist_bfdf460b": {
@@ -5396,34 +5396,6 @@
               "requirement": "pygments==2.16.1     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
             }
           },
-          "pip_39_tabulate_sdist_0095b12b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tabulate-0.9.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tabulate==0.9.0",
-              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
-              ]
-            }
-          },
           "pip_39_sphinxcontrib_serializinghtml_py3_none_any_9b36e503": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5458,6 +5430,34 @@
               "sha256": "9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1",
               "urls": [
                 "https://files.pythonhosted.org/packages/95/d6/2e0bda62b2a808070ac922d21a950aa2cb5e4fcfb87e5ff5f86bc43a2201/sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_tabulate_sdist_0095b12b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tabulate-0.9.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tabulate==0.9.0",
+              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
               ]
             }
           },
@@ -5592,6 +5592,27 @@
               ]
             }
           },
+          "pip_310_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "certifi==2023.7.22     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
+            }
+          },
           "pip_39_zipp_py3_none_any_58da6168": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5618,27 +5639,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/da/cc/b9958af9f9c86b51f846d8487440af495ecf19b16e426fce1ed0b0796175/zipp-3.20.0-py3-none-any.whl"
               ]
-            }
-          },
-          "pip_310_certifi": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "certifi==2023.7.22     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             }
           },
           "pip_310_pyyaml": {
@@ -5817,6 +5817,27 @@
               ]
             }
           },
+          "pip_310_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "chardet==4.0.0     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            }
+          },
           "pip_39_websockets_cp39_cp39_macosx_10_9_universal2_777354ee": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5843,27 +5864,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/c0/21/cb9dfbbea8dc0ad89ced52630e7e61edb425fb9fdc6002f8d0c5dd26b94b/websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl"
               ]
-            }
-          },
-          "pip_310_chardet": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "chardet==4.0.0     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             }
           },
           "pip_39_pyyaml_cp39_cp39_manylinux_2_17_s390x_b786eecb": {
@@ -6020,6 +6020,28 @@
               ]
             }
           },
+          "pip_310_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "wheel==0.40.0     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
+            }
+          },
           "pip_39_pyyaml_cp39_cp39_macosx_11_0_arm64_c8098ddc": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6046,28 +6068,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/0e/88/21b2f16cb2123c1e9375f2c93486e35fdc86e63f02e274f0e99c589ef153/PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
               ]
-            }
-          },
-          "pip_310_wheel": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "wheel==0.40.0     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
             }
           },
           "pip_39_dill_py3_none_any_a07ffd23": {
@@ -6098,6 +6098,27 @@
               ]
             }
           },
+          "pip_310_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "jinja2==3.1.4     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+            }
+          },
           "pip_39_babel_py3_none_any_7077a498": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6124,27 +6145,6 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/86/14/5dc2eb02b7cc87b2f95930310a2cc5229198414919a116b564832c747bc1/Babel-2.13.1-py3-none-any.whl"
               ]
-            }
-          },
-          "pip_310_jinja2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "jinja2==3.1.4     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
             }
           },
           "pip_310_websockets": {
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "9uxFBLt5C2maO2dUYrWGFn3cAx5Rzt9Ha8y0siUl2oM=",
+        "bzlTransitiveDigest": "UvrP/CAjGKFBB93blIhN3hlokUjfGCXOWAbAKcpsnyg=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",
@@ -6334,28 +6334,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_zipp_sdist_a7a22e05": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "zipp-3.11.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.11.0",
-              "sha256": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_urllib3_sdist_076907bf": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6375,6 +6353,28 @@
               "sha256": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
               "urls": [
                 "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_sdist_a7a22e05": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "zipp-3.11.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.11.0",
+              "sha256": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
               ]
             }
           },
@@ -6677,31 +6677,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_keyring_py3_none_any_771ed2a9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "keyring-23.13.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==23.13.1",
-              "sha256": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_jaraco_classes_sdist_89559fa5": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6727,7 +6702,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_rich_py3_none_any_7c963f0d": {
+          "rules_python_publish_deps_311_keyring_py3_none_any_771ed2a9": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -6742,13 +6717,35 @@
                 "cp311_osx_x86_64",
                 "cp311_windows_x86_64"
               ],
-              "filename": "rich-13.2.0-py3-none-any.whl",
+              "filename": "keyring-23.13.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.2.0",
-              "sha256": "7c963f0d03819221e9ac561e1bc866e3f95a02248c1234daa48954e6d381c003",
+              "requirement": "keyring==23.13.1",
+              "sha256": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/cf/a6369a2aee266c2d7604230f083d4bd14b8f69bc69eb25b3da63b9f2f853/rich-13.2.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8c7fe7af": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.0.1",
+              "sha256": "8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/c5/dd3a17a615775d0ffc3e12b0e47833d8b7e0a4871431dad87a3f92382a19/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
               ]
             }
           },
@@ -6774,7 +6771,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8c7fe7af": {
+          "rules_python_publish_deps_311_rich_py3_none_any_7c963f0d": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -6784,15 +6781,18 @@
                 "cp311_linux_arm",
                 "cp311_linux_ppc",
                 "cp311_linux_s390x",
-                "cp311_linux_x86_64"
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "filename": "rich-13.2.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+              "requirement": "rich==13.2.0",
+              "sha256": "7c963f0d03819221e9ac561e1bc866e3f95a02248c1234daa48954e6d381c003",
               "urls": [
-                "https://files.pythonhosted.org/packages/df/c5/dd3a17a615775d0ffc3e12b0e47833d8b7e0a4871431dad87a3f92382a19/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+                "https://files.pythonhosted.org/packages/0e/cf/a6369a2aee266c2d7604230f083d4bd14b8f69bc69eb25b3da63b9f2f853/rich-13.2.0-py3-none-any.whl"
               ]
             }
           },
@@ -6840,26 +6840,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "idna-3.10.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.10",
-              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_887623fe": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6879,6 +6859,26 @@
               "sha256": "887623fe0d70f48ab3f5e4dbf234986b1329a64c066d719432d0698522749929",
               "urls": [
                 "https://files.pythonhosted.org/packages/da/56/1b2c8aa8e62bfb568022b68d77ebd2bd9afddea37898350fbfe008dcefa7/cryptography-42.0.4-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
               ]
             }
           },
@@ -7045,28 +7045,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_idna_py3_none_any_90b77e79": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "idna-3.4-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.4",
-              "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_44a64043": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7086,6 +7064,28 @@
               "sha256": "44a64043f743485925d3bcac548d05df0f9bb445c5fcca6681889c7c3ab12764",
               "urls": [
                 "https://files.pythonhosted.org/packages/7e/45/81f378eb85aab14b229c1032ba3694eff85a3d75b35092c3e71abd2d34f6/cryptography-42.0.4-cp39-abi3-manylinux_2_28_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_py3_none_any_90b77e79": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "idna-3.4-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.4",
+              "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl"
               ]
             }
           },
@@ -7153,6 +7153,24 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_pywin32_ctypes_py2_none_any_9dc2d991": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.0",
+              "sha256": "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9e/4b/3ab2720f1fa4b4bc924ef1932b842edf10007e4547ea8157b0b9fc78599a/pywin32_ctypes-0.2.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_twine_sdist_9e102ef5": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7175,24 +7193,6 @@
               "sha256": "9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8",
               "urls": [
                 "https://files.pythonhosted.org/packages/b7/1a/a7884359429d801cd63c2c5512ad0a337a509994b0e42d9696d4778d71f6/twine-4.0.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_py2_none_any_9dc2d991": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32_ctypes-0.2.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.0",
-              "sha256": "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9e/4b/3ab2720f1fa4b4bc924ef1932b842edf10007e4547ea8157b0b9fc78599a/pywin32_ctypes-0.2.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -7263,6 +7263,26 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_charset_normalizer_sdist_f30c3cb3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset-normalizer-3.3.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.3.2",
+              "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_cryptography_sdist_831a4b37": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7285,26 +7305,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_sdist_f30c3cb3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset-normalizer-3.3.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.3.2",
-              "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_certifi_py3_none_any_922820b5": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7322,51 +7322,6 @@
               "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
               "urls": [
                 "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_zipp_sdist_bf1dcf64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "zipp-3.19.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.19.2",
-              "sha256": "bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d3/20/b48f58857d98dcb78f9e30ed2cfe533025e2e9827bbd36ea0a64cc00cbc1/zipp-3.19.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
               ]
             }
           },
@@ -7412,6 +7367,51 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_sdist_bf1dcf64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.19.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.19.2",
+              "sha256": "bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d3/20/b48f58857d98dcb78f9e30ed2cfe533025e2e9827bbd36ea0a64cc00cbc1/zipp-3.19.2.tar.gz"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_more_itertools_py3_none_any_250e83d7": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7434,31 +7434,6 @@
               "sha256": "250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
               "urls": [
                 "https://files.pythonhosted.org/packages/5d/87/1ec3fcc09d2c04b977eabf8a1083222f82eaa2f46d5a4f85f403bf8e7b30/more_itertools-9.0.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
               ]
             }
           },
@@ -7487,6 +7462,51 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_549a3a73": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.3.2",
+              "sha256": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_rfc3986_sdist_97aacf9d": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7509,26 +7529,6 @@
               "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
               "urls": [
                 "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_549a3a73": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.3.2",
-              "sha256": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl"
               ]
             }
           },
@@ -7741,6 +7741,28 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_s390x_4a8fcf28": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.0.1",
+              "sha256": "4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/80/54/183163f9910936e57a60ee618f4f5cc91c2f8333ee2d4ebc6c50f6c8684d/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_webencodings_sdist_b36a1c24": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7763,28 +7785,6 @@
               "sha256": "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923",
               "urls": [
                 "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_s390x_4a8fcf28": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/80/54/183163f9910936e57a60ee618f4f5cc91c2f8333ee2d4ebc6c50f6c8684d/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl"
               ]
             }
           },
@@ -7813,26 +7813,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_urllib3_py2_none_any_37a03444": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "urllib3-1.26.19-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==1.26.19",
-              "sha256": "37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_79909e27": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7852,6 +7832,26 @@
               "sha256": "79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
               "urls": [
                 "https://files.pythonhosted.org/packages/d9/7a/60d45c9453212b30eebbf8b5cddbdef330eebddfcf335bce7920c43fb72e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_py2_none_any_37a03444": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-1.26.19-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==1.26.19",
+              "sha256": "37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl"
               ]
             }
           },
@@ -7924,6 +7924,24 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_pywin32_ctypes_sdist_24ffc3b3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32-ctypes-0.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.0",
+              "sha256": "24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7a/7d/0dbc4c99379452a819b0fb075a0ffbb98611df6b6d59f54db67367af5bc0/pywin32-ctypes-0.2.0.tar.gz"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_rich_sdist_f1a00cdd": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -7946,24 +7964,6 @@
               "sha256": "f1a00cdd3eebf999a15d85ec498bfe0b1a77efe9b34f645768a54132ef444ac5",
               "urls": [
                 "https://files.pythonhosted.org/packages/9e/5e/c3dc3ea32e2c14bfe46e48de954dd175bff76bcc549dd300acb9689521ae/rich-13.2.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_sdist_24ffc3b3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32-ctypes-0.2.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.0",
-              "sha256": "24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7a/7d/0dbc4c99379452a819b0fb075a0ffbb98611df6b6d59f54db67367af5bc0/pywin32-ctypes-0.2.0.tar.gz"
               ]
             }
           },
@@ -8039,6 +8039,26 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_66394663": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.3.2",
+              "sha256": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+              "urls": [
+                "https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_docutils_py3_none_any_5e1de4d8": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -8058,6 +8078,26 @@
               "sha256": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc",
               "urls": [
                 "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
               ]
             }
           },
@@ -8083,46 +8123,6 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "docutils-0.21.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.21.2",
-              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_66394663": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.3.2",
-              "sha256": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
-              "urls": [
-                "https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl"
-              ]
-            }
-          },
           "rules_python_publish_deps_311_jeepney_sdist_5efe48d2": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -8142,26 +8142,6 @@
               "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
               "urls": [
                 "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_zipp_py3_none_any_f091755f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "zipp-3.19.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.19.2",
-              "sha256": "f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl"
               ]
             }
           },
@@ -8190,6 +8170,26 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_zipp_py3_none_any_f091755f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.19.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.19.2",
+              "sha256": "f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_0c0a5902": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -8209,31 +8209,6 @@
               "sha256": "0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
               "urls": [
                 "https://files.pythonhosted.org/packages/12/e5/aa09a1c39c3e444dd223d63e2c816c18ed78d035cff954143b2a539bdc9e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rfc3986==2.0.0",
-              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -8259,6 +8234,31 @@
               "sha256": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
               "urls": [
                 "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -8326,6 +8326,28 @@
               "groups": {}
             }
           },
+          "rules_python_publish_deps_311_charset_normalizer_sdist_ebea339a": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "charset-normalizer-3.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.0.1",
+              "sha256": "ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz"
+              ]
+            }
+          },
           "rules_python_publish_deps_311_webencodings_py2_none_any_a0af1213": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -8351,25 +8373,23 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_sdist_ebea339a": {
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_573f6eac": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "charset-normalizer-3.0.1.tar.gz",
+              "filename": "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+              "requirement": "charset-normalizer==3.3.2",
+              "sha256": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
               "urls": [
-                "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz"
+                "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
               ]
             }
           },
@@ -8392,26 +8412,6 @@
               "sha256": "72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
               "urls": [
                 "https://files.pythonhosted.org/packages/01/ff/9ee4a44e8c32fe96dfc12daa42f29294608a55eadc88f327939327fb20fb/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_573f6eac": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.3.2",
-              "sha256": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
-              "urls": [
-                "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
               ]
             }
           },

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "+F6sV3YAo/qldTLeU0MTvh5nK4Vr1gCZSWzoX+v0qH0=",
+        "bzlTransitiveDigest": "hJ7eKsoEMeWHFRSZTVOIUp6MuIW+j8o0kWoQVhEuqmU=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "1uBC9tJDPdn7Ubmb5CUjscK+gb/nYP7elM49ue6TLB0=",
+        "bzlTransitiveDigest": "qzmXF5mOOAUh9/YsfU7yBaX1cvNUWD61alQXaKPT6co=",
         "usagesDigest": "Y8ihY+R57BAFhalrVLVdJFrpwlbsiKz9JPJ99ljF7HA=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -367,15 +367,18 @@ You cannot use both the additive_build_content and additive_build_content_file a
     for module in module_ctx.modules:
         for attr in module.tags.override:
             if not module.is_root:
-                fail("overrides are only supported in root modules")
+                _fail("overrides are only supported in root modules")
+                return None
 
             if not attr.file.endswith(".whl"):
-                fail("Only whl overrides are supported at this time")
+                _fail("Only whl overrides are supported at this time")
+                return None
 
             whl_name = normalize_name(parse_whl_name(attr.file).distribution)
 
             if attr.file in _overriden_whl_set:
-                fail("Duplicate module overrides for '{}'".format(attr.file))
+                _fail("Duplicate module overrides for '{}'".format(attr.file))
+                return None
             _overriden_whl_set[attr.file] = None
 
             for patch in attr.patches:
@@ -416,7 +419,7 @@ You cannot use both the additive_build_content and additive_build_content_file a
             elif pip_hub_map[hub_name].module_name != mod.name:
                 # We cannot have two hubs with the same name in different
                 # modules.
-                fail((
+                _fail((
                     "Duplicate cross-module pip hub named '{hub}': pip hub " +
                     "names must be unique across modules. First defined " +
                     "by module '{first_module}', second attempted by " +
@@ -426,9 +429,10 @@ You cannot use both the additive_build_content and additive_build_content_file a
                     first_module = pip_hub_map[hub_name].module_name,
                     second_module = mod.name,
                 ))
+                return None
 
             elif pip_attr.python_version in pip_hub_map[hub_name].python_versions:
-                fail((
+                _fail((
                     "Duplicate pip python version '{version}' for hub " +
                     "'{hub}' in module '{module}': the Python versions " +
                     "used for a hub must be unique"
@@ -437,6 +441,7 @@ You cannot use both the additive_build_content and additive_build_content_file a
                     module = mod.name,
                     version = pip_attr.python_version,
                 ))
+                return None
             else:
                 pip_hub_map[pip_attr.hub_name].python_versions.append(pip_attr.python_version)
 

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -403,7 +403,7 @@ You cannot use both the additive_build_content and additive_build_content_file a
     exposed_packages = {}
     whl_libraries = {}
 
-    is_extension_reproducible = True
+    is_reproducible = True
 
     for mod in module_ctx.modules:
         for pip_attr in mod.tags.parse:
@@ -450,15 +450,18 @@ You cannot use both the additive_build_content and additive_build_content_file a
                 whl_overrides = whl_overrides,
                 whl_libraries = whl_libraries,
             )
-            is_extension_reproducible = is_extension_reproducible and is_hub_reproducible
+            is_reproducible = is_reproducible and is_hub_reproducible
 
     return struct(
         whl_mods = whl_mods,
         hub_whl_map = hub_whl_map,
         hub_group_map = hub_group_map,
-        exposed_packages = exposed_packages,
+        exposed_packages = {
+            name: sorted(value)
+            for name, value in exposed_packages.items()
+        },
         whl_libraries = whl_libraries,
-        is_extension_reproducible = is_extension_reproducible,
+        is_reproducible = is_reproducible,
     )
 
 def _pip_impl(module_ctx):
@@ -545,7 +548,7 @@ def _pip_impl(module_ctx):
                 key: json.encode(value)
                 for key, value in whl_map.items()
             },
-            packages = sorted(mods.exposed_packages.get(hub_name, {})),
+            packages = mods.exposed_packages.get(hub_name, {}),
             groups = mods.hub_group_map.get(hub_name),
         )
 
@@ -556,7 +559,7 @@ def _pip_impl(module_ctx):
         # In order to be able to dogfood the `experimental_index_url` feature before it gets
         # stabilized, we have created the `_pip_non_reproducible` function, that will result
         # in extra entries in the lock file.
-        return module_ctx.extension_metadata(reproducible = mods.is_extension_reproducible)
+        return module_ctx.extension_metadata(reproducible = mods.is_reproducible)
     else:
         return None
 

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -535,12 +535,12 @@ def _pip_impl(module_ctx):
     # Build all of the wheel modifications if the tag class is called.
     _whl_mods_impl(mods.whl_mods)
 
+    # We sort so that the lock-file remains the same no matter the order of how the
+    # args are manipulated in the code going before.
     for name, args in sorted(mods.whl_libraries.items()):
-        # We sort so that the lock-file remains the same no matter the order of how the
-        # args are manipulated in the code going before.
         whl_library(name = name, **dict(sorted(args.items())))
 
-    for hub_name, whl_map in mods.hub_whl_map.items():
+    for hub_name, whl_map in sorted(mods.hub_whl_map.items()):
         hub_repository(
             name = hub_name,
             repo_name = hub_name,

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -393,6 +393,18 @@ You cannot use both the additive_build_content and additive_build_content_file a
     return struct(
         whl_mods = whl_mods,
         whl_overrides = whl_overrides,
+
+        # Used to track all the different pip hubs and the spoke pip Python
+        # versions.
+        pip_hub_map = {},
+
+        # Keeps track of all the hub's whl repos across the different versions.
+        # dict[hub, dict[whl, dict[version, str pip]]]
+        # Where hub, whl, and pip are the repo names
+        hub_whl_map = {},
+        hub_group_map = {},
+        exposed_packages = {},
+        simpleapi_cache = {},
     )
 
 def _pip_impl(module_ctx):
@@ -466,29 +478,17 @@ def _pip_impl(module_ctx):
     # Build all of the wheel modifications if the tag class is called.
     _whl_mods_impl(mods.whl_mods)
 
-    # Used to track all the different pip hubs and the spoke pip Python
-    # versions.
-    pip_hub_map = {}
-
-    # Keeps track of all the hub's whl repos across the different versions.
-    # dict[hub, dict[whl, dict[version, str pip]]]
-    # Where hub, whl, and pip are the repo names
-    hub_whl_map = {}
-    hub_group_map = {}
-    exposed_packages = {}
-
-    simpleapi_cache = {}
     is_extension_reproducible = True
 
     for mod in module_ctx.modules:
         for pip_attr in mod.tags.parse:
             hub_name = pip_attr.hub_name
-            if hub_name not in pip_hub_map:
-                pip_hub_map[pip_attr.hub_name] = struct(
+            if hub_name not in mods.pip_hub_map:
+                mods.pip_hub_map[pip_attr.hub_name] = struct(
                     module_name = mod.name,
                     python_versions = [pip_attr.python_version],
                 )
-            elif pip_hub_map[hub_name].module_name != mod.name:
+            elif mods.pip_hub_map[hub_name].module_name != mod.name:
                 # We cannot have two hubs with the same name in different
                 # modules.
                 fail((
@@ -498,11 +498,11 @@ def _pip_impl(module_ctx):
                     "module '{second_module}'"
                 ).format(
                     hub = hub_name,
-                    first_module = pip_hub_map[hub_name].module_name,
+                    first_module = mods.pip_hub_map[hub_name].module_name,
                     second_module = mod.name,
                 ))
 
-            elif pip_attr.python_version in pip_hub_map[hub_name].python_versions:
+            elif pip_attr.python_version in mods.pip_hub_map[hub_name].python_versions:
                 fail((
                     "Duplicate pip python version '{version}' for hub " +
                     "'{hub}' in module '{module}': the Python versions " +
@@ -513,20 +513,20 @@ def _pip_impl(module_ctx):
                     version = pip_attr.python_version,
                 ))
             else:
-                pip_hub_map[pip_attr.hub_name].python_versions.append(pip_attr.python_version)
+                mods.pip_hub_map[pip_attr.hub_name].python_versions.append(pip_attr.python_version)
 
             is_hub_reproducible = _create_whl_repos(
                 module_ctx,
-                exposed_packages = exposed_packages,
-                group_map = hub_group_map,
+                exposed_packages = mods.exposed_packages,
+                group_map = mods.hub_group_map,
                 pip_attr = pip_attr,
-                simpleapi_cache = simpleapi_cache,
-                whl_map = hub_whl_map,
+                simpleapi_cache = mods.simpleapi_cache,
+                whl_map = mods.hub_whl_map,
                 whl_overrides = mods.whl_overrides,
             )
             is_extension_reproducible = is_extension_reproducible and is_hub_reproducible
 
-    for hub_name, whl_map in hub_whl_map.items():
+    for hub_name, whl_map in mods.hub_whl_map.items():
         hub_repository(
             name = hub_name,
             repo_name = hub_name,
@@ -534,8 +534,8 @@ def _pip_impl(module_ctx):
                 key: json.encode(value)
                 for key, value in whl_map.items()
             },
-            packages = sorted(exposed_packages.get(hub_name, {})),
-            groups = hub_group_map.get(hub_name),
+            packages = sorted(mods.exposed_packages.get(hub_name, {})),
+            groups = mods.hub_group_map.get(hub_name),
         )
 
     if bazel_features.external_deps.extension_metadata_has_reproducible:


### PR DESCRIPTION
This PR introduces a new `parse_modules` function in the `pypi/extension.bzl`
code to mimic the structure of the `python` extension and to make it easier to
write unit tests against the extension itself.

With this we can:
* Write unit tests to see what `whl_library` repos would be created.
* Mock out the SimpleAPI interaction by pre-populating the `simpleapi_cache`.

This is just making the seam and the tests, etc will be written in followup PRs.
