### PR TITLE
feat: add features.version value

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+python/features.bzl export-subst
 tools/publish/*.txt linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ A brief description of the categories of changes:
   `requirements_linux.txt`, `requirements_windows.txt` for each respective OS
   and one extra file `requirements_universal.txt` if you prefer a single file.
   The `requirements.txt` file may be removed in the future.
+* The rules_python version is now reported in `//python/features.bzl#features.version`
 
 {#v0-0-0-removed}
 ### Removed

--- a/python/features.bzl
+++ b/python/features.bzl
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Allows detecting of rules_python features that aren't easily detected."""
 
+_VERSION_PRIVATE = "$Format:%(describe:tags=true)$"
+
 features = struct(
+    version = _VERSION_PRIVATE if '$Format' not in _VERSION_PRIVATE else ''
     precompile = True,
 )

--- a/python/features.bzl
+++ b/python/features.bzl
@@ -13,9 +13,11 @@
 # limitations under the License.
 """Allows detecting of rules_python features that aren't easily detected."""
 
+# This is a magic string expanded by `git archive`, as set by `.gitattributes`
+# See https://git-scm.com/docs/git-archive/2.29.0#Documentation/git-archive.txt-export-subst
 _VERSION_PRIVATE = "$Format:%(describe:tags=true)$"
 
 features = struct(
-    version = _VERSION_PRIVATE if '$Format' not in _VERSION_PRIVATE else ''
+    version = _VERSION_PRIVATE if "$Format" not in _VERSION_PRIVATE else "",
     precompile = True,
 )


### PR DESCRIPTION
This adds a `features.version` value that is populated by git when `git archive` is run. This means it will be expanded when our release action runs to the tag name. Otherwise, it isn't expanded. When it isn't expanded, the value is set to the empty string.