### PR TITLE
chore: add aignas to the BCR maintainers

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -10,6 +10,11 @@
       "name": "Thulio Ferraz Assis",
       "email": "thulio@aspect.dev",
       "github": "f0rmiga"
+    },
+    {
+      "name": "Ignas Anikevicius",
+      "email": "bcr-ignas@use.startmail.com",
+      "github": "aignas"
     }
   ],
   "repository": [


### PR DESCRIPTION
It seems that it got removed in bazelbuild/bazel-central-registry#2838
