### PR TITLE
tests: use rules_cc 0.0.13 for ignore_root_user_error test

### DIFF
--- a/tests/integration/ignore_root_user_error/WORKSPACE
+++ b/tests/integration/ignore_root_user_error/WORKSPACE
@@ -1,3 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
+    strip_prefix = "rules_cc-0.0.13",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
+)
+
 local_repository(
     name = "rules_python",
     path = "../../..",
@@ -12,8 +21,6 @@ python_register_toolchains(
     ignore_root_user_error = True,
     python_version = "3.9",
 )
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",


### PR DESCRIPTION
This is so that the test works with Bazel@head

Fixes https://github.com/bazelbuild/rules_python/issues/2310