### PR TITLE
fix(bzlmod): generate config_setting values for all python toolchains (#2350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ A brief description of the categories of changes:
 * Particular sub-systems are identified using parentheses, e.g. `(bzlmod)` or
   `(docs)`.
 
+{#v0-0-0}
 ## Unreleased
+
+[0.0.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.0.0
 
 ### Changed
 - Nothing yet
@@ -33,6 +36,17 @@ A brief description of the categories of changes:
 
 ### Removed
 - Nothing yet
+
+{#v0-37-2}
+## [0.37.2] - 2024-10-27
+
+[0.37.2]: https://github.com/bazelbuild/rules_python/releases/tag/0.37.2
+
+{#v0-37-2-fixed}
+### Fixed
+* (bzlmod) Generate `config_setting` values for all available toolchains instead
+  of only the registered toolchains, which restores the previous behaviour that
+  `bzlmod` users would have observed.
 
 {#v0-37-1}
 ## [0.37.1] - 2024-10-22

--- a/examples/multi_python_versions/MODULE.bazel
+++ b/examples/multi_python_versions/MODULE.bazel
@@ -30,6 +30,7 @@ python.toolchain(
 )
 use_repo(
     python,
+    "pythons_hub",
     python = "python_versions",
 )
 

--- a/examples/multi_python_versions/tests/BUILD.bazel
+++ b/examples/multi_python_versions/tests/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@python//3.10:defs.bzl", py_binary_3_10 = "py_binary", py_test_3_10 = "py_test")
 load("@python//3.11:defs.bzl", py_binary_3_11 = "py_binary", py_test_3_11 = "py_test")
 load("@python//3.8:defs.bzl", py_binary_3_8 = "py_binary", py_test_3_8 = "py_test")
 load("@python//3.9:defs.bzl", py_binary_3_9 = "py_binary", py_test_3_9 = "py_test")
+load("@pythons_hub//:versions.bzl", "MINOR_MAPPING", "PYTHON_VERSIONS")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:versions.bzl", DEFAULT_MINOR_MAPPING = "MINOR_MAPPING", DEFAULT_TOOL_VERSIONS = "TOOL_VERSIONS")
+load("@rules_python//python/private:text_util.bzl", "render")  # buildifier: disable=bzl-visibility
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 copy_file(
@@ -182,4 +187,38 @@ sh_test(
         "VERSION_CHECK": "3.10",
         "VERSION_PY_BINARY": "$(rootpath :version_3_10)",
     },
+)
+
+# The following test ensures that default toolchain versions are the same as in
+# the TOOL_VERSIONS array.
+
+# NOTE @aignas 2024-10-26: This test here is to do a sanity check and not
+# include extra dependencies - if rules_testing is included here, we can
+# potentially uses `rules_testing` for a more lightweight test.
+write_file(
+    name = "default_python_versions",
+    out = "default_python_versions.txt",
+    content = [
+        "MINOR_MAPPING:",
+        render.dict(dict(sorted(DEFAULT_MINOR_MAPPING.items()))),
+        "PYTHON_VERSIONS:",
+        render.list(sorted(DEFAULT_TOOL_VERSIONS)),
+    ],
+)
+
+write_file(
+    name = "pythons_hub_versions",
+    out = "pythons_hub_versions.txt",
+    content = [
+        "MINOR_MAPPING:",
+        render.dict(dict(sorted(MINOR_MAPPING.items()))),
+        "PYTHON_VERSIONS:",
+        render.list(sorted(PYTHON_VERSIONS)),
+    ],
+)
+
+diff_test(
+    name = "test_versions",
+    file1 = "default_python_versions",
+    file2 = "pythons_hub_versions",
 )

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -241,6 +241,7 @@ def _python_impl(module_ctx):
         # Last toolchain is default
         default_python_version = py.default_python_version,
         minor_mapping = py.config.minor_mapping,
+        python_versions = list(py.config.default["tool_versions"].keys()),
         toolchain_prefixes = [
             render.toolchain_prefix(index, toolchain.name, _TOOLCHAIN_INDEX_PAD_LENGTH)
             for index, toolchain in enumerate(py.toolchains)


### PR DESCRIPTION
fix(bzlmod): generate config_setting values for all python toolchains (#2350)

#2253 broke how the config settings are generated and only generated the
config setting values for the python version values that we would have
the registered toolchains for. This PR restores the previous behaviour.
However, if the root module uses `python.override` to remove the allowed
toolchains, then `config_settings` will be also affected.

(cherry picked from commit 9340a8199cac0912305dad427a5cdc72ee4fc7ff)

Conflicts:
- CHANGELOG.md
