### PR TITLE
docs: link to main docs in generated release notes

### DIFF
--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -25,9 +25,10 @@ git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat > release_notes.txt << EOF
-## Using Bzlmod with Bazel 6
 
-**NOTE: bzlmod support is still beta. APIs subject to change.**
+For more detailed setup instructions, see https://rules-python.readthedocs.io/en/latest/getting-started.html
+
+## Using Bzlmod
 
 Add to your \`MODULE.bazel\` file:
 


### PR DESCRIPTION
The generated release notes provide some very simple copy/paste quick start, but don't
tell where to find more detailed info. Link to our main docs so users know where to
find out more.

Along the way:
* Drop Bazel 6 mention. It'll be unsupported pretty soon.
* Drop "bzlmod is beta" mention, since the APIs are stable enough (and stability is
  better covered in other docs which can handle the nuance of what is/isn't GA)
