### PR TITLE
deps: use rules_cc 0.0.13 to support newer bazel versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ A brief description of the categories of changes:
 
 {#v0-0-0-changed}
 ### Changed
-- Nothing yet
+* (deps) (WORKSPACE only) rules_cc 0.0.13 and protobuf 27.0 is now the default
+  version used; this for Bazel 8+ support (previously version was rules_cc 0.0.9
+  and no protobuf version specified)
+  ([2310](https://github.com/bazelbuild/rules_python/issues/2310)).
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/python/private/py_repositories.bzl
+++ b/python/private/py_repositories.bzl
@@ -55,8 +55,14 @@ def py_repositories():
     )
     http_archive(
         name = "rules_cc",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
-        sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
-        strip_prefix = "rules_cc-0.0.9",
+        sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
+        strip_prefix = "rules_cc-0.0.13",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
+    )
+    http_archive(
+        name = "protobuf",
+        sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
+        strip_prefix = "protobuf-27.0",
+        url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
     )
     pypi_deps()

--- a/tests/integration/compile_pip_requirements/WORKSPACE
+++ b/tests/integration/compile_pip_requirements/WORKSPACE
@@ -1,19 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "protobuf",
-    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-    strip_prefix = "protobuf-27.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
-    strip_prefix = "rules_cc-0.0.13",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
-)
-
 local_repository(
     name = "rules_python",
     path = "../../..",

--- a/tests/integration/ignore_root_user_error/WORKSPACE
+++ b/tests/integration/ignore_root_user_error/WORKSPACE
@@ -1,19 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "protobuf",
-    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-    strip_prefix = "protobuf-27.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
-    strip_prefix = "rules_cc-0.0.13",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
-)
-
 local_repository(
     name = "rules_python",
     path = "../../..",

--- a/tests/integration/pip_parse/WORKSPACE
+++ b/tests/integration/pip_parse/WORKSPACE
@@ -1,19 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "protobuf",
-    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-    strip_prefix = "protobuf-27.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
-    strip_prefix = "rules_cc-0.0.13",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
-)
-
 local_repository(
     name = "rules_python",
     path = "../../..",

--- a/tests/integration/py_cc_toolchain_registered/WORKSPACE
+++ b/tests/integration/py_cc_toolchain_registered/WORKSPACE
@@ -1,19 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "protobuf",
-    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-    strip_prefix = "protobuf-27.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
-    strip_prefix = "rules_cc-0.0.13",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
-)
-
 local_repository(
     name = "rules_python",
     path = "../../..",


### PR DESCRIPTION
In order for WORKSPACE to work with newer bazel versions, rules_cc 0.0.13 or higher is
necessary. rules_cc then requires a newer protobuf version.

Note I couldn't figure out the minimum protobuf version, but 27.0 seems to work OK.

AFAIK only WORKSPACE is affected. Our bzlmod uses 0.0.9 and hasn't had issues.

Fixes https://github.com/bazelbuild/rules_python/issues/2310