### PR TITLE
fix: Remove --no-build-isolation from pip install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ A brief description of the categories of changes:
   ([2310](https://github.com/bazelbuild/rules_python/issues/2310)).
 * (publish) The dependencies have been updated to the latest available versions
   for the `twine` publishing rule.
+* (whl_library) Remove `--no-build-isolation` to allow non-hermetic sdist builds
+  by default. Users wishing to keep this argument and to enforce more hermetic
+  builds can do so by passing the argument in
+  [`pip.parse#extra_pip_args`](https://rules-python.readthedocs.io/en/latest/api/rules_python/python/extensions/pip.html#pip.parse.extra_pip_args)
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "ovGr2x1QDHBffYRqtz5fRgBCvBIG9xO/6Lk2UEnqj48=",
+        "bzlTransitiveDigest": "45JfYNdHqP7vwP3B2J7fF5SOBX2ewmWdn0AmVfmIYT8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "OP8sZohIIGi+NNlfo7dAnU3yGo3Ea4xAU6TgzbPbCgw=",
+        "bzlTransitiveDigest": "pgIPI+ouKZGvpe1ZWE13QCQ5n0E4veB3tzWhx5XURJ0=",
         "usagesDigest": "LYtSAPzhPjmfD9vF39mCED1UQSvHEo2Hv+aK5Z4ZWWc=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -230,7 +230,7 @@ def _whl_library_impl(rctx):
             # and, allow getting build dependencies from PYTHONPATH, which we
             # setup in this repository rule, but still download any necessary
             # build deps from PyPI (e.g. `flit_core`) if they are missing.
-            extra_pip_args.extend(["--no-build-isolation", "--find-links", "."])
+            extra_pip_args.extend(["--find-links", "."])
 
     args = _parse_optional_attrs(rctx, args, extra_pip_args)
 


### PR DESCRIPTION
Fixes #2328.

In #2126, we discussed and added `--no-build-isolation` to ensure that sdist builds pulled from rules_python supplied dependencies. An unanticipated/misunderstood side-effect of this is that pip will no longer resolve necessary, declared build time dependencies from a package index. That's a significant point of friction for users, and, it's much harder to opt-out of the behavior than to opt-in given the presence of `extra_pip_args`.
