### PR TITLE
type(feat): Allow parsing of wheel file paths in requirements.in 

### DIFF
--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -27,6 +27,7 @@ def pip_compile(
         src = None,
         extra_args = [],
         extra_deps = [],
+        extra_data = [],
         generate_hashes = True,
         py_binary = _py_binary,
         py_test = _py_test,
@@ -99,7 +100,7 @@ def pip_compile(
         visibility = visibility,
     )
 
-    data = [name, requirements_txt] + srcs + [f for f in (requirements_linux, requirements_darwin, requirements_windows) if f != None]
+    data = [name, requirements_txt] + srcs + [f for f in (requirements_linux, requirements_darwin, requirements_windows) if f != None] + extra_data
 
     # Use the Label constructor so this is expanded in the context of the file
     # where it appears, which is to say, in @rules_python


### PR DESCRIPTION
I have a `.whl` file inside my bazel repo. I would like to add this to `requirements.in` like

```
path/to/my.whl
```

Adding `extra_data` to `pip_compile` and passing this through is sufficient.
eg
```
compile_pip_requirements(
  ...
  extra_data = ["//path/to:my.whl"],
)
```

An issue I came across is pip tools puts the absolute path to the wheel in `requirements.txt` which isn't great.
So I change the path back to a relative one in `dependency_resolver.py`