### PR TITLE
ci: upgrade to rbe_ubuntu2004

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -177,7 +177,7 @@ tasks:
     <<: *minimum_supported_version
     <<: *reusable_config
     name: "RBE: Ubuntu, minimum Bazel"
-    platform: rbe_ubuntu1604
+    platform: rbe_ubuntu2004
     build_flags:
       # BazelCI sets --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1,
       # which prevents cc toolchain autodetection from working correctly
@@ -195,7 +195,7 @@ tasks:
   rbe:
     <<: *reusable_config
     name: "RBE: Ubuntu"
-    platform: rbe_ubuntu1604
+    platform: rbe_ubuntu2004
     test_flags:
       - "--test_tag_filters=-integration-test,-acceptance-test"
       - "--extra_toolchains=@buildkite_config//config:cc-toolchain"


### PR DESCRIPTION
This is per https://github.com/bazelbuild/rules_python/pull/2293#issuecomment-2407749777

From what I can tell ubuntu1604 is very old and not well supported.
