### PR TITLE
fix(pypi): use local version specifiers for patched whl output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ A brief description of the categories of changes:
   `bzlmod` users would have observed.
 * (pypi) (Bazel 7.4+) Allow spaces in filenames included in `whl_library`s
   ([617](https://github.com/bazelbuild/rules_python/issues/617)).
+* (pypi) The patched wheel filenames from now on are using local version specifiers
+  which fixes usage of the said wheels using standard package managers.
 
 {#v0-0-0-added}
 ### Added

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "45JfYNdHqP7vwP3B2J7fF5SOBX2ewmWdn0AmVfmIYT8=",
+        "bzlTransitiveDigest": "OnvWC8kpudJsMpnQA2DXs2S1fGs6SjC3zAPrR4at3Gk=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "pgIPI+ouKZGvpe1ZWE13QCQ5n0E4veB3tzWhx5XURJ0=",
+        "bzlTransitiveDigest": "xh+TtLzV8LOcWVAZY/yYoYhtnxdLP/wnjxePFI15qao=",
         "usagesDigest": "LYtSAPzhPjmfD9vF39mCED1UQSvHEo2Hv+aK5Z4ZWWc=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "pHRVJ9LwNXYPoAIhwSWrDBP3EGIk1gvfIhS9x6DPETg=",
+        "bzlTransitiveDigest": "qxyKk6sb6G2WeW3iUlRmVO5jafUab5qPwz66Y2anPp8=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -6581,7 +6581,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "QaGs/jEEn/UUXPAkdj2CvAwPdqGbGtor63UMTzlvZno=",
+        "bzlTransitiveDigest": "6NoEDGeQugmtzNzf4Emcb8Sb/cW3RTxSSA6DTHLB1/A=",
         "usagesDigest": "LYtSAPzhPjmfD9vF39mCED1UQSvHEo2Hv+aK5Z4ZWWc=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",

--- a/python/private/pypi/patch_whl.bzl
+++ b/python/private/pypi/patch_whl.bzl
@@ -45,8 +45,9 @@ def patched_whl_name(original_whl_name):
     version = parsed_whl.version
     suffix = "patched"
     if "+" in version:
-        # We comply with the spec and mark the file as patched by adding a
-        # local version identifier at the end.
+        # This already has some local version, so we just append one more
+        # identifier here. We comply with the spec and mark the file as patched
+        # by adding a local version identifier at the end.
         #
         # By doing this we can still install the package using most of the package
         # managers

--- a/tests/pypi/patch_whl/BUILD.bazel
+++ b/tests/pypi/patch_whl/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":patch_whl_tests.bzl", "patch_whl_test_suite")
+
+patch_whl_test_suite(name = "patch_whl_tests")

--- a/tests/pypi/patch_whl/patch_whl_tests.bzl
+++ b/tests/pypi/patch_whl/patch_whl_tests.bzl
@@ -1,0 +1,40 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""
+
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//python/private/pypi:patch_whl.bzl", "patched_whl_name")  # buildifier: disable=bzl-visibility
+
+_tests = []
+
+def _test_simple(env):
+    got = patched_whl_name("foo-1.2.3-py3-none-any.whl")
+    env.expect.that_str(got).equals("foo-1.2.3+patched-py3-none-any.whl")
+
+_tests.append(_test_simple)
+
+def _test_simple_local_version(env):
+    got = patched_whl_name("foo-1.2.3+special-py3-none-any.whl")
+    env.expect.that_str(got).equals("foo-1.2.3+special.patched-py3-none-any.whl")
+
+_tests.append(_test_simple_local_version)
+
+def patch_whl_test_suite(name):
+    """Create the test suite.
+
+    Args:
+        name: the name of the test suite
+    """
+    test_suite(name = name, basic_tests = _tests)


### PR DESCRIPTION
Before this change the installation of the patched wheels using `uv` or
similar would break. This change fixes that by using local version
specifier, which is better than using a build tag when installing the
wheels.

Before the change:
```console
$ cd examples/bzlmod
$ bazel build @pip//requests:whl
$ uv pip install <path to requests wheel in the example>
error: The wheel filename "requests-2.25.1-patched-py2.py3-none-any.whl" has an invalid build tag: must start with a digit
```

After:
```
$ uv pip install <path to requests wheel in the example>
Resolved 5 packages in 288ms
Prepared 5 packages in 152ms
Installed 5 packages in 13ms
 + certifi==2024.8.30
 + chardet==4.0.0
 + idna==2.10
 + requests==2.25.1+patched (from file:///home/aignas/src/github/aignas/rules_python/examples/bzlmod/bazel-bzlmod/external/rules_python~~pip~pip_39_requests_py2_none_any_c210084e/requests-2.25.1+patched-py2.py3-none-any.whl)
 + urllib3==1.26.20
```