### PR TITLE
draft: helper to run an arbitrary interpreter or interpreter from a binary

### DIFF
--- a/tools/run/BUILD.bazel
+++ b/tools/run/BUILD.bazel
@@ -1,0 +1,10 @@
+load(":run.bzl", "interpreter")
+
+interpreter(
+    name = "run",
+)
+
+label_flag(
+    name = "bin",
+    build_setting_default = "//python:none",
+)

--- a/tools/run/run.bzl
+++ b/tools/run/run.bzl
@@ -1,0 +1,40 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
+load("//python/private:sentinel.bzl", "SentinelInfo")
+load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")
+
+def _interpreter_impl(ctx):
+    if SentinelInfo in ctx.attr.binary:
+        toolchain = ctx.toolchains[TARGET_TOOLCHAIN_TYPE]
+        runtime = toolchain.py3_runtime
+    else:
+        runtime = ctx.attr.binary[PyRuntimeInfo]
+
+    # NOTE: We name the output filename after the underlying file name
+    # because of things like pyenv: they use $0 to determine what to
+    # re-exec. If it's not a recognized name, then they fail.
+    if runtime.interpreter:
+        executable = ctx.actions.declare_file(runtime.interpreter.basename)
+        ctx.actions.symlink(output = executable, target_file = runtime.interpreter, is_executable = True)
+    else:
+        executable = ctx.actions.declare_symlink(paths.basename(runtime.interpreter_path))
+        ctx.actions.symlink(output = executable, target_path = runtime.interpreter_path)
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles([executable], transitive_files = runtime.files),
+        ),
+    ]
+
+interpreter = rule(
+    implementation = _interpreter_impl,
+    toolchains = [TARGET_TOOLCHAIN_TYPE],
+    executable = True,
+    attrs = {
+        "binary": attr.label(
+            default = "//tools/run:bin",
+        ),
+    },
+)


### PR DESCRIPTION
Run a specific interpreter:
* `bazel run @rules_python//tools/run --@rules_python//python/config_settings:python_version=3.12`

Run interpreter from a binary:
* `bazel run @rules_python//tools/run --@rules_python//tools/run:bin=//my:binary`
