### PR TITLE
change(pypi): use the python package version instead of sha in repo names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ A brief description of the categories of changes:
   by default. Users wishing to keep this argument and to enforce more hermetic
   builds can do so by passing the argument in
   [`pip.parse#extra_pip_args`](https://rules-python.readthedocs.io/en/latest/api/rules_python/python/extensions/pip.html#pip.parse.extra_pip_args)
+* (pypi, bzlmod) Change the repo naming when `experimental_index_url` is enabled
+  to include the version number in the external repository names.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "45JfYNdHqP7vwP3B2J7fF5SOBX2ewmWdn0AmVfmIYT8=",
+        "bzlTransitiveDigest": "iqa9U8iftHi1/TnBA8W4cjnzFATGPisvukdRRMTDReA=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -1414,7 +1414,7 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
-          "pip_39_snowballstemmer_py2_none_any_c8e1716e": {
+          "pip_39_isort_5.11.4.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1432,17 +1432,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
+              "filename": "isort-5.11.4.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "snowballstemmer==2.2.0",
-              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
+              "requirement": "isort==5.11.4",
+              "sha256": "6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
               "urls": [
-                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/76/46/004e2dd6c312e8bb7cb40a6c01b770956e0ef137857e82d47bd9c829356b/isort-5.11.4.tar.gz"
               ]
             }
           },
-          "pip_39_wrapt_cp39_cp39_musllinux_1_1_aarch64_b9b7a708": {
+          "pip_39_sphinxcontrib_htmlhelp_2.0.4.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1460,17 +1460,26 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "filename": "sphinxcontrib_htmlhelp-2.0.4.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
+              "sha256": "6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
               "urls": [
-                "https://files.pythonhosted.org/packages/e0/20/9716fb522d17a726364c4d032c8806ffe312268773dd46a394436b2787cc/wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+                "https://files.pythonhosted.org/packages/fd/2d/abf5cd4cc1d5cd9842748b15a28295e4c4a927facfa8a0e173bd3f151bc5/sphinxcontrib_htmlhelp-2.0.4.tar.gz"
               ]
             }
           },
-          "pip_39_zipp_sdist_0145e43d": {
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_17_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1488,41 +1497,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "zipp-3.20.0.tar.gz",
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
-              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_astroid_py3_none_any_10e0ad5f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "astroid-2.12.13-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "astroid==2.12.13",
-              "sha256": "10e0ad5f7b79c435179d0d0f0df69998c4eef4597534aae44910db060baeb907",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b1/61/42e075b7d29ed4d452d91cbaaca142710d50d04e68eb7161ce5807a00a30/astroid-2.12.13-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
@@ -1577,7 +1558,7 @@
               "requirement": "sphinx==7.2.6     --hash=sha256:1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560     --hash=sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"
             }
           },
-          "pip_39_tomlkit_py3_none_any_07de26b0": {
+          "pip_39_pyyaml_6.0.1_cp39_cp39_macosx_11_0_arm64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1595,17 +1576,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "tomlkit-0.11.6-py3-none-any.whl",
+              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "tomlkit==0.11.6",
-              "sha256": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
               "urls": [
-                "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/0e/88/21b2f16cb2123c1e9375f2c93486e35fdc86e63f02e274f0e99c589ef153/PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
               ]
             }
           },
-          "pip_39_sphinx_sdist_9a5160e1": {
+          "pip_39_six_1.16.0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1623,7 +1604,69 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinx-7.2.6.tar.gz",
+              "filename": "six-1.16.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "six==1.16.0",
+              "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_requests_2.25.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "requests-2.25.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "requests==2.25.1",
+              "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+              "urls": [
+                "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz"
+              ],
+              "whl_patches": {
+                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
+              }
+            }
+          },
+          "pip_39_sphinxcontrib_qthelp_1.0.6_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_qthelp-1.0.6-py3-none-any.whl",
               "group_deps": [
                 "sphinx",
                 "sphinxcontrib_qthelp",
@@ -1635,10 +1678,38 @@
               "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinx==7.2.6",
-              "sha256": "9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5",
+              "requirement": "sphinxcontrib-qthelp==1.0.6",
+              "sha256": "bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4",
               "urls": [
-                "https://files.pythonhosted.org/packages/73/8e/6e51da4b26665b4b92b1944ea18b2d9c825e753e19180cc5bdc818d0ed3b/sphinx-7.2.6.tar.gz"
+                "https://files.pythonhosted.org/packages/1f/e5/1850f3f118e95581c1e30b57028ac979badee1eb29e70ee72b0241f5a185/sphinxcontrib_qthelp-1.0.6-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_python_magic_0.4.27_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python_magic-0.4.27-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-magic==0.4.27",
+              "sha256": "c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl"
               ]
             }
           },
@@ -1672,7 +1743,7 @@
               "requirement": "sphinxcontrib-serializinghtml==1.1.9     --hash=sha256:0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54     --hash=sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
             }
           },
-          "pip_39_s3cmd_sdist_966b0a49": {
+          "pip_39_s3cmd_2.1.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1697,62 +1768,6 @@
               "sha256": "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03",
               "urls": [
                 "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_pygments_py3_none_any_13fc09fa": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "Pygments-2.16.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pygments==2.16.1",
-              "sha256": "13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
-              "urls": [
-                "https://files.pythonhosted.org/packages/43/88/29adf0b44ba6ac85045e63734ae0997d3c58d8b1a91c914d240828d0d73d/Pygments-2.16.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_manylinux_2_5_x86_64_40e7bc81": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e0/6a/3c660fa34c8106aa9719f2a6636c1c3ea7afd5931ae665eb197fdf4def84/wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
               ]
             }
           },
@@ -1798,7 +1813,287 @@
               "requirement": "astroid==2.13.5     --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501     --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"
             }
           },
-          "pip_39_lazy_object_proxy_sdist_78247b6d": {
+          "pip_39_certifi_2023.7.22_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "certifi-2023.7.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "certifi==2023.7.22",
+              "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_pylint_print_1.0.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pylint_print-1.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pylint-print==1.0.1",
+              "sha256": "a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/a9/6f0687b575d502b4fa770cd52231e23462c548829e5f2e6f43a3d2b9c939/pylint_print-1.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_pathspec_0.10.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pathspec-0.10.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pathspec==0.10.3",
+              "sha256": "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/32/1a/6baf904503c3e943cae9605c9c88a43b964dea5b59785cf956091b341b08/pathspec-0.10.3.tar.gz"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_jsmath_1.0.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib-jsmath-1.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-jsmath==1.0.1",
+              "sha256": "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e0/6a/3c660fa34c8106aa9719f2a6636c1c3ea7afd5931ae665eb197fdf4def84/wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6.0.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_urllib3_1.26.18_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "urllib3-1.26.18-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "urllib3==1.26.18",
+              "sha256": "34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/53/aa91e163dcfd1e5b82d8a890ecf13314e3e149c05270cc644581f77f17fd/urllib3-1.26.18-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "6f1a3f10f836fab6ca6efa97bb952300b20ae56b409414ca85bff2ad241d2a61",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/36/5741e62ccf629c8e38cc20f930491f8a33ce7dba972cae93dba3d6f02552/websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_yamllint_1.28.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "yamllint-1.28.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "yamllint==1.28.0",
+              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1.10.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1826,7 +2121,7 @@
               ]
             }
           },
-          "pip_39_websockets_sdist_88fc51d9": {
+          "pip_39_sphinx_7.2.6_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1844,203 +2139,7 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz"
-              ]
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_manylinux_2_17_x86_64_05fb2117": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_pyyaml_cp39_cp39_macosx_10_9_x86_64_9eb6caa9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_py3_none_any_6681ba9e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "6681ba9e7f8f3b19440921e99efbb40fc89f26cd71bf539e45d8c8a25c976dc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/47/96/9d5749106ff57629b54360664ae7eb9afd8302fad1680ead385383e33746/websockets-11.0.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_macosx_10_9_universal2_8023faf4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6a/86/654dc431513cd4417dfcead8102f22bece2d6abf2f584f0e1cc1524f7b94/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl"
-              ]
-            }
-          },
-          "pip_39_urllib3_sdist_f8ecc1bb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "urllib3-1.26.18.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
-              ]
-            }
-          },
-          "pip_39_platformdirs_py3_none_any_1a89a123": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "platformdirs-2.6.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "platformdirs==2.6.0",
-              "sha256": "1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
-              "urls": [
-                "https://files.pythonhosted.org/packages/87/69/cd019a9473bcdfb38983e2d550ccb239264fc4c2fc32c42ac1b1cc2506b6/platformdirs-2.6.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_applehelp_sdist_39fdc8d7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_applehelp-1.0.7.tar.gz",
+              "filename": "sphinx-7.2.6-py3-none-any.whl",
               "group_deps": [
                 "sphinx",
                 "sphinxcontrib_qthelp",
@@ -2052,10 +2151,10 @@
               "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-applehelp==1.0.7",
-              "sha256": "39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa",
+              "requirement": "sphinx==7.2.6",
+              "sha256": "1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560",
               "urls": [
-                "https://files.pythonhosted.org/packages/1c/5a/fce19be5d4db26edc853a0c34832b39db7b769b7689da027529767b0aa98/sphinxcontrib_applehelp-1.0.7.tar.gz"
+                "https://files.pythonhosted.org/packages/b2/b6/8ed35256aa530a9d3da15d20bdc0ba888d5364441bb50a5a83ee7827affe/sphinx-7.2.6-py3-none-any.whl"
               ]
             }
           },
@@ -2086,7 +2185,7 @@
               }
             }
           },
-          "pip_39_pyyaml_cp39_cp39_win_amd64_510c9dee": {
+          "pip_39_sphinxcontrib_devhelp_1.0.5_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2104,17 +2203,26 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-win_amd64.whl",
+              "filename": "sphinxcontrib_devhelp-1.0.5-py3-none-any.whl",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+              "requirement": "sphinxcontrib-devhelp==1.0.5",
+              "sha256": "fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f",
               "urls": [
-                "https://files.pythonhosted.org/packages/84/4d/82704d1ab9290b03da94e6425f5e87396b999fd7eb8e08f3a92c158402bf/PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
+                "https://files.pythonhosted.org/packages/c0/03/010ac733ec7b7f71c1dc88e7115743ee466560d6d85373b56fb9916e4586/sphinxcontrib_devhelp-1.0.5-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_pyyaml_cp39_cp39_manylinux_2_17_aarch64_5773183b": {
+          "pip_39_babel_2.13.1_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2132,41 +2240,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "Babel-2.13.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+              "requirement": "babel==2.13.1",
+              "sha256": "7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed",
               "urls": [
-                "https://files.pythonhosted.org/packages/ac/6c/967d91a8edf98d2b2b01d149bd9e51b8f9fb527c98d80ebb60c6b21d60c4/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_typing_extensions_py3_none_any_04e5ca03": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "typing_extensions-4.12.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
-              "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/86/14/5dc2eb02b7cc87b2f95930310a2cc5229198414919a116b564832c747bc1/Babel-2.13.1-py3-none-any.whl"
               ]
             }
           },
@@ -2221,7 +2301,7 @@
               "requirement": "sphinxcontrib-devhelp==1.0.5     --hash=sha256:63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212     --hash=sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             }
           },
-          "pip_39_yamllint_py2_none_any_89bb5b5a": {
+          "pip_39_tabulate_0.9.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2239,17 +2319,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "yamllint-1.28.0-py2.py3-none-any.whl",
+              "filename": "tabulate-0.9.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "yamllint==1.28.0",
-              "sha256": "89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
+              "requirement": "tabulate==0.9.0",
+              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
               "urls": [
-                "https://files.pythonhosted.org/packages/40/f9/882281af7c40a99bfa5b14585071c5aa13f48961582ebe067ae38221d0d9/yamllint-1.28.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
               ]
             }
           },
-          "pip_39_jinja2_sdist_4a3aee7a": {
+          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2267,17 +2347,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "jinja2-3.1.4.tar.gz",
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "jinja2==3.1.4",
-              "sha256": "4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
               "urls": [
-                "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz"
+                "https://files.pythonhosted.org/packages/ac/6c/967d91a8edf98d2b2b01d149bd9e51b8f9fb527c98d80ebb60c6b21d60c4/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "pip_39_sphinxcontrib_qthelp_sdist_62b9d1a1": {
+          "pip_39_sphinxcontrib_jsmath_1.0.1_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2295,26 +2375,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_qthelp-1.0.6.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
+              "filename": "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-qthelp==1.0.6",
-              "sha256": "62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
+              "requirement": "sphinxcontrib-jsmath==1.0.1",
+              "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
               "urls": [
-                "https://files.pythonhosted.org/packages/4f/a2/53129fc967ac8402d5e4e83e23c959c3f7a07362ec154bdb2e197d8cc270/sphinxcontrib_qthelp-1.0.6.tar.gz"
+                "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_websockets_cp39_cp39_musllinux_1_1_aarch64_1fdf26fa": {
+          "pip_39_zipp_3.20.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2332,14 +2403,48 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "filename": "zipp-3.20.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
+              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
+              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
               "urls": [
-                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
               ]
+            }
+          },
+          "pip_39_requests_2.25.1_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "requests-2.25.1-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "requests==2.25.1",
+              "sha256": "c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl"
+              ],
+              "whl_patches": {
+                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
+              }
             }
           },
           "pip_310_alabaster": {
@@ -2363,34 +2468,6 @@
               "requirement": "alabaster==0.7.13     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2"
             }
           },
-          "pip_39_setuptools_sdist_a7620757": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "setuptools-65.6.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "setuptools==65.6.3",
-              "sha256": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
-              ]
-            }
-          },
           "pip_310_python_magic": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2412,7 +2489,7 @@
               "requirement": "python-magic==0.4.27     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"
             }
           },
-          "pip_39_chardet_sdist_0d6f53a1": {
+          "pip_39_tomlkit_0.11.6_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2430,17 +2507,470 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "chardet-4.0.0.tar.gz",
+              "filename": "tomlkit-0.11.6-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomlkit==0.11.6",
+              "sha256": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_typing_extensions_4.12.2.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "typing_extensions-4.12.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
+              "sha256": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pylint_2.15.9_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pylint-2.15.9-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pylint==2.15.9",
+              "sha256": "349c8cd36aede4d50a0754a8c0218b43323d13d5d88f4b2952ddfe3e169681eb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7d/df/0e50d5640ed4c6a492cdc6df0c281afee3f85d98209e7ec7b31243838b40/pylint-2.15.9-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_python_dateutil_2.8.2.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python-dateutil-2.8.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-dateutil==2.8.2",
+              "sha256": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
+              ]
+            }
+          },
+          "pip_310_tabulate": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "tabulate==0.9.0     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
+            }
+          },
+          "pip_310_lazy_object_proxy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "lazy-object-proxy==1.9.0     --hash=sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382     --hash=sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82     --hash=sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9     --hash=sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494     --hash=sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46     --hash=sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30     --hash=sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63     --hash=sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4     --hash=sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae     --hash=sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be     --hash=sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701     --hash=sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd     --hash=sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006     --hash=sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a     --hash=sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586     --hash=sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8     --hash=sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821     --hash=sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07     --hash=sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b     --hash=sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171     --hash=sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b     --hash=sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2     --hash=sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7     --hash=sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4     --hash=sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8     --hash=sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e     --hash=sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f     --hash=sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda     --hash=sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4     --hash=sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e     --hash=sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671     --hash=sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11     --hash=sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455     --hash=sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734     --hash=sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb     --hash=sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
+            }
+          },
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fe/30/40879041ed6a3364bfa862c4237aa7fe94dcd4affa2175718acbbf4d29b9/lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6.0.1_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/40/da/a175a35cf5583580e90ac3e2a3dbca90e43011593ae62ce63f79d7b28d92/PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_310_sphinxcontrib_htmlhelp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "sphinxcontrib-htmlhelp==2.0.4     --hash=sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a     --hash=sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
+            }
+          },
+          "pip_39_zipp_3.20.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
+              "sha256": "58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/da/cc/b9958af9f9c86b51f846d8487440af495ecf19b16e426fce1ed0b0796175/zipp-3.20.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_pylint": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pylint==2.15.10     --hash=sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e     --hash=sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
+            }
+          },
+          "pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "97b52894d948d2f6ea480171a27122d77af14ced35f62e5c892ca2fae9344311",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/89/0d150939f2e592ed78c071d69237ac1c872462cc62a750c5f592f3d4ab18/websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_idna_2.10.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "idna-2.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "idna==2.10",
+              "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz"
+              ]
+            }
+          },
+          "pip_310_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "babel==2.13.1     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"
+            }
+          },
+          "pip_39_websockets_11.0.3_cp39_cp39_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "3580dd9c1ad0701169e4d6fc41e878ffe05e6bdcaf3c412f9d559389d0c9e016",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/1a/3da73e69ebc00649d11ed836541c92c1a2df0b8a8aa641a2c8746e7c2b9c/websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "other_module_pip_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@other_module_pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "other_module_pip_311",
+              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
+            }
+          },
+          "pip_39_chardet_4.0.0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "chardet-4.0.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "chardet==4.0.0",
-              "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+              "sha256": "f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
               "urls": [
-                "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz"
+                "https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_mccabe_sdist_348e0240": {
+          "pip_310_yamllint": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
+            }
+          },
+          "pip_39_mccabe_0.7.0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2458,17 +2988,696 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "mccabe-0.7.0.tar.gz",
+              "filename": "mccabe-0.7.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "mccabe==0.7.0",
-              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+              "sha256": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
               "urls": [
-                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
+                "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_sphinxcontrib_serializinghtml_sdist_0c64ff89": {
+          "pip_39_python_dateutil_2.8.2_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-dateutil==2.8.2",
+              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2.1.3_cp39_cp39_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a2/b2/624042cb58cc6b3529a6c3a7b7d230766e3ecb768cba118ba7befd18ed6f/MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl"
+              ]
+            }
+          },
+          "pip_39_packaging_23.2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "packaging-23.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "packaging==23.2",
+              "sha256": "8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "other_module_pip": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "other_module_pip",
+              "whl_map": {
+                "absl_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"other_module_pip_311_absl_py\",\"target_platforms\":null,\"version\":\"3.11\"}]"
+              },
+              "packages": [],
+              "groups": {}
+            }
+          },
+          "pip_39_astroid_2.12.13_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "astroid-2.12.13-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "astroid==2.12.13",
+              "sha256": "10e0ad5f7b79c435179d0d0f0df69998c4eef4597534aae44910db060baeb907",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b1/61/42e075b7d29ed4d452d91cbaaca142710d50d04e68eb7161ce5807a00a30/astroid-2.12.13-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_pygments_2.16.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "Pygments-2.16.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pygments==2.16.1",
+              "sha256": "13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
+              "urls": [
+                "https://files.pythonhosted.org/packages/43/88/29adf0b44ba6ac85045e63734ae0997d3c58d8b1a91c914d240828d0d73d/Pygments-2.16.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_pylint_print": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pylint-print==1.0.1     --hash=sha256:30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0     --hash=sha256:a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b"
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e0/20/9716fb522d17a726364c4d032c8806ffe312268773dd46a394436b2787cc/wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_imagesize_1.4.1_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "imagesize-1.4.1-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "imagesize==1.4.1",
+              "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_platformdirs_2.6.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "platformdirs-2.6.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "platformdirs==2.6.0",
+              "sha256": "b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ec/4c/9af851448e55c57b30a13a72580306e628c3b431d97fdae9e0b8d4fa3685/platformdirs-2.6.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_babel_2.13.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "Babel-2.13.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "babel==2.13.1",
+              "sha256": "33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900",
+              "urls": [
+                "https://files.pythonhosted.org/packages/aa/6c/737d2345d86741eeb594381394016b9c74c1253b4cbe274bb1e7b5e2138e/Babel-2.13.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_certifi_2023.7.22.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "certifi-2023.7.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "certifi==2023.7.22",
+              "sha256": "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+              "urls": [
+                "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pygments_2.16.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "Pygments-2.16.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pygments==2.16.1",
+              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_devhelp_1.0.5.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_devhelp-1.0.5.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-devhelp==1.0.5",
+              "sha256": "63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/f2/6425b6db37e7c2254ad661c90a871061a078beaddaf9f15a00ba9c3a1529/sphinxcontrib_devhelp-1.0.5.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4a/4b/c71ef18ef83c82f99e6da8332910692af78ea32bd1d1d76c9787dfa36aea/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "pip_39_importlib_metadata_8.4.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
+              "sha256": "9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_typing_extensions_4.12.2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "typing_extensions-4.12.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
+              "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_pylint_2.15.9.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pylint-2.15.9.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pylint==2.15.9",
+              "sha256": "18783cca3cfee5b83c6c5d10b3cdb66c6594520ffae61890858fe8d932e1c6b4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/68/3a/1e61444eb8276ad962a7f300b6920b7ad391f4fbe551d34443f093a18899/pylint-2.15.9.tar.gz"
+              ]
+            }
+          },
+          "pip_39_snowballstemmer_2.2.0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "snowballstemmer==2.2.0",
+              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_tomli_2.0.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tomli-2.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_s3cmd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
+            }
+          },
+          "pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+              "urls": [
+                "https://files.pythonhosted.org/packages/68/8d/c33c43c499c19f4b51181e196c9a497010908fc22c5de33551e298aa6a21/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_serializinghtml_1.1.9.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2505,28 +3714,7 @@
               ]
             }
           },
-          "pip_310_tabulate": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "tabulate==0.9.0     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
-            }
-          },
-          "pip_39_docutils_sdist_f08a4e27": {
+          "pip_39_sphinxcontrib_htmlhelp_2.0.4_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2544,109 +3732,7 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "docutils-0.20.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "docutils==0.20.1",
-              "sha256": "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz"
-              ]
-            }
-          },
-          "pip_310_lazy_object_proxy": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "lazy-object-proxy==1.9.0     --hash=sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382     --hash=sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82     --hash=sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9     --hash=sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494     --hash=sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46     --hash=sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30     --hash=sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63     --hash=sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4     --hash=sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae     --hash=sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be     --hash=sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701     --hash=sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd     --hash=sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006     --hash=sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a     --hash=sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586     --hash=sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8     --hash=sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821     --hash=sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07     --hash=sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b     --hash=sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171     --hash=sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b     --hash=sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2     --hash=sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7     --hash=sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4     --hash=sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8     --hash=sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e     --hash=sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f     --hash=sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda     --hash=sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4     --hash=sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e     --hash=sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671     --hash=sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11     --hash=sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455     --hash=sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734     --hash=sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb     --hash=sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
-            }
-          },
-          "pip_39_packaging_py3_none_any_8c491190": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "packaging-23.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "packaging==23.2",
-              "sha256": "8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_tomli_sdist_de526c12": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tomli-2.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
-              "sha256": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
-              ]
-            }
-          },
-          "pip_310_sphinxcontrib_htmlhelp": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
+              "filename": "sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl",
               "group_deps": [
                 "sphinx",
                 "sphinxcontrib_qthelp",
@@ -2656,90 +3742,16 @@
                 "sphinxcontrib_serializinghtml"
               ],
               "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "sphinxcontrib-htmlhelp==2.0.4     --hash=sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a     --hash=sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
-            }
-          },
-          "pip_310_pylint": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pylint==2.15.10     --hash=sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e     --hash=sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
-            }
-          },
-          "pip_39_pygments_sdist_1daff049": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "Pygments-2.16.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pygments==2.16.1",
-              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
+              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
+              "sha256": "8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9",
               "urls": [
-                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
+                "https://files.pythonhosted.org/packages/28/7a/958f8e3e6abe8219d0d1f1224886de847ab227b218f4a07b61bc337f64be/sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_wheel_sdist_cd1196f3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wheel-0.40.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wheel==0.40.0",
-              "sha256": "cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_idna_py2_none_any_b97d804b": {
+          "pip_39_idna_2.10_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2767,28 +3779,7 @@
               ]
             }
           },
-          "pip_310_babel": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "babel==2.13.1     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"
-            }
-          },
-          "pip_39_pylint_py3_none_any_349c8cd3": {
+          "pip_39_websockets_11.0.3_cp39_cp39_win_amd64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2806,993 +3797,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "pylint-2.15.9-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pylint==2.15.9",
-              "sha256": "349c8cd36aede4d50a0754a8c0218b43323d13d5d88f4b2952ddfe3e169681eb",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7d/df/0e50d5640ed4c6a492cdc6df0c281afee3f85d98209e7ec7b31243838b40/pylint-2.15.9-py3-none-any.whl"
-              ]
-            }
-          },
-          "other_module_pip_311_absl_py": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@other_module_pip//{name}:{target}",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "other_module_pip_311",
-              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
-            }
-          },
-          "pip_39_colorama_sdist_08695f5c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "colorama-0.4.6.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "colorama==0.4.6",
-              "sha256": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
-              ]
-            }
-          },
-          "pip_39_jinja2_py3_none_any_bc5dd2ab": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "jinja2-3.1.4-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "jinja2==3.1.4",
-              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_310_yamllint": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
-            }
-          },
-          "pip_39_pathspec_py3_none_any_3c95343a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pathspec-0.10.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pathspec==0.10.3",
-              "sha256": "3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_sdist_af598ed3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
-              ]
-            }
-          },
-          "pip_39_python_magic_py2_none_any_c212960a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python_magic-0.4.27-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-magic==0.4.27",
-              "sha256": "c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_htmlhelp_sdist_6c26a118": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_htmlhelp-2.0.4.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
-              "sha256": "6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fd/2d/abf5cd4cc1d5cd9842748b15a28295e4c4a927facfa8a0e173bd3f151bc5/sphinxcontrib_htmlhelp-2.0.4.tar.gz"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_x86_64_9a3a87cf": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8e/ae/3e15cffacbdb64ac49930cdbc23cb0c67e1bb9e8a8ca7765fd8a8d2510c3/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_typing_extensions_sdist_1a7ead55": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "typing_extensions-4.12.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
-              "sha256": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
-              ]
-            }
-          },
-          "pip_39_tabulate_py3_none_any_024ca478": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tabulate-0.9.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tabulate==0.9.0",
-              "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "other_module_pip": {
-            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
-            "ruleClassName": "hub_repository",
-            "attributes": {
-              "repo_name": "other_module_pip",
-              "whl_map": {
-                "absl_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"other_module_pip_311_absl_py\",\"target_platforms\":null,\"version\":\"3.11\"}]"
-              },
-              "packages": [],
-              "groups": {}
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_manylinux_2_17_aarch64_9dcdfd0e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
-              "urls": [
-                "https://files.pythonhosted.org/packages/68/8d/c33c43c499c19f4b51181e196c9a497010908fc22c5de33551e298aa6a21/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_aarch64_21713819": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_win_amd64_dee60e1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
-          "pip_310_pylint_print": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pylint-print==1.0.1     --hash=sha256:30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0     --hash=sha256:a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b"
-            }
-          },
-          "pip_39_tomlkit_sdist_71b952e5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tomlkit-0.11.6.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tomlkit==0.11.6",
-              "sha256": "71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/04/58b4c11430ed4b7b8f1723a5e4f20929d59361e9b17f0872d69681fd8ffd/tomlkit-0.11.6.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinx_py3_none_any_1e09160a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinx-7.2.6-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinx==7.2.6",
-              "sha256": "1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b2/b6/8ed35256aa530a9d3da15d20bdc0ba888d5364441bb50a5a83ee7827affe/sphinx-7.2.6-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_pylint_sdist_18783cca": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pylint-2.15.9.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pylint==2.15.9",
-              "sha256": "18783cca3cfee5b83c6c5d10b3cdb66c6594520ffae61890858fe8d932e1c6b4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/68/3a/1e61444eb8276ad962a7f300b6920b7ad391f4fbe551d34443f093a18899/pylint-2.15.9.tar.gz"
-              ]
-            }
-          },
-          "pip_39_pathspec_sdist_56200de4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pathspec-0.10.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pathspec==0.10.3",
-              "sha256": "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/32/1a/6baf904503c3e943cae9605c9c88a43b964dea5b59785cf956091b341b08/pathspec-0.10.3.tar.gz"
-              ]
-            }
-          },
-          "pip_39_alabaster_py3_none_any_1ee19aca": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "alabaster-0.7.13-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "alabaster==0.7.13",
-              "sha256": "1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_musllinux_1_1_x86_64_34aa51c4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f9/3c/110e52b9da396a4ef3a0521552a1af9c7875a762361f48678c1ac272fd7e/wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_musllinux_1_1_aarch64_ab4a0df4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
-              "urls": [
-                "https://files.pythonhosted.org/packages/03/65/3473d2cb84bb2cda08be95b97fc4f53e6bcd701a2d50ba7b7c905e1e9273/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_cp39_cp39_manylinux_2_17_aarch64_6f1a3f10": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-win_amd64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "websockets==11.0.3",
-              "sha256": "6f1a3f10f836fab6ca6efa97bb952300b20ae56b409414ca85bff2ad241d2a61",
+              "sha256": "c792ea4eabc0159535608fc5658a74d1a81020eb35195dd63214dcf07556f67e",
               "urls": [
-                "https://files.pythonhosted.org/packages/d9/36/5741e62ccf629c8e38cc20f930491f8a33ce7dba972cae93dba3d6f02552/websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_packaging_sdist_048fb0e9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "packaging-23.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "packaging==23.2",
-              "sha256": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
-              ]
-            }
-          },
-          "pip_39_s3cmd_py2_none_any_49cd23d5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "s3cmd==2.1.0",
-              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_idna_sdist_b307872f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "idna-2.10.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "idna==2.10",
-              "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz"
-              ]
-            }
-          },
-          "pip_310_s3cmd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
-            }
-          },
-          "pip_39_snowballstemmer_sdist_09b16deb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "snowballstemmer-2.2.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "snowballstemmer==2.2.0",
-              "sha256": "09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_imagesize_py2_none_any_0d8d18d0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "imagesize-1.4.1-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "imagesize==1.4.1",
-              "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_setuptools_py3_none_any_57f6f22b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "setuptools-65.6.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "setuptools==65.6.3",
-              "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_cp39_cp39_win_amd64_a899b10e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fe/30/40879041ed6a3364bfa862c4237aa7fe94dcd4affa2175718acbbf4d29b9/lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_devhelp_py3_none_any_fe8009ae": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_devhelp-1.0.5-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-devhelp==1.0.5",
-              "sha256": "fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/03/010ac733ec7b7f71c1dc88e7115743ee466560d6d85373b56fb9916e4586/sphinxcontrib_devhelp-1.0.5-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_dill_sdist_e5db55f3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "dill-0.3.6.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "dill==0.3.6",
-              "sha256": "e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz"
-              ]
-            }
-          },
-          "pip_39_colorama_py2_none_any_4f1d9991": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "colorama-0.4.6-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "colorama==0.4.6",
-              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_chardet_py2_none_any_f864054d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "chardet-4.0.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "chardet==4.0.0",
-              "sha256": "f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/f4/3f/65dfa50084a06ab0a05f3ca74195c2c17a1c075b8361327d831ccce0a483/websockets-11.0.3-cp39-cp39-win_amd64.whl"
               ]
             }
           },
@@ -3859,7 +3870,148 @@
               "requirement": "pathspec==0.11.1     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
             }
           },
-          "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_5_x86_64_18dd842b": {
+          "pip_39_tomlkit_0.11.6.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tomlkit-0.11.6.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomlkit==0.11.6",
+              "sha256": "71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/04/58b4c11430ed4b7b8f1723a5e4f20929d59361e9b17f0872d69681fd8ffd/tomlkit-0.11.6.tar.gz"
+              ]
+            }
+          },
+          "pip_39_tabulate_0.9.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tabulate-0.9.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tabulate==0.9.0",
+              "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_alabaster_0.7.13.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "alabaster-0.7.13.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "alabaster==0.7.13",
+              "sha256": "a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz"
+              ]
+            }
+          },
+          "pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_5_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "279e5de4671e79a9ac877427f4ac4ce93751b8823f276b681d04b2156713b9dd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a6/9c/2356ecb952fd3992b73f7a897d65e57d784a69b94bb8d8fd5f97531e5c02/websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_wheel_0.40.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wheel-0.40.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wheel==0.40.0",
+              "sha256": "cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_5_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3887,7 +4039,7 @@
               ]
             }
           },
-          "pip_39_markupsafe_cp39_cp39_macosx_10_9_x86_64_6b2b5695": {
+          "pip_39_importlib_metadata_8.4.0_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3905,17 +4057,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl",
+              "filename": "importlib_metadata-8.4.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
+              "sha256": "66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
               "urls": [
-                "https://files.pythonhosted.org/packages/62/9b/4908a57acf39d8811836bc6776b309c2e07d63791485589acf0b6d7bc0c6/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl"
+                "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_platformdirs_sdist_b46ffafa": {
+          "pip_39_python_magic_0.4.27.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3933,154 +4085,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "platformdirs-2.6.0.tar.gz",
+              "filename": "python-magic-0.4.27.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "platformdirs==2.6.0",
-              "sha256": "b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e",
+              "requirement": "python-magic==0.4.27",
+              "sha256": "c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b",
               "urls": [
-                "https://files.pythonhosted.org/packages/ec/4c/9af851448e55c57b30a13a72580306e628c3b431d97fdae9e0b8d4fa3685/platformdirs-2.6.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_cp39_cp39_macosx_10_9_x86_64_366c32fe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bc/2f/b9230d00c2eaa629e67cc69f285bf6b5692cb1d0179a1f8764edd451da86/lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_win_amd64_3fd4abcb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a2/b2/624042cb58cc6b3529a6c3a7b7d230766e3ecb768cba118ba7befd18ed6f/MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
-          "pip_39_wheel_py3_none_any_d236b20e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wheel-0.40.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wheel==0.40.0",
-              "sha256": "d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247",
-              "urls": [
-                "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_certifi_py3_none_any_92d60375": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "certifi-2023.7.22-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_macosx_11_0_arm64_988635d1": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bb/70/73c54e24ea69a8b06ae9649e61d5e64f2b4bdfc6f202fc7794abeac1ed20/wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl"
+                "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz"
               ]
             }
           },
@@ -4105,6 +4116,90 @@
               "requirement": "typing-extensions==4.6.3     --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26     --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
             }
           },
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_setuptools_65.6.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "setuptools-65.6.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "setuptools==65.6.3",
+              "sha256": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
+              ]
+            }
+          },
+          "pip_39_yamllint_1.28.0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "yamllint-1.28.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "yamllint==1.28.0",
+              "sha256": "89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/40/f9/882281af7c40a99bfa5b14585071c5aa13f48961582ebe067ae38221d0d9/yamllint-1.28.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
           "pip_310_isort": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4126,7 +4221,7 @@
               "requirement": "isort==5.12.0     --hash=sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504     --hash=sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
             }
           },
-          "pip_39_websockets_cp39_cp39_musllinux_1_1_x86_64_97b52894": {
+          "pip_39_dill_0.3.6.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4144,13 +4239,41 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "filename": "dill-0.3.6.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "97b52894d948d2f6ea480171a27122d77af14ced35f62e5c892ca2fae9344311",
+              "requirement": "dill==0.3.6",
+              "sha256": "e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373",
               "urls": [
-                "https://files.pythonhosted.org/packages/72/89/0d150939f2e592ed78c071d69237ac1c872462cc62a750c5f592f3d4ab18/websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+                "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bb/70/73c54e24ea69a8b06ae9649e61d5e64f2b4bdfc6f202fc7794abeac1ed20/wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl"
               ]
             }
           },
@@ -4184,7 +4307,7 @@
               "requirement": "sphinxcontrib-qthelp==1.0.6     --hash=sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d     --hash=sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             }
           },
-          "pip_39_pyyaml_cp39_cp39_musllinux_1_1_x86_64_04ac92ad": {
+          "pip_39_sphinxcontrib_qthelp_1.0.6.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4202,69 +4325,22 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "filename": "sphinxcontrib_qthelp-1.0.6.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+              "requirement": "sphinxcontrib-qthelp==1.0.6",
+              "sha256": "62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
               "urls": [
-                "https://files.pythonhosted.org/packages/40/da/a175a35cf5583580e90ac3e2a3dbca90e43011593ae62ce63f79d7b28d92/PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_jsmath_py2_none_any_2ec2eaeb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-jsmath==1.0.1",
-              "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_cp39_cp39_macosx_10_9_x86_64_3232822c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+                "https://files.pythonhosted.org/packages/4f/a2/53129fc967ac8402d5e4e83e23c959c3f7a07362ec154bdb2e197d8cc270/sphinxcontrib_qthelp-1.0.6.tar.gz"
               ]
             }
           },
@@ -4289,7 +4365,7 @@
               "requirement": "wrapt==1.15.0     --hash=sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0     --hash=sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420     --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a     --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c     --hash=sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079     --hash=sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923     --hash=sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f     --hash=sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1     --hash=sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8     --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86     --hash=sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0     --hash=sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364     --hash=sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e     --hash=sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c     --hash=sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e     --hash=sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c     --hash=sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727     --hash=sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff     --hash=sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e     --hash=sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29     --hash=sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7     --hash=sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72     --hash=sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475     --hash=sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a     --hash=sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317     --hash=sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2     --hash=sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd     --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640     --hash=sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98     --hash=sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248     --hash=sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e     --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d     --hash=sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec     --hash=sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1     --hash=sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e     --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9     --hash=sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92     --hash=sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb     --hash=sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094     --hash=sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46     --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29     --hash=sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd     --hash=sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705     --hash=sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8     --hash=sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975     --hash=sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb     --hash=sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e     --hash=sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b     --hash=sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418     --hash=sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019     --hash=sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1     --hash=sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba     --hash=sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6     --hash=sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2     --hash=sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3     --hash=sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7     --hash=sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752     --hash=sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416     --hash=sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f     --hash=sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1     --hash=sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc     --hash=sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145     --hash=sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee     --hash=sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a     --hash=sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7     --hash=sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b     --hash=sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653     --hash=sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0     --hash=sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90     --hash=sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29     --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6     --hash=sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034     --hash=sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09     --hash=sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559     --hash=sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
             }
           },
-          "pip_39_importlib_metadata_py3_none_any_66f342cc": {
+          "pip_39_s3cmd_2.1.0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4307,17 +4383,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "importlib_metadata-8.4.0-py3-none-any.whl",
+              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
-              "sha256": "66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
+              "requirement": "s3cmd==2.1.0",
+              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
               "urls": [
-                "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_yamllint_sdist_9e3d8ddd": {
+          "pip_39_setuptools_65.6.3_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4335,41 +4411,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "yamllint-1.28.0.tar.gz",
+              "filename": "setuptools-65.6.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "yamllint==1.28.0",
-              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
+              "requirement": "setuptools==65.6.3",
+              "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
               "urls": [
-                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_python_dateutil_sdist_0123cacc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python-dateutil-2.8.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-dateutil==2.8.2",
-              "sha256": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
+                "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
               ]
             }
           },
@@ -4379,53 +4427,53 @@
             "attributes": {
               "repo_name": "pip",
               "whl_map": {
-                "alabaster": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_alabaster\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13-py3-none-any.whl\",\"repo\":\"pip_39_alabaster_py3_none_any_1ee19aca\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13.tar.gz\",\"repo\":\"pip_39_alabaster_sdist_a27a4a08\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "astroid": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_astroid\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13-py3-none-any.whl\",\"repo\":\"pip_39_astroid_py3_none_any_10e0ad5f\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13.tar.gz\",\"repo\":\"pip_39_astroid_sdist_1493fe8b\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "babel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_babel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1-py3-none-any.whl\",\"repo\":\"pip_39_babel_py3_none_any_7077a498\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1.tar.gz\",\"repo\":\"pip_39_babel_sdist_33e0952d\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "certifi": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_certifi\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22-py3-none-any.whl\",\"repo\":\"pip_39_certifi_py3_none_any_92d60375\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22.tar.gz\",\"repo\":\"pip_39_certifi_sdist_539cc1d1\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "chardet": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_chardet\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_chardet_py2_none_any_f864054d\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0.tar.gz\",\"repo\":\"pip_39_chardet_sdist_0d6f53a1\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "colorama": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_colorama\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6-py2.py3-none-any.whl\",\"repo\":\"pip_39_colorama_py2_none_any_4f1d9991\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6.tar.gz\",\"repo\":\"pip_39_colorama_sdist_08695f5c\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "dill": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_dill\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6-py3-none-any.whl\",\"repo\":\"pip_39_dill_py3_none_any_a07ffd23\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6.tar.gz\",\"repo\":\"pip_39_dill_sdist_e5db55f3\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "docutils": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_docutils\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1-py3-none-any.whl\",\"repo\":\"pip_39_docutils_py3_none_any_96f387a2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1.tar.gz\",\"repo\":\"pip_39_docutils_sdist_f08a4e27\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "idna": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_idna\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10-py2.py3-none-any.whl\",\"repo\":\"pip_39_idna_py2_none_any_b97d804b\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10.tar.gz\",\"repo\":\"pip_39_idna_sdist_b307872f\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "imagesize": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_imagesize\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_imagesize_py2_none_any_0d8d18d0\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1.tar.gz\",\"repo\":\"pip_39_imagesize_sdist_69150444\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0-py3-none-any.whl\",\"repo\":\"pip_39_importlib_metadata_py3_none_any_66f342cc\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0.tar.gz\",\"repo\":\"pip_39_importlib_metadata_sdist_9a547d3b\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "isort": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_isort\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4-py3-none-any.whl\",\"repo\":\"pip_39_isort_py3_none_any_c033fd0e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4.tar.gz\",\"repo\":\"pip_39_isort_sdist_6db30c5d\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "jinja2": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_jinja2\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4-py3-none-any.whl\",\"repo\":\"pip_39_jinja2_py3_none_any_bc5dd2ab\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4.tar.gz\",\"repo\":\"pip_39_jinja2_sdist_4a3aee7a\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "lazy_object_proxy": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_lazy_object_proxy\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy-object-proxy-1.10.0.tar.gz\",\"repo\":\"pip_39_lazy_object_proxy_sdist_78247b6d\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_macosx_10_9_x86_64_366c32fe\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_17_aarch64_2297f08f\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_5_x86_64_18dd842b\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_aarch64_21713819\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_musllinux_1_1_x86_64_9a3a87cf\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_lazy_object_proxy_cp39_cp39_win_amd64_a899b10e\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "markupsafe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_markupsafe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_macosx_10_9_universal2_8023faf4\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_macosx_10_9_x86_64_6b2b5695\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_manylinux_2_17_aarch64_9dcdfd0e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_manylinux_2_17_x86_64_05fb2117\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_musllinux_1_1_aarch64_ab4a0df4\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_musllinux_1_1_x86_64_0a4e4a1a\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_markupsafe_cp39_cp39_win_amd64_3fd4abcb\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3.tar.gz\",\"repo\":\"pip_39_markupsafe_sdist_af598ed3\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "mccabe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_mccabe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_mccabe_py2_none_any_6c2d30ab\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0.tar.gz\",\"repo\":\"pip_39_mccabe_sdist_348e0240\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "packaging": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_packaging\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2-py3-none-any.whl\",\"repo\":\"pip_39_packaging_py3_none_any_8c491190\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2.tar.gz\",\"repo\":\"pip_39_packaging_sdist_048fb0e9\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pathspec": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pathspec\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3-py3-none-any.whl\",\"repo\":\"pip_39_pathspec_py3_none_any_3c95343a\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3.tar.gz\",\"repo\":\"pip_39_pathspec_sdist_56200de4\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "platformdirs": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_platformdirs\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0-py3-none-any.whl\",\"repo\":\"pip_39_platformdirs_py3_none_any_1a89a123\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0.tar.gz\",\"repo\":\"pip_39_platformdirs_sdist_b46ffafa\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pygments": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pygments\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1-py3-none-any.whl\",\"repo\":\"pip_39_pygments_py3_none_any_13fc09fa\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1.tar.gz\",\"repo\":\"pip_39_pygments_sdist_1daff049\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pylint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9-py3-none-any.whl\",\"repo\":\"pip_39_pylint_py3_none_any_349c8cd3\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9.tar.gz\",\"repo\":\"pip_39_pylint_sdist_18783cca\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pylint_print": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint_print\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-print-1.0.1.tar.gz\",\"repo\":\"pip_39_pylint_print_sdist_30aa207e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint_print-1.0.1-py3-none-any.whl\",\"repo\":\"pip_39_pylint_print_py3_none_any_a2b2599e\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "python_dateutil": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_dateutil\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-dateutil-2.8.2.tar.gz\",\"repo\":\"pip_39_python_dateutil_sdist_0123cacc\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_dateutil-2.8.2-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_dateutil_py2_none_any_961d03dc\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "python_magic": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_magic\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-magic-0.4.27.tar.gz\",\"repo\":\"pip_39_python_magic_sdist_c1ba14b0\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_magic-0.4.27-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_magic_py2_none_any_c212960a\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pyyaml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pyyaml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_macosx_10_9_x86_64_9eb6caa9\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_macosx_11_0_arm64_c8098ddc\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_manylinux_2_17_aarch64_5773183b\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_manylinux_2_17_s390x_b786eecb\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_manylinux_2_17_x86_64_bc1bf292\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_musllinux_1_1_x86_64_04ac92ad\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_pyyaml_cp39_cp39_win_amd64_510c9dee\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1.tar.gz\",\"repo\":\"pip_39_pyyaml_sdist_bfdf460b\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "requests": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_requests\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_requests_py2_none_any_c210084e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1.tar.gz\",\"repo\":\"pip_39_requests_sdist_27973dd4\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "s3cmd": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_s3cmd\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_s3cmd_py2_none_any_49cd23d5\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0.tar.gz\",\"repo\":\"pip_39_s3cmd_sdist_966b0a49\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "setuptools": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3-py3-none-any.whl\",\"repo\":\"pip_39_setuptools_py3_none_any_57f6f22b\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3.tar.gz\",\"repo\":\"pip_39_setuptools_sdist_a7620757\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "six": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_six\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_six_py2_none_any_8abb2f1d\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0.tar.gz\",\"repo\":\"pip_39_six_sdist_1e61c374\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "snowballstemmer": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_snowballstemmer\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_snowballstemmer_py2_none_any_c8e1716e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0.tar.gz\",\"repo\":\"pip_39_snowballstemmer_sdist_09b16deb\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinx": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinx\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinx_py3_none_any_1e09160a\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6.tar.gz\",\"repo\":\"pip_39_sphinx_sdist_9a5160e1\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_applehelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_applehelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_applehelp_py3_none_any_094c4d56\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_applehelp_sdist_39fdc8d7\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_devhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_devhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_devhelp_py3_none_any_fe8009ae\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_devhelp_sdist_63b41e0d\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_htmlhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_htmlhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_py3_none_any_8001661c\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_sdist_6c26a118\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_jsmath": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_jsmath\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib-jsmath-1.0.1.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_jsmath_sdist_a9925e4a\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_jsmath_py2_none_any_2ec2eaeb\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_qthelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_qthelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_qthelp_py3_none_any_bf76886e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_qthelp_sdist_62b9d1a1\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_serializinghtml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_serializinghtml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_py3_none_any_9b36e503\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_sdist_0c64ff89\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tabulate": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tabulate\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0-py3-none-any.whl\",\"repo\":\"pip_39_tabulate_py3_none_any_024ca478\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0.tar.gz\",\"repo\":\"pip_39_tabulate_sdist_0095b12b\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tomli": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomli\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1-py3-none-any.whl\",\"repo\":\"pip_39_tomli_py3_none_any_939de3e7\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1.tar.gz\",\"repo\":\"pip_39_tomli_sdist_de526c12\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tomlkit": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomlkit\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6-py3-none-any.whl\",\"repo\":\"pip_39_tomlkit_py3_none_any_07de26b0\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6.tar.gz\",\"repo\":\"pip_39_tomlkit_sdist_71b952e5\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "typing_extensions": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_typing_extensions\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2-py3-none-any.whl\",\"repo\":\"pip_39_typing_extensions_py3_none_any_04e5ca03\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2.tar.gz\",\"repo\":\"pip_39_typing_extensions_sdist_1a7ead55\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_urllib3\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18-py2.py3-none-any.whl\",\"repo\":\"pip_39_urllib3_py2_none_any_34b97092\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18.tar.gz\",\"repo\":\"pip_39_urllib3_sdist_f8ecc1bb\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "websockets": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_websockets\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_macosx_10_9_universal2_777354ee\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_macosx_10_9_x86_64_8c82f119\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_macosx_11_0_arm64_3580dd9c\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_manylinux_2_17_aarch64_6f1a3f10\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_manylinux_2_5_x86_64_279e5de4\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_musllinux_1_1_aarch64_1fdf26fa\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_musllinux_1_1_x86_64_97b52894\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_websockets_cp39_cp39_win_amd64_c792ea4e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-py3-none-any.whl\",\"repo\":\"pip_39_websockets_py3_none_any_6681ba9e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3.tar.gz\",\"repo\":\"pip_39_websockets_sdist_88fc51d9\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "wheel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wheel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0-py3-none-any.whl\",\"repo\":\"pip_39_wheel_py3_none_any_d236b20e\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0.tar.gz\",\"repo\":\"pip_39_wheel_sdist_cd1196f3\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "wrapt": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wrapt\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_macosx_10_9_x86_64_3232822c\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_macosx_11_0_arm64_988635d1\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_manylinux_2_17_aarch64_9cca3c2c\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_manylinux_2_5_x86_64_40e7bc81\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_musllinux_1_1_aarch64_b9b7a708\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_musllinux_1_1_x86_64_34aa51c4\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_wrapt_cp39_cp39_win_amd64_dee60e1d\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1.tar.gz\",\"repo\":\"pip_39_wrapt_sdist_380a85cf\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "yamllint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_yamllint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_yamllint_py2_none_any_89bb5b5a\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0.tar.gz\",\"repo\":\"pip_39_yamllint_sdist_9e3d8ddd\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "zipp": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0-py3-none-any.whl\",\"repo\":\"pip_39_zipp_py3_none_any_58da6168\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0.tar.gz\",\"repo\":\"pip_39_zipp_sdist_0145e43d\",\"target_platforms\":null,\"version\":\"3.9\"}]"
+                "alabaster": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_alabaster\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13-py3-none-any.whl\",\"repo\":\"pip_39_alabaster_0.7.13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13.tar.gz\",\"repo\":\"pip_39_alabaster_0.7.13.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "astroid": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_astroid\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13-py3-none-any.whl\",\"repo\":\"pip_39_astroid_2.12.13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13.tar.gz\",\"repo\":\"pip_39_astroid_2.12.13.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "babel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_babel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1-py3-none-any.whl\",\"repo\":\"pip_39_babel_2.13.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1.tar.gz\",\"repo\":\"pip_39_babel_2.13.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "certifi": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_certifi\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22-py3-none-any.whl\",\"repo\":\"pip_39_certifi_2023.7.22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22.tar.gz\",\"repo\":\"pip_39_certifi_2023.7.22.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "chardet": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_chardet\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_chardet_4.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0.tar.gz\",\"repo\":\"pip_39_chardet_4.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "colorama": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_colorama\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6-py2.py3-none-any.whl\",\"repo\":\"pip_39_colorama_0.4.6_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6.tar.gz\",\"repo\":\"pip_39_colorama_0.4.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "dill": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_dill\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6-py3-none-any.whl\",\"repo\":\"pip_39_dill_0.3.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6.tar.gz\",\"repo\":\"pip_39_dill_0.3.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "docutils": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_docutils\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1-py3-none-any.whl\",\"repo\":\"pip_39_docutils_0.20.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1.tar.gz\",\"repo\":\"pip_39_docutils_0.20.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "idna": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_idna\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10-py2.py3-none-any.whl\",\"repo\":\"pip_39_idna_2.10_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10.tar.gz\",\"repo\":\"pip_39_idna_2.10.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "imagesize": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_imagesize\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_imagesize_1.4.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1.tar.gz\",\"repo\":\"pip_39_imagesize_1.4.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0-py3-none-any.whl\",\"repo\":\"pip_39_importlib_metadata_8.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0.tar.gz\",\"repo\":\"pip_39_importlib_metadata_8.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "isort": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_isort\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4-py3-none-any.whl\",\"repo\":\"pip_39_isort_5.11.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4.tar.gz\",\"repo\":\"pip_39_isort_5.11.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "jinja2": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_jinja2\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4-py3-none-any.whl\",\"repo\":\"pip_39_jinja2_3.1.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4.tar.gz\",\"repo\":\"pip_39_jinja2_3.1.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "lazy_object_proxy": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_lazy_object_proxy\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy-object-proxy-1.10.0.tar.gz\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "markupsafe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_markupsafe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3.tar.gz\",\"repo\":\"pip_39_markupsafe_2.1.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "mccabe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_mccabe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_mccabe_0.7.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0.tar.gz\",\"repo\":\"pip_39_mccabe_0.7.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "packaging": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_packaging\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2-py3-none-any.whl\",\"repo\":\"pip_39_packaging_23.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2.tar.gz\",\"repo\":\"pip_39_packaging_23.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pathspec": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pathspec\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3-py3-none-any.whl\",\"repo\":\"pip_39_pathspec_0.10.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3.tar.gz\",\"repo\":\"pip_39_pathspec_0.10.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "platformdirs": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_platformdirs\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0-py3-none-any.whl\",\"repo\":\"pip_39_platformdirs_2.6.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0.tar.gz\",\"repo\":\"pip_39_platformdirs_2.6.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pygments": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pygments\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1-py3-none-any.whl\",\"repo\":\"pip_39_pygments_2.16.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1.tar.gz\",\"repo\":\"pip_39_pygments_2.16.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pylint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9-py3-none-any.whl\",\"repo\":\"pip_39_pylint_2.15.9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9.tar.gz\",\"repo\":\"pip_39_pylint_2.15.9.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pylint_print": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint_print\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-print-1.0.1.tar.gz\",\"repo\":\"pip_39_pylint_print_1.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint_print-1.0.1-py3-none-any.whl\",\"repo\":\"pip_39_pylint_print_1.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "python_dateutil": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_dateutil\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-dateutil-2.8.2.tar.gz\",\"repo\":\"pip_39_python_dateutil_2.8.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_dateutil-2.8.2-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_dateutil_2.8.2_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "python_magic": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_magic\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-magic-0.4.27.tar.gz\",\"repo\":\"pip_39_python_magic_0.4.27.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_magic-0.4.27-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_magic_0.4.27_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pyyaml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pyyaml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1.tar.gz\",\"repo\":\"pip_39_pyyaml_6.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "requests": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_requests\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_requests_2.25.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1.tar.gz\",\"repo\":\"pip_39_requests_2.25.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "s3cmd": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_s3cmd\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_s3cmd_2.1.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0.tar.gz\",\"repo\":\"pip_39_s3cmd_2.1.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "setuptools": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3-py3-none-any.whl\",\"repo\":\"pip_39_setuptools_65.6.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3.tar.gz\",\"repo\":\"pip_39_setuptools_65.6.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "six": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_six\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_six_1.16.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0.tar.gz\",\"repo\":\"pip_39_six_1.16.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "snowballstemmer": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_snowballstemmer\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_snowballstemmer_2.2.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0.tar.gz\",\"repo\":\"pip_39_snowballstemmer_2.2.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinx": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinx\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinx_7.2.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6.tar.gz\",\"repo\":\"pip_39_sphinx_7.2.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_applehelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_applehelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1.0.7_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1.0.7.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_devhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_devhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1.0.5_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1.0.5.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_htmlhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_htmlhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2.0.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2.0.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_jsmath": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_jsmath\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib-jsmath-1.0.1.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1.0.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_qthelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_qthelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1.0.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1.0.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_serializinghtml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_serializinghtml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1.1.9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1.1.9.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tabulate": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tabulate\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0-py3-none-any.whl\",\"repo\":\"pip_39_tabulate_0.9.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0.tar.gz\",\"repo\":\"pip_39_tabulate_0.9.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tomli": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomli\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1-py3-none-any.whl\",\"repo\":\"pip_39_tomli_2.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1.tar.gz\",\"repo\":\"pip_39_tomli_2.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tomlkit": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomlkit\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6-py3-none-any.whl\",\"repo\":\"pip_39_tomlkit_0.11.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6.tar.gz\",\"repo\":\"pip_39_tomlkit_0.11.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "typing_extensions": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_typing_extensions\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2-py3-none-any.whl\",\"repo\":\"pip_39_typing_extensions_4.12.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2.tar.gz\",\"repo\":\"pip_39_typing_extensions_4.12.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_urllib3\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18-py2.py3-none-any.whl\",\"repo\":\"pip_39_urllib3_1.26.18_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18.tar.gz\",\"repo\":\"pip_39_urllib3_1.26.18.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "websockets": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_websockets\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-py3-none-any.whl\",\"repo\":\"pip_39_websockets_11.0.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3.tar.gz\",\"repo\":\"pip_39_websockets_11.0.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "wheel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wheel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0-py3-none-any.whl\",\"repo\":\"pip_39_wheel_0.40.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0.tar.gz\",\"repo\":\"pip_39_wheel_0.40.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "wrapt": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wrapt\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1.tar.gz\",\"repo\":\"pip_39_wrapt_1.14.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "yamllint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_yamllint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_yamllint_1.28.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0.tar.gz\",\"repo\":\"pip_39_yamllint_1.28.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "zipp": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0-py3-none-any.whl\",\"repo\":\"pip_39_zipp_3.20.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0.tar.gz\",\"repo\":\"pip_39_zipp_3.20.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]"
               },
               "packages": [
                 "alabaster",
@@ -4488,7 +4536,7 @@
               }
             }
           },
-          "pip_39_importlib_metadata_sdist_9a547d3b": {
+          "pip_39_chardet_4.0.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4506,17 +4554,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "importlib_metadata-8.4.0.tar.gz",
+              "filename": "chardet-4.0.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
-              "sha256": "9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5",
+              "requirement": "chardet==4.0.0",
+              "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
               "urls": [
-                "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz"
+                "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz"
               ]
             }
           },
-          "pip_39_pyyaml_cp39_cp39_manylinux_2_17_x86_64_bc1bf292": {
+          "pip_39_docutils_0.20.1_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4534,17 +4582,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "filename": "docutils-0.20.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+              "requirement": "docutils==0.20.1",
+              "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
               "urls": [
-                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_tomli_py3_none_any_939de3e7": {
+          "pip_39_dill_0.3.6_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4562,78 +4610,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "tomli-2.0.1-py3-none-any.whl",
+              "filename": "dill-0.3.6-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
-              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "requirement": "dill==0.3.6",
+              "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
               "urls": [
-                "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_qthelp_py3_none_any_bf76886e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_qthelp-1.0.6-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-qthelp==1.0.6",
-              "sha256": "bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1f/e5/1850f3f118e95581c1e30b57028ac979badee1eb29e70ee72b0241f5a185/sphinxcontrib_qthelp-1.0.6-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_cp39_cp39_win_amd64_c792ea4e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "c792ea4eabc0159535608fc5658a74d1a81020eb35195dd63214dcf07556f67e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f4/3f/65dfa50084a06ab0a05f3ca74195c2c17a1c075b8361327d831ccce0a483/websockets-11.0.3-cp39-cp39-win_amd64.whl"
+                "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl"
               ]
             }
           },
@@ -4656,6 +4639,62 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "python-dateutil==2.8.2     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          },
+          "pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/9b/4908a57acf39d8811836bc6776b309c2e07d63791485589acf0b6d7bc0c6/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_tomli_2.0.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tomli-2.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
+              "sha256": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
+              ]
             }
           },
           "pip_310_imagesize": {
@@ -4700,7 +4739,7 @@
               "requirement": "tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             }
           },
-          "pip_39_sphinxcontrib_jsmath_sdist_a9925e4a": {
+          "pip_39_sphinx_7.2.6.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4718,17 +4757,26 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib-jsmath-1.0.1.tar.gz",
+              "filename": "sphinx-7.2.6.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-jsmath==1.0.1",
-              "sha256": "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8",
+              "requirement": "sphinx==7.2.6",
+              "sha256": "9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5",
               "urls": [
-                "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz"
+                "https://files.pythonhosted.org/packages/73/8e/6e51da4b26665b4b92b1944ea18b2d9c825e753e19180cc5bdc818d0ed3b/sphinx-7.2.6.tar.gz"
               ]
             }
           },
-          "pip_39_alabaster_sdist_a27a4a08": {
+          "pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_universal2": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4746,17 +4794,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "alabaster-0.7.13.tar.gz",
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "alabaster==0.7.13",
-              "sha256": "a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
               "urls": [
-                "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz"
+                "https://files.pythonhosted.org/packages/6a/86/654dc431513cd4417dfcead8102f22bece2d6abf2f584f0e1cc1524f7b94/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl"
               ]
             }
           },
-          "pip_39_pylint_print_py3_none_any_a2b2599e": {
+          "pip_39_colorama_0.4.6_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4774,17 +4822,67 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "pylint_print-1.0.1-py3-none-any.whl",
+              "filename": "colorama-0.4.6-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pylint-print==1.0.1",
-              "sha256": "a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b",
+              "requirement": "colorama==0.4.6",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
               "urls": [
-                "https://files.pythonhosted.org/packages/8f/a9/6f0687b575d502b4fa770cd52231e23462c548829e5f2e6f43a3d2b9c939/pylint_print-1.0.1-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_six_sdist_1e61c374": {
+          "pip_39_wheel_0.40.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wheel-0.40.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wheel==0.40.0",
+              "sha256": "d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247",
+              "urls": [
+                "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "platformdirs==3.5.1     --hash=sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f     --hash=sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
+            }
+          },
+          "pip_39_six_1.16.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4812,89 +4910,6 @@
               ]
             }
           },
-          "pip_39_requests_sdist_27973dd4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "requests-2.25.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "requests==2.25.1",
-              "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz"
-              ],
-              "whl_patches": {
-                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
-              }
-            }
-          },
-          "pip_310_platformdirs": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "platformdirs==3.5.1     --hash=sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f     --hash=sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
-            }
-          },
-          "pip_39_six_py2_none_any_8abb2f1d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "six-1.16.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "six==1.16.0",
-              "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
           "pip_310_dill": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4916,7 +4931,7 @@
               "requirement": "dill==0.3.6     --hash=sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0     --hash=sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             }
           },
-          "pip_39_urllib3_py2_none_any_34b97092": {
+          "pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4934,17 +4949,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "urllib3-1.26.18-py2.py3-none-any.whl",
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
               "urls": [
-                "https://files.pythonhosted.org/packages/b0/53/aa91e163dcfd1e5b82d8a890ecf13314e3e149c05270cc644581f77f17fd/urllib3-1.26.18-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/03/65/3473d2cb84bb2cda08be95b97fc4f53e6bcd701a2d50ba7b7c905e1e9273/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl"
               ]
             }
           },
-          "pip_39_websockets_cp39_cp39_macosx_11_0_arm64_3580dd9c": {
+          "pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4962,17 +4977,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "websockets==11.0.3",
-              "sha256": "3580dd9c1ad0701169e4d6fc41e878ffe05e6bdcaf3c412f9d559389d0c9e016",
+              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
               "urls": [
-                "https://files.pythonhosted.org/packages/a0/1a/3da73e69ebc00649d11ed836541c92c1a2df0b8a8aa641a2c8746e7c2b9c/websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl"
+                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
               ]
             }
           },
-          "pip_39_babel_sdist_33e0952d": {
+          "pip_39_pathspec_0.10.3_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4990,13 +5005,69 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "Babel-2.13.1.tar.gz",
+              "filename": "pathspec-0.10.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "babel==2.13.1",
-              "sha256": "33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900",
+              "requirement": "pathspec==0.10.3",
+              "sha256": "3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
               "urls": [
-                "https://files.pythonhosted.org/packages/aa/6c/737d2345d86741eeb594381394016b9c74c1253b4cbe274bb1e7b5e2138e/Babel-2.13.1.tar.gz"
+                "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_docutils_0.20.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "docutils-0.20.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "docutils==0.20.1",
+              "sha256": "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_websockets_11.0.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "6681ba9e7f8f3b19440921e99efbb40fc89f26cd71bf539e45d8c8a25c976dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/47/96/9d5749106ff57629b54360664ae7eb9afd8302fad1680ead385383e33746/websockets-11.0.3-py3-none-any.whl"
               ]
             }
           },
@@ -5021,7 +5092,7 @@
               "requirement": "sphinxcontrib-jsmath==1.0.1     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             }
           },
-          "pip_39_mccabe_py2_none_any_6c2d30ab": {
+          "pip_39_isort_5.11.4_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5039,13 +5110,78 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "mccabe-0.7.0-py2.py3-none-any.whl",
+              "filename": "isort-5.11.4-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "mccabe==0.7.0",
-              "sha256": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
+              "requirement": "isort==5.11.4",
+              "sha256": "c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b",
               "urls": [
-                "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_serializinghtml_1.1.9_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
+              "sha256": "9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/95/d6/2e0bda62b2a808070ac922d21a950aa2cb5e4fcfb87e5ff5f86bc43a2201/sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/20/f59423543a8422cb8c69a579ebd0ef2c9dafa70cc8142b7372b5b4073caa/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl"
               ]
             }
           },
@@ -5091,7 +5227,7 @@
               "requirement": "markupsafe==2.1.3     --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e     --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e     --hash=sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431     --hash=sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686     --hash=sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c     --hash=sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559     --hash=sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc     --hash=sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb     --hash=sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939     --hash=sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c     --hash=sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0     --hash=sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4     --hash=sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9     --hash=sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575     --hash=sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba     --hash=sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d     --hash=sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd     --hash=sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3     --hash=sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00     --hash=sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155     --hash=sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac     --hash=sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52     --hash=sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f     --hash=sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8     --hash=sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b     --hash=sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007     --hash=sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24     --hash=sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea     --hash=sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198     --hash=sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0     --hash=sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee     --hash=sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be     --hash=sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2     --hash=sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1     --hash=sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707     --hash=sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6     --hash=sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c     --hash=sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58     --hash=sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823     --hash=sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779     --hash=sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636     --hash=sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c     --hash=sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad     --hash=sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee     --hash=sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc     --hash=sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2     --hash=sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48     --hash=sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7     --hash=sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e     --hash=sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b     --hash=sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa     --hash=sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5     --hash=sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e     --hash=sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb     --hash=sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9     --hash=sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57     --hash=sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc     --hash=sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc     --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2     --hash=sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
             }
           },
-          "pip_39_isort_sdist_6db30c5d": {
+          "pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5109,17 +5245,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "isort-5.11.4.tar.gz",
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "isort==5.11.4",
-              "sha256": "6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
+              "requirement": "websockets==11.0.3",
+              "sha256": "8c82f11964f010053e13daafdc7154ce7385ecc538989a354ccc7067fd7028fd",
               "urls": [
-                "https://files.pythonhosted.org/packages/76/46/004e2dd6c312e8bb7cb40a6c01b770956e0ef137857e82d47bd9c829356b/isort-5.11.4.tar.gz"
+                "https://files.pythonhosted.org/packages/8f/f2/8a3eb016be19743c7eb9e67c855df0fdfa5912534ffaf83a05b62667d761/websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl"
               ]
             }
           },
-          "pip_39_python_magic_sdist_c1ba14b0": {
+          "pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_universal2": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5137,17 +5273,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "python-magic-0.4.27.tar.gz",
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "python-magic==0.4.27",
-              "sha256": "c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b",
+              "requirement": "websockets==11.0.3",
+              "sha256": "777354ee16f02f643a4c7f2b3eff8027a33c9861edc691a2003531f5da4f6bc8",
               "urls": [
-                "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz"
+                "https://files.pythonhosted.org/packages/c0/21/cb9dfbbea8dc0ad89ced52630e7e61edb425fb9fdc6002f8d0c5dd26b94b/websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl"
               ]
             }
           },
-          "pip_39_lazy_object_proxy_cp39_cp39_manylinux_2_17_aarch64_2297f08f": {
+          "pip_39_urllib3_1.26.18.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5165,17 +5301,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "urllib3-1.26.18.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
+              "requirement": "urllib3==1.26.18",
+              "sha256": "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
               "urls": [
-                "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
               ]
             }
           },
-          "pip_39_wrapt_cp39_cp39_manylinux_2_17_aarch64_9cca3c2c": {
+          "pip_39_imagesize_1.4.1.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5193,13 +5329,41 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "imagesize-1.4.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+              "requirement": "imagesize==1.4.1",
+              "sha256": "69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a",
               "urls": [
-                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_snowballstemmer_2.2.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "snowballstemmer-2.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "snowballstemmer==2.2.0",
+              "sha256": "09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz"
               ]
             }
           },
@@ -5224,7 +5388,7 @@
               "requirement": "mccabe==0.7.0     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             }
           },
-          "pip_39_certifi_sdist_539cc1d1": {
+          "pip_39_packaging_23.2.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5242,13 +5406,69 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "certifi-2023.7.22.tar.gz",
+              "filename": "packaging-23.2.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+              "requirement": "packaging==23.2",
+              "sha256": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
               "urls": [
-                "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
+                "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6.0.1_cp39_cp39_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+              "urls": [
+                "https://files.pythonhosted.org/packages/84/4d/82704d1ab9290b03da94e6425f5e87396b999fd7eb8e08f3a92c158402bf/PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
+              ]
+            }
+          },
+          "pip_39_astroid_2.12.13.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "astroid-2.12.13.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "astroid==2.12.13",
+              "sha256": "1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/61/d0/e7cfca72ec7d6c5e0da725c003db99bb056e9b6c2f4ee6fae1145adf28a6/astroid-2.12.13.tar.gz"
               ]
             }
           },
@@ -5282,280 +5502,7 @@
               "requirement": "sphinxcontrib-applehelp==1.0.7     --hash=sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d     --hash=sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
             }
           },
-          "pip_39_python_dateutil_py2_none_any_961d03dc": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-dateutil==2.8.2",
-              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_pyyaml_sdist_bfdf460b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
-              "urls": [
-                "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_devhelp_sdist_63b41e0d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_devhelp-1.0.5.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-devhelp==1.0.5",
-              "sha256": "63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2e/f2/6425b6db37e7c2254ad661c90a871061a078beaddaf9f15a00ba9c3a1529/sphinxcontrib_devhelp-1.0.5.tar.gz"
-              ]
-            }
-          },
-          "pip_310_pygments": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pygments==2.16.1     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
-            }
-          },
-          "pip_39_sphinxcontrib_serializinghtml_py3_none_any_9b36e503": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
-              "sha256": "9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/95/d6/2e0bda62b2a808070ac922d21a950aa2cb5e4fcfb87e5ff5f86bc43a2201/sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_tabulate_sdist_0095b12b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tabulate-0.9.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tabulate==0.9.0",
-              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
-              ]
-            }
-          },
-          "whl_mods_hub": {
-            "bzlFile": "@@rules_python~//python/private/pypi:extension.bzl",
-            "ruleClassName": "_whl_mods_repo",
-            "attributes": {
-              "whl_mods": {
-                "requests": "{\"additive_build_content\":\"load(\\\"@bazel_skylib//rules:write_file.bzl\\\", \\\"write_file\\\")\\n\\nwrite_file(\\n    name = \\\"generated_file\\\",\\n    out = \\\"generated_file.txt\\\",\\n    content = [\\\"Hello world from requests\\\"],\\n)\\n\\nfilegroup(\\n    name = \\\"whl_orig\\\",\\n    srcs = glob(\\n        [\\\"*.whl\\\"],\\n        allow_empty = False,\\n        exclude = [\\\"*-patched-*.whl\\\"],\\n    ),\\n)\\n\",\"copy_executables\":{},\"copy_files\":{},\"data\":[\":generated_file\"],\"data_exclude_glob\":[],\"srcs_exclude_glob\":[]}",
-                "wheel": "{\"additive_build_content\":\"load(\\\"@bazel_skylib//rules:write_file.bzl\\\", \\\"write_file\\\")\\nwrite_file(\\n    name = \\\"generated_file\\\",\\n    out = \\\"generated_file.txt\\\",\\n    content = [\\\"Hello world from build content file\\\"],\\n)\\n\",\"copy_executables\":{\"@@//whl_mods:data/copy_executable.py\":\"copied_content/executable.py\"},\"copy_files\":{\"@@//whl_mods:data/copy_file.txt\":\"copied_content/file.txt\"},\"data\":[\":generated_file\"],\"data_exclude_glob\":[\"site-packages/*.dist-info/WHEEL\"],\"srcs_exclude_glob\":[]}"
-              }
-            }
-          },
-          "pip_39_markupsafe_cp39_cp39_musllinux_1_1_x86_64_0a4e4a1a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ab/20/f59423543a8422cb8c69a579ebd0ef2c9dafa70cc8142b7372b5b4073caa/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_imagesize_sdist_69150444": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "imagesize-1.4.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "imagesize==1.4.1",
-              "sha256": "69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_websockets_cp39_cp39_manylinux_2_5_x86_64_279e5de4": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "279e5de4671e79a9ac877427f4ac4ce93751b8823f276b681d04b2156713b9dd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a6/9c/2356ecb952fd3992b73f7a897d65e57d784a69b94bb8d8fd5f97531e5c02/websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_applehelp_py3_none_any_094c4d56": {
+          "pip_39_sphinxcontrib_applehelp_1.0.7_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5592,28 +5539,7 @@
               ]
             }
           },
-          "pip_310_certifi": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "certifi==2023.7.22     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
-            }
-          },
-          "pip_39_zipp_py3_none_any_58da6168": {
+          "pip_39_mccabe_0.7.0.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5631,72 +5557,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "zipp-3.20.0-py3-none-any.whl",
+              "filename": "mccabe-0.7.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
-              "sha256": "58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d",
+              "requirement": "mccabe==0.7.0",
+              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
               "urls": [
-                "https://files.pythonhosted.org/packages/da/cc/b9958af9f9c86b51f846d8487440af495ecf19b16e426fce1ed0b0796175/zipp-3.20.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
               ]
             }
           },
-          "pip_310_pyyaml": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pyyaml==6.0     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293     --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b     --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57     --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b     --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4     --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07     --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba     --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9     --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287     --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513     --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0     --hash=sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782     --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0     --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92     --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f     --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2     --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc     --hash=sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1     --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c     --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86     --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4     --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c     --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34     --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b     --hash=sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d     --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c     --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb     --hash=sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7     --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737     --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3     --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d     --hash=sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358     --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53     --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78     --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803     --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a     --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
-            }
-          },
-          "pip_39_requests_py2_none_any_c210084e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "requests-2.25.1-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "requests==2.25.1",
-              "sha256": "c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl"
-              ],
-              "whl_patches": {
-                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
-              }
-            }
-          },
-          "pip_39_docutils_py3_none_any_96f387a2": {
+          "pip_39_colorama_0.4.6.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5714,17 +5585,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "docutils-0.20.1-py3-none-any.whl",
+              "filename": "colorama-0.4.6.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "docutils==0.20.1",
-              "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+              "requirement": "colorama==0.4.6",
+              "sha256": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
               "urls": [
-                "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
               ]
             }
           },
-          "pip_39_isort_py3_none_any_c033fd0e": {
+          "pip_39_jinja2_3.1.4.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5742,159 +5613,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "isort-5.11.4-py3-none-any.whl",
+              "filename": "jinja2-3.1.4.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "isort==5.11.4",
-              "sha256": "c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b",
+              "requirement": "jinja2==3.1.4",
+              "sha256": "4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
               "urls": [
-                "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz"
               ]
             }
           },
-          "pip_39_astroid_sdist_1493fe8b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "astroid-2.12.13.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "astroid==2.12.13",
-              "sha256": "1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/61/d0/e7cfca72ec7d6c5e0da725c003db99bb056e9b6c2f4ee6fae1145adf28a6/astroid-2.12.13.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_htmlhelp_py3_none_any_8001661c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
-              "sha256": "8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/28/7a/958f8e3e6abe8219d0d1f1224886de847ab227b218f4a07b61bc337f64be/sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_310_chardet": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "chardet==4.0.0     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
-            }
-          },
-          "pip_39_websockets_cp39_cp39_macosx_10_9_universal2_777354ee": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "777354ee16f02f643a4c7f2b3eff8027a33c9861edc691a2003531f5da4f6bc8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/21/cb9dfbbea8dc0ad89ced52630e7e61edb425fb9fdc6002f8d0c5dd26b94b/websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl"
-              ]
-            }
-          },
-          "pip_39_pyyaml_cp39_cp39_manylinux_2_17_s390x_b786eecb": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4a/4b/c71ef18ef83c82f99e6da8332910692af78ea32bd1d1d76c9787dfa36aea/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "pip_39_pylint_print_sdist_30aa207e": {
+          "pip_39_pylint_print_1.0.1.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5922,7 +5651,7 @@
               ]
             }
           },
-          "pip_39_websockets_cp39_cp39_macosx_10_9_x86_64_8c82f119": {
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5940,13 +5669,340 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl",
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/ae/3e15cffacbdb64ac49930cdbc23cb0c67e1bb9e8a8ca7765fd8a8d2510c3/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "pip_310_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pygments==2.16.1     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
+            }
+          },
+          "pip_39_markupsafe_2.1.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+              "urls": [
+                "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
+              ]
+            }
+          },
+          "whl_mods_hub": {
+            "bzlFile": "@@rules_python~//python/private/pypi:extension.bzl",
+            "ruleClassName": "_whl_mods_repo",
+            "attributes": {
+              "whl_mods": {
+                "requests": "{\"additive_build_content\":\"load(\\\"@bazel_skylib//rules:write_file.bzl\\\", \\\"write_file\\\")\\n\\nwrite_file(\\n    name = \\\"generated_file\\\",\\n    out = \\\"generated_file.txt\\\",\\n    content = [\\\"Hello world from requests\\\"],\\n)\\n\\nfilegroup(\\n    name = \\\"whl_orig\\\",\\n    srcs = glob(\\n        [\\\"*.whl\\\"],\\n        allow_empty = False,\\n        exclude = [\\\"*-patched-*.whl\\\"],\\n    ),\\n)\\n\",\"copy_executables\":{},\"copy_files\":{},\"data\":[\":generated_file\"],\"data_exclude_glob\":[],\"srcs_exclude_glob\":[]}",
+                "wheel": "{\"additive_build_content\":\"load(\\\"@bazel_skylib//rules:write_file.bzl\\\", \\\"write_file\\\")\\nwrite_file(\\n    name = \\\"generated_file\\\",\\n    out = \\\"generated_file.txt\\\",\\n    content = [\\\"Hello world from build content file\\\"],\\n)\\n\",\"copy_executables\":{\"@@//whl_mods:data/copy_executable.py\":\"copied_content/executable.py\"},\"copy_files\":{\"@@//whl_mods:data/copy_file.txt\":\"copied_content/file.txt\"},\"data\":[\":generated_file\"],\"data_exclude_glob\":[\"site-packages/*.dist-info/WHEEL\"],\"srcs_exclude_glob\":[]}"
+              }
+            }
+          },
+          "pip_39_pyyaml_6.0.1_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/3c/110e52b9da396a4ef3a0521552a1af9c7875a762361f48678c1ac272fd7e/wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "pip_310_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "certifi==2023.7.22     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
+            }
+          },
+          "pip_310_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pyyaml==6.0     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293     --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b     --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57     --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b     --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4     --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07     --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba     --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9     --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287     --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513     --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0     --hash=sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782     --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0     --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92     --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f     --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2     --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc     --hash=sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1     --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c     --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86     --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4     --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c     --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34     --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b     --hash=sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d     --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c     --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb     --hash=sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7     --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737     --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3     --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d     --hash=sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358     --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53     --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78     --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803     --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a     --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            }
+          },
+          "pip_39_sphinxcontrib_applehelp_1.0.7.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_applehelp-1.0.7.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-applehelp==1.0.7",
+              "sha256": "39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1c/5a/fce19be5d4db26edc853a0c34832b39db7b769b7689da027529767b0aa98/sphinxcontrib_applehelp-1.0.7.tar.gz"
+              ]
+            }
+          },
+          "pip_39_jinja2_3.1.4_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "jinja2-3.1.4-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "jinja2==3.1.4",
+              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "chardet==4.0.0     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            }
+          },
+          "pip_39_alabaster_0.7.13_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "alabaster-0.7.13-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "alabaster==0.7.13",
+              "sha256": "1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bc/2f/b9230d00c2eaa629e67cc69f285bf6b5692cb1d0179a1f8764edd451da86/lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11.0.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "websockets==11.0.3",
-              "sha256": "8c82f11964f010053e13daafdc7154ce7385ecc538989a354ccc7067fd7028fd",
+              "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016",
               "urls": [
-                "https://files.pythonhosted.org/packages/8f/f2/8a3eb016be19743c7eb9e67c855df0fdfa5912534ffaf83a05b62667d761/websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl"
+                "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz"
               ]
             }
           },
@@ -5971,6 +6027,34 @@
               "requirement": "urllib3==1.26.18     --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07     --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             }
           },
+          "pip_39_platformdirs_2.6.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "platformdirs-2.6.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "platformdirs==2.6.0",
+              "sha256": "1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
+              "urls": [
+                "https://files.pythonhosted.org/packages/87/69/cd019a9473bcdfb38983e2d550ccb239264fc4c2fc32c42ac1b1cc2506b6/platformdirs-2.6.0-py3-none-any.whl"
+              ]
+            }
+          },
           "pip_310_six": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5990,34 +6074,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "six==1.16.0     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            }
-          },
-          "pip_39_wrapt_sdist_380a85cf": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
-              ]
             }
           },
           "pip_310_wheel": {
@@ -6042,7 +6098,7 @@
               "requirement": "wheel==0.40.0     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
             }
           },
-          "pip_39_pyyaml_cp39_cp39_macosx_11_0_arm64_c8098ddc": {
+          "pip_39_wrapt_1.14.1_cp39_cp39_win_amd64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -6060,41 +6116,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl",
+              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/88/21b2f16cb2123c1e9375f2c93486e35fdc86e63f02e274f0e99c589ef153/PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
-              ]
-            }
-          },
-          "pip_39_dill_py3_none_any_a07ffd23": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "dill-0.3.6-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "dill==0.3.6",
-              "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
               ]
             }
           },
@@ -6117,34 +6145,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "jinja2==3.1.4     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
-            }
-          },
-          "pip_39_babel_py3_none_any_7077a498": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "Babel-2.13.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "babel==2.13.1",
-              "sha256": "7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed",
-              "urls": [
-                "https://files.pythonhosted.org/packages/86/14/5dc2eb02b7cc87b2f95930310a2cc5229198414919a116b564832c747bc1/Babel-2.13.1-py3-none-any.whl"
-              ]
             }
           },
           "pip_310_websockets": {
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "pgIPI+ouKZGvpe1ZWE13QCQ5n0E4veB3tzWhx5XURJ0=",
+        "bzlTransitiveDigest": "3xiJG0qOok3nehSJ+kW0/IeKzrjB0DW6hDAy8bEYgz0=",
         "usagesDigest": "LYtSAPzhPjmfD9vF39mCED1UQSvHEo2Hv+aK5Z4ZWWc=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
@@ -6312,770 +6312,7 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
-              "urls": [
-                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_sdist_1c39c601": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "urllib3-2.2.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==2.2.3",
-              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
-              "urls": [
-                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_sdist_e7d814a8": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "urllib3-2.2.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==2.2.3",
-              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
-              "urls": [
-                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
-              "urls": [
-                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_sdist_223217c3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_sdist_315b9001": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
-              "urls": [
-                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_secretstorage_sdist_2403533e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "SecretStorage-3.3.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "secretstorage==3.3.3",
-              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
-              "urls": [
-                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco_functools-4.1.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-functools==4.1.0",
-              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "pycparser-2.22-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.22",
-              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
-              "urls": [
-                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "idna-3.10.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.10",
-              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32-ctypes-0.2.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.3",
-              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
-              "urls": [
-                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "readme_renderer-44.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==44.0",
-              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_sdist_786ff802": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pygments-2.18.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.18.0",
-              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
-              "urls": [
-                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "14c5a72e9fe82aea5fe3072116ad4661af5cf8e8ff8fc5ad3450f123e4925e86",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b3/89/1daff5d9ba5a95a157c092c7c5f39b8dd2b1ddb4559966f808d31cfb67e0/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_zipp_py3_none_any_a817ac80": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "zipp-3.20.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.20.2",
-              "sha256": "a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "backports_tarfile-1.2.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "backports-tarfile==1.2.0",
-              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
-              "urls": [
-                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "jeepney-0.8.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jeepney==0.8.0",
-              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "secretstorage==3.3.3",
-              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
-              "urls": [
-                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.classes-3.4.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.4.0",
-              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d": {
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -7097,382 +6334,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-toolbelt-1.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==1.0.0",
-              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rich_py3_none_any_9836f509": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rich-13.9.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.9.3",
-              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==8.5.0",
-              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_twine_py3_none_any_215dbe7b": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "twine-5.1.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==5.1.1",
-              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_sdist_3a6b1873": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "docutils-0.21.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.21.2",
-              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_keyring_sdist_b07ebc55": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "keyring-25.4.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==25.4.1",
-              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==3.0.0",
-              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_certifi_py3_none_any_922820b5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "certifi-2024.8.30-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2024.8.30",
-              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_more_itertools_sdist_5482bfef": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "more-itertools-10.5.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==10.5.0",
-              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_certifi_sdist_bec941d2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "certifi-2024.8.30.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2024.8.30",
-              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c": {
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -7484,586 +6346,17 @@
                 "cp311_linux_s390x",
                 "cp311_linux_x86_64"
               ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
               "requirement": "cffi==1.17.1",
-              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
+              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
               "urls": [
-                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_keyring_py3_none_any_5426f817": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "keyring-25.4.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==25.4.1",
-              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
-              "urls": [
-                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
-              "urls": [
-                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rfc3986_sdist_97aacf9d": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rfc3986-2.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rfc3986==2.0.0",
-              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_twine_sdist_9aa08251": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "twine-5.1.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==5.1.1",
-              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
-              "urls": [
-                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pkginfo_sdist_5df73835": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pkginfo-1.10.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.10.0",
-              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "backports-tarfile==1.2.0",
-              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "markdown-it-py-3.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==3.0.0",
-              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
-              "urls": [
-                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pkginfo-1.10.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.10.0",
-              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
-              "urls": [
-                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_idna_py3_none_any_946d195a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "idna-3.10-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.10",
-              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_sdist_94a16692": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_sdist_55365417": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-2.32.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.32.3",
-              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
-              "urls": [
-                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_sdist_491c8be9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "pycparser-2.22.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.22",
-              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pygments-2.18.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.18.0",
-              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_sdist_71522656": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.5.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==8.5.0",
-              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-context==6.0.1",
-              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "more_itertools-10.5.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==10.5.0",
-              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
-              "urls": [
-                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7": {
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64le": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8088,166 +6381,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_rich_sdist_bc1e01b8": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rich-13.9.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.9.3",
-              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==1.0.0",
-              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
-              "urls": [
-                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "docutils-0.21.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.21.2",
-              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.3",
-              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b": {
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8272,7 +6406,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_jeepney_sdist_5efe48d2": {
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_ppc64le": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8284,17 +6418,568 @@
                 "cp311_linux_s390x",
                 "cp311_linux_x86_64"
               ],
-              "filename": "jeepney-0.8.0.tar.gz",
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
-              "requirement": "jeepney==0.8.0",
-              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+              "requirement": "cffi==1.17.1",
+              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
               "urls": [
-                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39": {
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_1.10.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
+              "urls": [
+                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_3.4.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_5.1.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_2.2.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_3.3.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_8.5.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_2.32.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_1.0.0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "urls": [
+                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_10.5.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more-itertools-10.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
+              "urls": [
+                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_3.0.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown-it-py-3.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_0.1.2.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_0.8.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_2.22.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_3.3.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+              "urls": [
+                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8316,7 +7001,57 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_2.2.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_2.0.0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8341,7 +7076,273 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_zipp_sdist_bc9eb26f": {
+          "rules_python_publish_deps_311_twine_5.1.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_2.22_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_2.18.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_0.21.2.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_2024.8.30_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_armv7l": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
+              "urls": [
+                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_13.9.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_13.9.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_3.20.2.tar.gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8366,42 +7367,1013 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_importlib_metadata_8.5.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_4.1.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco_functools-4.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_1.2.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports_tarfile-1.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
+              "urls": [
+                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_44.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_2.0.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_25.4.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_0.2.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32-ctypes-0.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_3.4.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_44.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_2.18.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1.17.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
+              "urls": [
+                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_10.5.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more_itertools-10.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
+              "urls": [
+                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_1.10.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_3.10.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_0.8.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_1.0.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-toolbelt-1.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+              "urls": [
+                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_0.21.2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_6.0.1.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco_context-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_4.1.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_3.0.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_2024.8.30.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_0.1.2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_0.2.3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_1.2.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_6.0.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_3.20.2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps": {
             "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
             "ruleClassName": "hub_repository",
             "attributes": {
               "repo_name": "rules_python_publish_deps",
               "whl_map": {
-                "backports_tarfile": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "certifi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_py3_none_any_922820b5\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_sdist_bec941d2\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_sdist_1c39c601\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "charset_normalizer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_sdist_223217c3\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cryptography": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_sdist_315b9001\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "docutils": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_sdist_3a6b1873\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_py3_none_any_946d195a\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_sdist_12f65c9b\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_sdist_71522656\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_classes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_context": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_functools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jeepney": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_sdist_5efe48d2\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "keyring": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_py3_none_any_5426f817\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_sdist_b07ebc55\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "markdown_it_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "mdurl": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_py3_none_any_84008a41\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_sdist_bb413d29\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "more_itertools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more-itertools-10.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_sdist_5482bfef\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "nh3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_nh3_sdist_94a16692\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pkginfo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_sdist_5df73835\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pycparser": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_sdist_491c8be9\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pygments": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_sdist_786ff802\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pywin32_ctypes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "readme_renderer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_sdist_8712034e\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_py3_none_any_70761cfe\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_sdist_55365417\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests_toolbelt": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rfc3986": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_sdist_97aacf9d\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rich": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_py3_none_any_9836f509\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_sdist_bc1e01b8\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "secretstorage": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_sdist_2403533e\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "twine": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_py3_none_any_215dbe7b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_sdist_9aa08251\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_sdist_e7d814a8\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "zipp": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_py3_none_any_a817ac80\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_sdist_bc9eb26f\",\"target_platforms\":null,\"version\":\"3.11\"}]"
+                "backports_tarfile": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1.2.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1.2.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "certifi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_2024.8.30_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_2024.8.30.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "charset_normalizer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "cryptography": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "docutils": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_0.21.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_0.21.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_3.10_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_3.10.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8.5.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8.5.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_classes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_context": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_functools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4.1.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4.1.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jeepney": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_0.8.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_0.8.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "keyring": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_25.4.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_25.4.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "markdown_it_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3.0.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "mdurl": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_0.1.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_0.1.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "more_itertools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more-itertools-10.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10.5.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10.5.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "nh3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pkginfo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1.10.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1.10.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pycparser": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_2.22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_2.22.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pygments": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_2.18.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_2.18.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pywin32_ctypes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0.2.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0.2.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "readme_renderer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "requests": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_2.32.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_2.32.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "requests_toolbelt": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "rfc3986": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "rich": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_13.9.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_13.9.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "secretstorage": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3.3.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3.3.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "twine": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_5.1.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_5.1.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_2.2.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_2.2.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "zipp": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_3.20.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_3.20.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]"
               },
               "packages": [
                 "backports_tarfile",
@@ -8432,7 +8404,157 @@
               "groups": {}
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f": {
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_2.32.3.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0.tar.gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_25.4.1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
+              "urls": [
+                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_3.10_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_universal2": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8457,7 +8579,7 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b": {
+          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_armv7l": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8472,160 +8594,13 @@
                 "cp311_osx_x86_64",
                 "cp311_windows_x86_64"
               ],
-              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.4.0",
-              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "requirement": "nh3==0.2.18",
+              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
               "urls": [
-                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco_context-6.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-context==6.0.1",
-              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_py3_none_any_70761cfe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-2.32.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.32.3",
-              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_readme_renderer_sdist_8712034e": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "readme_renderer-44.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==44.0",
-              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
-              "urls": [
-                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-functools==4.1.0",
-              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
               ]
             }
           }

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1392,7 +1392,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "iqa9U8iftHi1/TnBA8W4cjnzFATGPisvukdRRMTDReA=",
+        "bzlTransitiveDigest": "WZigHu1rtnKN0TNhUsVjWWeXMuy/6jzSCTHkm06ZOzE=",
         "usagesDigest": "MChlcSw99EuW3K7OOoMcXQIdcJnEh6YmfyjJm+9mxIg=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -1414,7 +1414,7 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
-          "pip_39_isort_5.11.4.tar.gz": {
+          "pip_39_pathspec_0_10_3_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1432,17 +1432,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "isort-5.11.4.tar.gz",
+              "filename": "pathspec-0.10.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "isort==5.11.4",
-              "sha256": "6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
+              "requirement": "pathspec==0.10.3",
+              "sha256": "3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
               "urls": [
-                "https://files.pythonhosted.org/packages/76/46/004e2dd6c312e8bb7cb40a6c01b770956e0ef137857e82d47bd9c829356b/isort-5.11.4.tar.gz"
+                "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_sphinxcontrib_htmlhelp_2.0.4.tar.gz": {
+          "pip_39_sphinxcontrib_devhelp_1_0_5_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1460,7 +1460,7 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_htmlhelp-2.0.4.tar.gz",
+              "filename": "sphinxcontrib_devhelp-1.0.5-py3-none-any.whl",
               "group_deps": [
                 "sphinx",
                 "sphinxcontrib_qthelp",
@@ -1472,14 +1472,14 @@
               "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
-              "sha256": "6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
+              "requirement": "sphinxcontrib-devhelp==1.0.5",
+              "sha256": "fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f",
               "urls": [
-                "https://files.pythonhosted.org/packages/fd/2d/abf5cd4cc1d5cd9842748b15a28295e4c4a927facfa8a0e173bd3f151bc5/sphinxcontrib_htmlhelp-2.0.4.tar.gz"
+                "https://files.pythonhosted.org/packages/c0/03/010ac733ec7b7f71c1dc88e7115743ee466560d6d85373b56fb9916e4586/sphinxcontrib_devhelp-1.0.5-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_17_aarch64": {
+          "pip_39_sphinxcontrib_qthelp_1_0_6_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1497,13 +1497,50 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "sphinxcontrib_qthelp-1.0.6.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
+              "requirement": "sphinxcontrib-qthelp==1.0.6",
+              "sha256": "62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
               "urls": [
-                "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/4f/a2/53129fc967ac8402d5e4e83e23c959c3f7a07362ec154bdb2e197d8cc270/sphinxcontrib_qthelp-1.0.6.tar.gz"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a2/b2/624042cb58cc6b3529a6c3a7b7d230766e3ecb768cba118ba7befd18ed6f/MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl"
               ]
             }
           },
@@ -1558,7 +1595,7 @@
               "requirement": "sphinx==7.2.6     --hash=sha256:1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560     --hash=sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"
             }
           },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_macosx_11_0_arm64": {
+          "pip_39_websockets_11_0_3_cp39_cp39_manylinux_2_17_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1576,17 +1613,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+              "requirement": "websockets==11.0.3",
+              "sha256": "6f1a3f10f836fab6ca6efa97bb952300b20ae56b409414ca85bff2ad241d2a61",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/88/21b2f16cb2123c1e9375f2c93486e35fdc86e63f02e274f0e99c589ef153/PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
+                "https://files.pythonhosted.org/packages/d9/36/5741e62ccf629c8e38cc20f930491f8a33ce7dba972cae93dba3d6f02552/websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "pip_39_six_1.16.0_py2_none_any": {
+          "pip_39_chardet_4_0_0_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1604,112 +1641,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "six-1.16.0-py2.py3-none-any.whl",
+              "filename": "chardet-4.0.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "six==1.16.0",
-              "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "requirement": "chardet==4.0.0",
+              "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
               "urls": [
-                "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_requests_2.25.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "requests-2.25.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "requests==2.25.1",
-              "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz"
-              ],
-              "whl_patches": {
-                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
-              }
-            }
-          },
-          "pip_39_sphinxcontrib_qthelp_1.0.6_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_qthelp-1.0.6-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-qthelp==1.0.6",
-              "sha256": "bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1f/e5/1850f3f118e95581c1e30b57028ac979badee1eb29e70ee72b0241f5a185/sphinxcontrib_qthelp-1.0.6-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_python_magic_0.4.27_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python_magic-0.4.27-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-magic==0.4.27",
-              "sha256": "c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz"
               ]
             }
           },
@@ -1743,7 +1681,7 @@
               "requirement": "sphinxcontrib-serializinghtml==1.1.9     --hash=sha256:0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54     --hash=sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
             }
           },
-          "pip_39_s3cmd_2.1.0.tar.gz": {
+          "pip_39_snowballstemmer_2_2_0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1761,13 +1699,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "s3cmd-2.1.0.tar.gz",
+              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "s3cmd==2.1.0",
-              "sha256": "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03",
+              "requirement": "snowballstemmer==2.2.0",
+              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
               "urls": [
-                "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
+                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -1792,168 +1730,7 @@
               "requirement": "idna==2.10     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             }
           },
-          "pip_310_astroid": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "astroid==2.13.5     --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501     --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"
-            }
-          },
-          "pip_39_certifi_2023.7.22_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "certifi-2023.7.22-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_pylint_print_1.0.1_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pylint_print-1.0.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pylint-print==1.0.1",
-              "sha256": "a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8f/a9/6f0687b575d502b4fa770cd52231e23462c548829e5f2e6f43a3d2b9c939/pylint_print-1.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_pathspec_0.10.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pathspec-0.10.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pathspec==0.10.3",
-              "sha256": "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/32/1a/6baf904503c3e943cae9605c9c88a43b964dea5b59785cf956091b341b08/pathspec-0.10.3.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_jsmath_1.0.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib-jsmath-1.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-jsmath==1.0.1",
-              "sha256": "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64": {
+          "pip_39_wrapt_1_14_1_cp39_cp39_manylinux_2_5_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1981,7 +1758,28 @@
               ]
             }
           },
-          "pip_39_pyyaml_6.0.1.tar.gz": {
+          "pip_310_astroid": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "astroid==2.13.5     --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501     --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"
+            }
+          },
+          "pip_39_idna_2_10_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -1999,17 +1797,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1.tar.gz",
+              "filename": "idna-2.10.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+              "requirement": "idna==2.10",
+              "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
               "urls": [
-                "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
+                "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz"
               ]
             }
           },
-          "pip_39_urllib3_1.26.18_py2_none_any": {
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_manylinux_2_17_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2027,101 +1825,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "urllib3-1.26.18-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b0/53/aa91e163dcfd1e5b82d8a890ecf13314e3e149c05270cc644581f77f17fd/urllib3-1.26.18-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "6f1a3f10f836fab6ca6efa97bb952300b20ae56b409414ca85bff2ad241d2a61",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/36/5741e62ccf629c8e38cc20f930491f8a33ce7dba972cae93dba3d6f02552/websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_yamllint_1.28.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "yamllint-1.28.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "yamllint==1.28.0",
-              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_1.10.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy-object-proxy-1.10.0.tar.gz",
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69",
+              "sha256": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
               "urls": [
-                "https://files.pythonhosted.org/packages/2c/f0/f02e2d150d581a294efded4020094a371bbab42423fe78625ac18854d89b/lazy-object-proxy-1.10.0.tar.gz"
+                "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "pip_39_sphinx_7.2.6_py3_none_any": {
+          "pip_39_idna_2_10_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2139,7 +1853,147 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinx-7.2.6-py3-none-any.whl",
+              "filename": "idna-2.10-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "idna==2.10",
+              "sha256": "b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_importlib_metadata_8_4_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
+              "sha256": "9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/20/f59423543a8422cb8c69a579ebd0ef2c9dafa70cc8142b7372b5b4073caa/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_dill_0_3_6_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "dill-0.3.6.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "dill==0.3.6",
+              "sha256": "e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz"
+              ]
+            }
+          },
+          "pip_39_docutils_0_20_1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "docutils-0.20.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "docutils==0.20.1",
+              "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_serializinghtml_1_1_9_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_serializinghtml-1.1.9.tar.gz",
               "group_deps": [
                 "sphinx",
                 "sphinxcontrib_qthelp",
@@ -2151,10 +2005,67 @@
               "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinx==7.2.6",
-              "sha256": "1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560",
+              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
+              "sha256": "0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54",
               "urls": [
-                "https://files.pythonhosted.org/packages/b2/b6/8ed35256aa530a9d3da15d20bdc0ba888d5364441bb50a5a83ee7827affe/sphinx-7.2.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/5c/41/df4cd017e8234ded544228f60f74fac1fe1c75bdb1e87b33a83c91a10530/sphinxcontrib_serializinghtml-1.1.9.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wheel_0_40_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wheel-0.40.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wheel==0.40.0",
+              "sha256": "cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
               ]
             }
           },
@@ -2185,7 +2096,7 @@
               }
             }
           },
-          "pip_39_sphinxcontrib_devhelp_1.0.5_py3_none_any": {
+          "pip_39_astroid_2_12_13_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2203,26 +2114,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_devhelp-1.0.5-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
+              "filename": "astroid-2.12.13-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-devhelp==1.0.5",
-              "sha256": "fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f",
+              "requirement": "astroid==2.12.13",
+              "sha256": "10e0ad5f7b79c435179d0d0f0df69998c4eef4597534aae44910db060baeb907",
               "urls": [
-                "https://files.pythonhosted.org/packages/c0/03/010ac733ec7b7f71c1dc88e7115743ee466560d6d85373b56fb9916e4586/sphinxcontrib_devhelp-1.0.5-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/b1/61/42e075b7d29ed4d452d91cbaaca142710d50d04e68eb7161ce5807a00a30/astroid-2.12.13-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_babel_2.13.1_py3_none_any": {
+          "pip_39_tabulate_0_9_0_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2240,13 +2142,41 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "Babel-2.13.1-py3-none-any.whl",
+              "filename": "tabulate-0.9.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "babel==2.13.1",
-              "sha256": "7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed",
+              "requirement": "tabulate==0.9.0",
+              "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
               "urls": [
-                "https://files.pythonhosted.org/packages/86/14/5dc2eb02b7cc87b2f95930310a2cc5229198414919a116b564832c747bc1/Babel-2.13.1-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_tomli_2_0_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tomli-2.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
+              "sha256": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
               ]
             }
           },
@@ -2301,7 +2231,7 @@
               "requirement": "sphinxcontrib-devhelp==1.0.5     --hash=sha256:63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212     --hash=sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             }
           },
-          "pip_39_tabulate_0.9.0.tar.gz": {
+          "pip_39_markupsafe_2_1_3_cp39_cp39_manylinux_2_17_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2319,17 +2249,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "tabulate-0.9.0.tar.gz",
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "tabulate==0.9.0",
-              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
               "urls": [
-                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
+                "https://files.pythonhosted.org/packages/68/8d/c33c43c499c19f4b51181e196c9a497010908fc22c5de33551e298aa6a21/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_aarch64": {
+          "pip_39_python_magic_0_4_27_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2347,17 +2277,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "python-magic-0.4.27.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+              "requirement": "python-magic==0.4.27",
+              "sha256": "c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b",
               "urls": [
-                "https://files.pythonhosted.org/packages/ac/6c/967d91a8edf98d2b2b01d149bd9e51b8f9fb527c98d80ebb60c6b21d60c4/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz"
               ]
             }
           },
-          "pip_39_sphinxcontrib_jsmath_1.0.1_py2_none_any": {
+          "pip_39_typing_extensions_4_12_2_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2375,76 +2305,14 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
+              "filename": "typing_extensions-4.12.2-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-jsmath==1.0.1",
-              "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
+              "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
               "urls": [
-                "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
               ]
-            }
-          },
-          "pip_39_zipp_3.20.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "zipp-3.20.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
-              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_requests_2.25.1_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "requests-2.25.1-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "requests==2.25.1",
-              "sha256": "c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl"
-              ],
-              "whl_patches": {
-                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
-                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
-              }
             }
           },
           "pip_310_alabaster": {
@@ -2489,7 +2357,7 @@
               "requirement": "python-magic==0.4.27     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"
             }
           },
-          "pip_39_tomlkit_0.11.6_py3_none_any": {
+          "pip_39_sphinx_7_2_6_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2507,17 +2375,26 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "tomlkit-0.11.6-py3-none-any.whl",
+              "filename": "sphinx-7.2.6.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "tomlkit==0.11.6",
-              "sha256": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+              "requirement": "sphinx==7.2.6",
+              "sha256": "9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5",
               "urls": [
-                "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/73/8e/6e51da4b26665b4b92b1944ea18b2d9c825e753e19180cc5bdc818d0ed3b/sphinx-7.2.6.tar.gz"
               ]
             }
           },
-          "pip_39_typing_extensions_4.12.2.tar.gz": {
+          "pip_39_pylint_print_1_0_1_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2535,17 +2412,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "typing_extensions-4.12.2.tar.gz",
+              "filename": "pylint_print-1.0.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
-              "sha256": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "requirement": "pylint-print==1.0.1",
+              "sha256": "a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b",
               "urls": [
-                "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
+                "https://files.pythonhosted.org/packages/8f/a9/6f0687b575d502b4fa770cd52231e23462c548829e5f2e6f43a3d2b9c939/pylint_print-1.0.1-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_pylint_2.15.9_py3_none_any": {
+          "pip_39_websockets_11_0_3_cp39_cp39_macosx_11_0_arm64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2563,41 +2440,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "pylint-2.15.9-py3-none-any.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pylint==2.15.9",
-              "sha256": "349c8cd36aede4d50a0754a8c0218b43323d13d5d88f4b2952ddfe3e169681eb",
+              "requirement": "websockets==11.0.3",
+              "sha256": "3580dd9c1ad0701169e4d6fc41e878ffe05e6bdcaf3c412f9d559389d0c9e016",
               "urls": [
-                "https://files.pythonhosted.org/packages/7d/df/0e50d5640ed4c6a492cdc6df0c281afee3f85d98209e7ec7b31243838b40/pylint-2.15.9-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_python_dateutil_2.8.2.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python-dateutil-2.8.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-dateutil==2.8.2",
-              "sha256": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
+                "https://files.pythonhosted.org/packages/a0/1a/3da73e69ebc00649d11ed836541c92c1a2df0b8a8aa641a2c8746e7c2b9c/websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl"
               ]
             }
           },
@@ -2622,6 +2471,34 @@
               "requirement": "tabulate==0.9.0     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
             }
           },
+          "pip_39_packaging_23_2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "packaging-23.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "packaging==23.2",
+              "sha256": "8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl"
+              ]
+            }
+          },
           "pip_310_lazy_object_proxy": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2643,7 +2520,7 @@
               "requirement": "lazy-object-proxy==1.9.0     --hash=sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382     --hash=sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82     --hash=sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9     --hash=sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494     --hash=sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46     --hash=sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30     --hash=sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63     --hash=sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4     --hash=sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae     --hash=sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be     --hash=sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701     --hash=sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd     --hash=sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006     --hash=sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a     --hash=sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586     --hash=sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8     --hash=sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821     --hash=sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07     --hash=sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b     --hash=sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171     --hash=sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b     --hash=sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2     --hash=sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7     --hash=sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4     --hash=sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8     --hash=sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e     --hash=sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f     --hash=sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda     --hash=sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4     --hash=sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e     --hash=sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671     --hash=sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11     --hash=sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455     --hash=sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734     --hash=sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb     --hash=sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
             }
           },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_win_amd64": {
+          "pip_39_jinja2_3_1_4_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2661,17 +2538,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl",
+              "filename": "jinja2-3.1.4-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd",
+              "requirement": "jinja2==3.1.4",
+              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
               "urls": [
-                "https://files.pythonhosted.org/packages/fe/30/40879041ed6a3364bfa862c4237aa7fe94dcd4affa2175718acbbf4d29b9/lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl"
+                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_musllinux_1_1_x86_64": {
+          "pip_39_yamllint_1_28_0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2689,41 +2566,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "filename": "yamllint-1.28.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+              "requirement": "yamllint==1.28.0",
+              "sha256": "89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
               "urls": [
-                "https://files.pythonhosted.org/packages/40/da/a175a35cf5583580e90ac3e2a3dbca90e43011593ae62ce63f79d7b28d92/PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+                "https://files.pythonhosted.org/packages/40/f9/882281af7c40a99bfa5b14585071c5aa13f48961582ebe067ae38221d0d9/yamllint-1.28.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -2757,34 +2606,6 @@
               "requirement": "sphinxcontrib-htmlhelp==2.0.4     --hash=sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a     --hash=sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
             }
           },
-          "pip_39_zipp_3.20.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "zipp-3.20.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
-              "sha256": "58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/da/cc/b9958af9f9c86b51f846d8487440af495ecf19b16e426fce1ed0b0796175/zipp-3.20.0-py3-none-any.whl"
-              ]
-            }
-          },
           "pip_310_pylint": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -2804,62 +2625,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "pylint==2.15.10     --hash=sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e     --hash=sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
-            }
-          },
-          "pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "97b52894d948d2f6ea480171a27122d77af14ced35f62e5c892ca2fae9344311",
-              "urls": [
-                "https://files.pythonhosted.org/packages/72/89/0d150939f2e592ed78c071d69237ac1c872462cc62a750c5f592f3d4ab18/websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_idna_2.10.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "idna-2.10.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "idna==2.10",
-              "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz"
-              ]
             }
           },
           "pip_310_babel": {
@@ -2883,7 +2648,7 @@
               "requirement": "babel==2.13.1     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"
             }
           },
-          "pip_39_websockets_11.0.3_cp39_cp39_macosx_11_0_arm64": {
+          "pip_39_colorama_0_4_6_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2901,27 +2666,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl",
+              "filename": "colorama-0.4.6.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "3580dd9c1ad0701169e4d6fc41e878ffe05e6bdcaf3c412f9d559389d0c9e016",
+              "requirement": "colorama==0.4.6",
+              "sha256": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
               "urls": [
-                "https://files.pythonhosted.org/packages/a0/1a/3da73e69ebc00649d11ed836541c92c1a2df0b8a8aa641a2c8746e7c2b9c/websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl"
+                "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
               ]
             }
           },
-          "other_module_pip_311_absl_py": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@other_module_pip//{name}:{target}",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "other_module_pip_311",
-              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
-            }
-          },
-          "pip_39_chardet_4.0.0_py2_none_any": {
+          "pip_39_docutils_0_20_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -2939,218 +2694,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "chardet-4.0.0-py2.py3-none-any.whl",
+              "filename": "docutils-0.20.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "chardet==4.0.0",
-              "sha256": "f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
+              "requirement": "docutils==0.20.1",
+              "sha256": "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b",
               "urls": [
-                "https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz"
               ]
             }
           },
-          "pip_310_yamllint": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
-            }
-          },
-          "pip_39_mccabe_0.7.0_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "mccabe-0.7.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "mccabe==0.7.0",
-              "sha256": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_python_dateutil_2.8.2_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-dateutil==2.8.2",
-              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_win_amd64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a2/b2/624042cb58cc6b3529a6c3a7b7d230766e3ecb768cba118ba7befd18ed6f/MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
-          "pip_39_packaging_23.2_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "packaging-23.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "packaging==23.2",
-              "sha256": "8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "other_module_pip": {
-            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
-            "ruleClassName": "hub_repository",
-            "attributes": {
-              "repo_name": "other_module_pip",
-              "whl_map": {
-                "absl_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"other_module_pip_311_absl_py\",\"target_platforms\":null,\"version\":\"3.11\"}]"
-              },
-              "packages": [],
-              "groups": {}
-            }
-          },
-          "pip_39_astroid_2.12.13_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "astroid-2.12.13-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "astroid==2.12.13",
-              "sha256": "10e0ad5f7b79c435179d0d0f0df69998c4eef4597534aae44910db060baeb907",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b1/61/42e075b7d29ed4d452d91cbaaca142710d50d04e68eb7161ce5807a00a30/astroid-2.12.13-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
-              "urls": [
-                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_pygments_2.16.1_py3_none_any": {
+          "pip_39_pygments_2_16_1_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3178,28 +2732,7 @@
               ]
             }
           },
-          "pip_310_pylint_print": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "pylint-print==1.0.1     --hash=sha256:30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0     --hash=sha256:a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b"
-            }
-          },
-          "pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_aarch64": {
+          "pip_39_pylint_print_1_0_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3217,73 +2750,27 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "filename": "pylint-print-1.0.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+              "requirement": "pylint-print==1.0.1",
+              "sha256": "30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0",
               "urls": [
-                "https://files.pythonhosted.org/packages/e0/20/9716fb522d17a726364c4d032c8806ffe312268773dd46a394436b2787cc/wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+                "https://files.pythonhosted.org/packages/60/76/8fd24bfcbd5130b487990c6ec5eab2a053f1ec8f7d33ef6c38fee7e22b70/pylint-print-1.0.1.tar.gz"
               ]
             }
           },
-          "pip_39_imagesize_1.4.1_py2_none_any": {
+          "other_module_pip_311_absl_py": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "imagesize-1.4.1-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "imagesize==1.4.1",
-              "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl"
-              ]
+              "dep_template": "@other_module_pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "other_module_pip_311",
+              "requirement": "absl-py==1.4.0     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
             }
           },
-          "pip_39_platformdirs_2.6.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "platformdirs-2.6.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "platformdirs==2.6.0",
-              "sha256": "b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ec/4c/9af851448e55c57b30a13a72580306e628c3b431d97fdae9e0b8d4fa3685/platformdirs-2.6.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_babel_2.13.1.tar.gz": {
+          "pip_39_babel_2_13_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3311,35 +2798,28 @@
               ]
             }
           },
-          "pip_39_certifi_2023.7.22.tar.gz": {
+          "pip_310_yamllint": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
               "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
               ],
-              "filename": "certifi-2023.7.22.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
-              "urls": [
-                "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
-              ]
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "yamllint==1.32.0     --hash=sha256:d01dde008c65de5b235188ab3110bebc59d18e5c65fc8a58267cd211cd9df34a     --hash=sha256:d97a66e48da820829d96077d76b8dfbe6c6140f106e558dae87e81ac4e6b30b7"
             }
           },
-          "pip_39_pygments_2.16.1.tar.gz": {
+          "pip_39_markupsafe_2_1_3_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3357,250 +2837,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "Pygments-2.16.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pygments==2.16.1",
-              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_devhelp_1.0.5.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_devhelp-1.0.5.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-devhelp==1.0.5",
-              "sha256": "63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2e/f2/6425b6db37e7c2254ad661c90a871061a078beaddaf9f15a00ba9c3a1529/sphinxcontrib_devhelp-1.0.5.tar.gz"
-              ]
-            }
-          },
-          "pip_39_wrapt_1.14.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_s390x": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4a/4b/c71ef18ef83c82f99e6da8332910692af78ea32bd1d1d76c9787dfa36aea/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "pip_39_importlib_metadata_8.4.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.4.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
-              "sha256": "9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_typing_extensions_4.12.2_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "typing_extensions-4.12.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
-              "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_pylint_2.15.9.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pylint-2.15.9.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pylint==2.15.9",
-              "sha256": "18783cca3cfee5b83c6c5d10b3cdb66c6594520ffae61890858fe8d932e1c6b4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/68/3a/1e61444eb8276ad962a7f300b6920b7ad391f4fbe551d34443f093a18899/pylint-2.15.9.tar.gz"
-              ]
-            }
-          },
-          "pip_39_snowballstemmer_2.2.0_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "snowballstemmer-2.2.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "snowballstemmer==2.2.0",
-              "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "filename": "MarkupSafe-2.1.3.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "markupsafe==2.1.3",
-              "sha256": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+              "sha256": "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
               "urls": [
-                "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
               ]
             }
           },
-          "pip_39_tomli_2.0.1_py3_none_any": {
+          "pip_39_tomli_2_0_1_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3628,28 +2875,7 @@
               ]
             }
           },
-          "pip_310_s3cmd": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
-            }
-          },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_aarch64": {
+          "pip_39_pygments_2_16_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3667,54 +2893,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "filename": "Pygments-2.16.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+              "requirement": "pygments==2.16.1",
+              "sha256": "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29",
               "urls": [
-                "https://files.pythonhosted.org/packages/68/8d/c33c43c499c19f4b51181e196c9a497010908fc22c5de33551e298aa6a21/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
               ]
             }
           },
-          "pip_39_sphinxcontrib_serializinghtml_1.1.9.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_serializinghtml-1.1.9.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
-              "sha256": "0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5c/41/df4cd017e8234ded544228f60f74fac1fe1c75bdb1e87b33a83c91a10530/sphinxcontrib_serializinghtml-1.1.9.tar.gz"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_htmlhelp_2.0.4_py3_none_any": {
+          "pip_39_sphinxcontrib_htmlhelp_2_0_4_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3751,7 +2940,19 @@
               ]
             }
           },
-          "pip_39_idna_2.10_py2_none_any": {
+          "other_module_pip": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "other_module_pip",
+              "whl_map": {
+                "absl_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"other_module_pip_311_absl_py\",\"target_platforms\":null,\"version\":\"3.11\"}]"
+              },
+              "packages": [],
+              "groups": {}
+            }
+          },
+          "pip_39_mccabe_0_7_0_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3769,17 +2970,740 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "idna-2.10-py2.py3-none-any.whl",
+              "filename": "mccabe-0.7.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "idna==2.10",
-              "sha256": "b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0",
+              "requirement": "mccabe==0.7.0",
+              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
               "urls": [
-                "https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
               ]
             }
           },
-          "pip_39_websockets_11.0.3_cp39_cp39_win_amd64": {
+          "pip_39_six_1_16_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "six-1.16.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "six==1.16.0",
+              "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+              "urls": [
+                "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wrapt_1_14_1_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e0/20/9716fb522d17a726364c4d032c8806ffe312268773dd46a394436b2787cc/wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_310_pylint_print": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "pylint-print==1.0.1     --hash=sha256:30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0     --hash=sha256:a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b"
+            }
+          },
+          "pip_39_certifi_2023_7_22_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "certifi-2023.7.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "certifi==2023.7.22",
+              "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/9b/4908a57acf39d8811836bc6776b309c2e07d63791485589acf0b6d7bc0c6/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_snowballstemmer_2_2_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "snowballstemmer-2.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "snowballstemmer==2.2.0",
+              "sha256": "09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "6681ba9e7f8f3b19440921e99efbb40fc89f26cd71bf539e45d8c8a25c976dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/47/96/9d5749106ff57629b54360664ae7eb9afd8302fad1680ead385383e33746/websockets-11.0.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_macosx_10_9_universal2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+              "urls": [
+                "https://files.pythonhosted.org/packages/6a/86/654dc431513cd4417dfcead8102f22bece2d6abf2f584f0e1cc1524f7b94/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7d/39/472f2554a0f1e825bd7c5afc11c817cd7a2f3657460f7159f691fbb37c51/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_importlib_metadata_8_4_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
+              "sha256": "66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_tomlkit_0_11_6_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "tomlkit-0.11.6-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "tomlkit==0.11.6",
+              "sha256": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_setuptools_65_6_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "setuptools-65.6.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "setuptools==65.6.3",
+              "sha256": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6_0_1_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6_0_1_cp39_cp39_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0e/88/21b2f16cb2123c1e9375f2c93486e35fdc86e63f02e274f0e99c589ef153/PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_qthelp_1_0_6_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_qthelp-1.0.6-py3-none-any.whl",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-qthelp==1.0.6",
+              "sha256": "bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1f/e5/1850f3f118e95581c1e30b57028ac979badee1eb29e70ee72b0241f5a185/sphinxcontrib_qthelp-1.0.6-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_s3cmd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "s3cmd==2.1.0     --hash=sha256:49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa     --hash=sha256:966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
+            }
+          },
+          "pip_39_isort_5_11_4_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "isort-5.11.4-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "isort==5.11.4",
+              "sha256": "c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_isort_5_11_4_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "isort-5.11.4.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "isort==5.11.4",
+              "sha256": "6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/46/004e2dd6c312e8bb7cb40a6c01b770956e0ef137857e82d47bd9c829356b/isort-5.11.4.tar.gz"
+              ]
+            }
+          },
+          "pip_39_pathspec_0_10_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pathspec-0.10.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pathspec==0.10.3",
+              "sha256": "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/32/1a/6baf904503c3e943cae9605c9c88a43b964dea5b59785cf956091b341b08/pathspec-0.10.3.tar.gz"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_cp39_cp39_manylinux_2_5_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "279e5de4671e79a9ac877427f4ac4ce93751b8823f276b681d04b2156713b9dd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a6/9c/2356ecb952fd3992b73f7a897d65e57d784a69b94bb8d8fd5f97531e5c02/websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_urllib3_1_26_18_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "urllib3-1.26.18-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "urllib3==1.26.18",
+              "sha256": "34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/53/aa91e163dcfd1e5b82d8a890ecf13314e3e149c05270cc644581f77f17fd/urllib3-1.26.18-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_chardet_4_0_0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "chardet-4.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "chardet==4.0.0",
+              "sha256": "f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_python_dateutil_2_8_2_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python_dateutil-2.8.2-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-dateutil==2.8.2",
+              "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_imagesize_1_4_1_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "imagesize-1.4.1-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "imagesize==1.4.1",
+              "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_cp39_cp39_win_amd64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3849,6 +3773,34 @@
               "requirement": "colorama==0.4.6     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             }
           },
+          "pip_39_imagesize_1_4_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "imagesize-1.4.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "imagesize==1.4.1",
+              "sha256": "69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz"
+              ]
+            }
+          },
           "pip_310_pathspec": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -3870,7 +3822,240 @@
               "requirement": "pathspec==0.11.1     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
             }
           },
-          "pip_39_tomlkit_0.11.6.tar.gz": {
+          "pip_39_pylint_2_15_9_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pylint-2.15.9.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pylint==2.15.9",
+              "sha256": "18783cca3cfee5b83c6c5d10b3cdb66c6594520ffae61890858fe8d932e1c6b4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/68/3a/1e61444eb8276ad962a7f300b6920b7ad391f4fbe551d34443f093a18899/pylint-2.15.9.tar.gz"
+              ]
+            }
+          },
+          "pip_39_s3cmd_2_1_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "s3cmd-2.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "s3cmd==2.1.0",
+              "sha256": "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_alabaster_0_7_13_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "alabaster-0.7.13-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "alabaster==0.7.13",
+              "sha256": "1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_applehelp_1_0_7_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_applehelp-1.0.7.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-applehelp==1.0.7",
+              "sha256": "39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1c/5a/fce19be5d4db26edc853a0c34832b39db7b769b7689da027529767b0aa98/sphinxcontrib_applehelp-1.0.7.tar.gz"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_jsmath_1_0_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib-jsmath-1.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-jsmath==1.0.1",
+              "sha256": "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz"
+              ]
+            }
+          },
+          "pip_39_yamllint_1_28_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "yamllint-1.28.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "yamllint==1.28.0",
+              "sha256": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+              "urls": [
+                "https://files.pythonhosted.org/packages/03/65/3473d2cb84bb2cda08be95b97fc4f53e6bcd701a2d50ba7b7c905e1e9273/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_pylint_2_15_9_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "pylint-2.15.9-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pylint==2.15.9",
+              "sha256": "349c8cd36aede4d50a0754a8c0218b43323d13d5d88f4b2952ddfe3e169681eb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7d/df/0e50d5640ed4c6a492cdc6df0c281afee3f85d98209e7ec7b31243838b40/pylint-2.15.9-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_tomlkit_0_11_6_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3898,7 +4083,7 @@
               ]
             }
           },
-          "pip_39_tabulate_0.9.0_py3_none_any": {
+          "pip_39_wrapt_1_14_1_cp39_cp39_win_amd64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3916,17 +4101,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "tabulate-0.9.0-py3-none-any.whl",
+              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "tabulate==0.9.0",
-              "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
               "urls": [
-                "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
               ]
             }
           },
-          "pip_39_alabaster_0.7.13.tar.gz": {
+          "pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_s390x": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3944,17 +4129,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "alabaster-0.7.13.tar.gz",
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "alabaster==0.7.13",
-              "sha256": "a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
               "urls": [
-                "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz"
+                "https://files.pythonhosted.org/packages/4a/4b/c71ef18ef83c82f99e6da8332910692af78ea32bd1d1d76c9787dfa36aea/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
               ]
             }
           },
-          "pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_5_x86_64": {
+          "pip_39_websockets_11_0_3_cp39_cp39_macosx_10_9_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -3972,46 +4157,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "websockets==11.0.3",
-              "sha256": "279e5de4671e79a9ac877427f4ac4ce93751b8823f276b681d04b2156713b9dd",
+              "sha256": "8c82f11964f010053e13daafdc7154ce7385ecc538989a354ccc7067fd7028fd",
               "urls": [
-                "https://files.pythonhosted.org/packages/a6/9c/2356ecb952fd3992b73f7a897d65e57d784a69b94bb8d8fd5f97531e5c02/websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                "https://files.pythonhosted.org/packages/8f/f2/8a3eb016be19743c7eb9e67c855df0fdfa5912534ffaf83a05b62667d761/websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl"
               ]
             }
           },
-          "pip_39_wheel_0.40.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wheel-0.40.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wheel==0.40.0",
-              "sha256": "cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_5_x86_64": {
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_manylinux_2_5_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4039,62 +4195,6 @@
               ]
             }
           },
-          "pip_39_importlib_metadata_8.4.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.4.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "importlib-metadata==8.4.0 ;python_version < '3.10'",
-              "sha256": "66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_python_magic_0.4.27.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "python-magic-0.4.27.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "python-magic==0.4.27",
-              "sha256": "c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz"
-              ]
-            }
-          },
           "pip_310_typing_extensions": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4116,90 +4216,6 @@
               "requirement": "typing-extensions==4.6.3     --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26     --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
             }
           },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "lazy-object-proxy==1.10.0",
-              "sha256": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_setuptools_65.6.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "setuptools-65.6.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "setuptools==65.6.3",
-              "sha256": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
-              ]
-            }
-          },
-          "pip_39_yamllint_1.28.0_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "yamllint-1.28.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "yamllint==1.28.0",
-              "sha256": "89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
-              "urls": [
-                "https://files.pythonhosted.org/packages/40/f9/882281af7c40a99bfa5b14585071c5aa13f48961582ebe067ae38221d0d9/yamllint-1.28.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
           "pip_310_isort": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4219,62 +4235,6 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "isort==5.12.0     --hash=sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504     --hash=sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
-            }
-          },
-          "pip_39_dill_0.3.6.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "dill-0.3.6.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "dill==0.3.6",
-              "sha256": "e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz"
-              ]
-            }
-          },
-          "pip_39_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bb/70/73c54e24ea69a8b06ae9649e61d5e64f2b4bdfc6f202fc7794abeac1ed20/wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl"
-              ]
             }
           },
           "pip_310_sphinxcontrib_qthelp": {
@@ -4307,7 +4267,7 @@
               "requirement": "sphinxcontrib-qthelp==1.0.6     --hash=sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d     --hash=sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             }
           },
-          "pip_39_sphinxcontrib_qthelp_1.0.6.tar.gz": {
+          "pip_39_wrapt_1_14_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4325,22 +4285,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_qthelp-1.0.6.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
+              "filename": "wrapt-1.14.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-qthelp==1.0.6",
-              "sha256": "62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
               "urls": [
-                "https://files.pythonhosted.org/packages/4f/a2/53129fc967ac8402d5e4e83e23c959c3f7a07362ec154bdb2e197d8cc270/sphinxcontrib_qthelp-1.0.6.tar.gz"
+                "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
               ]
             }
           },
@@ -4365,7 +4316,7 @@
               "requirement": "wrapt==1.15.0     --hash=sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0     --hash=sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420     --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a     --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c     --hash=sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079     --hash=sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923     --hash=sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f     --hash=sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1     --hash=sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8     --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86     --hash=sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0     --hash=sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364     --hash=sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e     --hash=sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c     --hash=sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e     --hash=sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c     --hash=sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727     --hash=sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff     --hash=sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e     --hash=sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29     --hash=sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7     --hash=sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72     --hash=sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475     --hash=sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a     --hash=sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317     --hash=sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2     --hash=sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd     --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640     --hash=sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98     --hash=sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248     --hash=sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e     --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d     --hash=sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec     --hash=sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1     --hash=sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e     --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9     --hash=sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92     --hash=sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb     --hash=sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094     --hash=sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46     --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29     --hash=sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd     --hash=sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705     --hash=sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8     --hash=sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975     --hash=sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb     --hash=sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e     --hash=sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b     --hash=sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418     --hash=sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019     --hash=sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1     --hash=sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba     --hash=sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6     --hash=sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2     --hash=sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3     --hash=sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7     --hash=sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752     --hash=sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416     --hash=sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f     --hash=sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1     --hash=sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc     --hash=sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145     --hash=sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee     --hash=sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a     --hash=sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7     --hash=sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b     --hash=sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653     --hash=sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0     --hash=sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90     --hash=sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29     --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6     --hash=sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034     --hash=sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09     --hash=sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559     --hash=sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
             }
           },
-          "pip_39_s3cmd_2.1.0_py2_none_any": {
+          "pip_39_six_1_16_0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4383,17 +4334,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
+              "filename": "six-1.16.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "s3cmd==2.1.0",
-              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
+              "requirement": "six==1.16.0",
+              "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
               "urls": [
-                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_setuptools_65.6.3_py3_none_any": {
+          "pip_39_platformdirs_2_6_0_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4411,13 +4362,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "setuptools-65.6.3-py3-none-any.whl",
+              "filename": "platformdirs-2.6.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "setuptools==65.6.3",
-              "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+              "requirement": "platformdirs==2.6.0",
+              "sha256": "1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
               "urls": [
-                "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/87/69/cd019a9473bcdfb38983e2d550ccb239264fc4c2fc32c42ac1b1cc2506b6/platformdirs-2.6.0-py3-none-any.whl"
               ]
             }
           },
@@ -4427,53 +4378,53 @@
             "attributes": {
               "repo_name": "pip",
               "whl_map": {
-                "alabaster": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_alabaster\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13-py3-none-any.whl\",\"repo\":\"pip_39_alabaster_0.7.13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13.tar.gz\",\"repo\":\"pip_39_alabaster_0.7.13.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "astroid": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_astroid\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13-py3-none-any.whl\",\"repo\":\"pip_39_astroid_2.12.13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13.tar.gz\",\"repo\":\"pip_39_astroid_2.12.13.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "babel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_babel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1-py3-none-any.whl\",\"repo\":\"pip_39_babel_2.13.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1.tar.gz\",\"repo\":\"pip_39_babel_2.13.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "certifi": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_certifi\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22-py3-none-any.whl\",\"repo\":\"pip_39_certifi_2023.7.22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22.tar.gz\",\"repo\":\"pip_39_certifi_2023.7.22.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "chardet": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_chardet\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_chardet_4.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0.tar.gz\",\"repo\":\"pip_39_chardet_4.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "colorama": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_colorama\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6-py2.py3-none-any.whl\",\"repo\":\"pip_39_colorama_0.4.6_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6.tar.gz\",\"repo\":\"pip_39_colorama_0.4.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "dill": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_dill\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6-py3-none-any.whl\",\"repo\":\"pip_39_dill_0.3.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6.tar.gz\",\"repo\":\"pip_39_dill_0.3.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "docutils": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_docutils\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1-py3-none-any.whl\",\"repo\":\"pip_39_docutils_0.20.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1.tar.gz\",\"repo\":\"pip_39_docutils_0.20.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "idna": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_idna\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10-py2.py3-none-any.whl\",\"repo\":\"pip_39_idna_2.10_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10.tar.gz\",\"repo\":\"pip_39_idna_2.10.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "imagesize": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_imagesize\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_imagesize_1.4.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1.tar.gz\",\"repo\":\"pip_39_imagesize_1.4.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0-py3-none-any.whl\",\"repo\":\"pip_39_importlib_metadata_8.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0.tar.gz\",\"repo\":\"pip_39_importlib_metadata_8.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "isort": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_isort\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4-py3-none-any.whl\",\"repo\":\"pip_39_isort_5.11.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4.tar.gz\",\"repo\":\"pip_39_isort_5.11.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "jinja2": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_jinja2\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4-py3-none-any.whl\",\"repo\":\"pip_39_jinja2_3.1.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4.tar.gz\",\"repo\":\"pip_39_jinja2_3.1.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "lazy_object_proxy": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_lazy_object_proxy\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy-object-proxy-1.10.0.tar.gz\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1.10.0_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "markupsafe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_markupsafe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_markupsafe_2.1.3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3.tar.gz\",\"repo\":\"pip_39_markupsafe_2.1.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "mccabe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_mccabe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_mccabe_0.7.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0.tar.gz\",\"repo\":\"pip_39_mccabe_0.7.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "packaging": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_packaging\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2-py3-none-any.whl\",\"repo\":\"pip_39_packaging_23.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2.tar.gz\",\"repo\":\"pip_39_packaging_23.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pathspec": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pathspec\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3-py3-none-any.whl\",\"repo\":\"pip_39_pathspec_0.10.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3.tar.gz\",\"repo\":\"pip_39_pathspec_0.10.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "platformdirs": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_platformdirs\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0-py3-none-any.whl\",\"repo\":\"pip_39_platformdirs_2.6.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0.tar.gz\",\"repo\":\"pip_39_platformdirs_2.6.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pygments": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pygments\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1-py3-none-any.whl\",\"repo\":\"pip_39_pygments_2.16.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1.tar.gz\",\"repo\":\"pip_39_pygments_2.16.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pylint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9-py3-none-any.whl\",\"repo\":\"pip_39_pylint_2.15.9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9.tar.gz\",\"repo\":\"pip_39_pylint_2.15.9.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pylint_print": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint_print\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-print-1.0.1.tar.gz\",\"repo\":\"pip_39_pylint_print_1.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint_print-1.0.1-py3-none-any.whl\",\"repo\":\"pip_39_pylint_print_1.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "python_dateutil": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_dateutil\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-dateutil-2.8.2.tar.gz\",\"repo\":\"pip_39_python_dateutil_2.8.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_dateutil-2.8.2-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_dateutil_2.8.2_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "python_magic": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_magic\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-magic-0.4.27.tar.gz\",\"repo\":\"pip_39_python_magic_0.4.27.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_magic-0.4.27-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_magic_0.4.27_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "pyyaml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pyyaml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_pyyaml_6.0.1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1.tar.gz\",\"repo\":\"pip_39_pyyaml_6.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "requests": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_requests\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_requests_2.25.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1.tar.gz\",\"repo\":\"pip_39_requests_2.25.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "s3cmd": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_s3cmd\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_s3cmd_2.1.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0.tar.gz\",\"repo\":\"pip_39_s3cmd_2.1.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "setuptools": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3-py3-none-any.whl\",\"repo\":\"pip_39_setuptools_65.6.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3.tar.gz\",\"repo\":\"pip_39_setuptools_65.6.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "six": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_six\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_six_1.16.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0.tar.gz\",\"repo\":\"pip_39_six_1.16.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "snowballstemmer": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_snowballstemmer\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_snowballstemmer_2.2.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0.tar.gz\",\"repo\":\"pip_39_snowballstemmer_2.2.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinx": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinx\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinx_7.2.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6.tar.gz\",\"repo\":\"pip_39_sphinx_7.2.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_applehelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_applehelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1.0.7_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1.0.7.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_devhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_devhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1.0.5_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1.0.5.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_htmlhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_htmlhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2.0.4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2.0.4.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_jsmath": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_jsmath\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib-jsmath-1.0.1.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1.0.1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_qthelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_qthelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1.0.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1.0.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "sphinxcontrib_serializinghtml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_serializinghtml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1.1.9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1.1.9.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tabulate": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tabulate\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0-py3-none-any.whl\",\"repo\":\"pip_39_tabulate_0.9.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0.tar.gz\",\"repo\":\"pip_39_tabulate_0.9.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tomli": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomli\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1-py3-none-any.whl\",\"repo\":\"pip_39_tomli_2.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1.tar.gz\",\"repo\":\"pip_39_tomli_2.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "tomlkit": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomlkit\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6-py3-none-any.whl\",\"repo\":\"pip_39_tomlkit_0.11.6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6.tar.gz\",\"repo\":\"pip_39_tomlkit_0.11.6.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "typing_extensions": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_typing_extensions\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2-py3-none-any.whl\",\"repo\":\"pip_39_typing_extensions_4.12.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2.tar.gz\",\"repo\":\"pip_39_typing_extensions_4.12.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_urllib3\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18-py2.py3-none-any.whl\",\"repo\":\"pip_39_urllib3_1.26.18_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18.tar.gz\",\"repo\":\"pip_39_urllib3_1.26.18.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "websockets": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_websockets\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_websockets_11.0.3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-py3-none-any.whl\",\"repo\":\"pip_39_websockets_11.0.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3.tar.gz\",\"repo\":\"pip_39_websockets_11.0.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "wheel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wheel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0-py3-none-any.whl\",\"repo\":\"pip_39_wheel_0.40.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0.tar.gz\",\"repo\":\"pip_39_wheel_0.40.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "wrapt": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wrapt\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_wrapt_1.14.1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1.tar.gz\",\"repo\":\"pip_39_wrapt_1.14.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "yamllint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_yamllint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_yamllint_1.28.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0.tar.gz\",\"repo\":\"pip_39_yamllint_1.28.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
-                "zipp": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0-py3-none-any.whl\",\"repo\":\"pip_39_zipp_3.20.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0.tar.gz\",\"repo\":\"pip_39_zipp_3.20.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.9\"}]"
+                "alabaster": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_alabaster\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13-py3-none-any.whl\",\"repo\":\"pip_39_alabaster_0_7_13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"alabaster-0.7.13.tar.gz\",\"repo\":\"pip_39_alabaster_0_7_13_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "astroid": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_astroid\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13-py3-none-any.whl\",\"repo\":\"pip_39_astroid_2_12_13_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"astroid-2.12.13.tar.gz\",\"repo\":\"pip_39_astroid_2_12_13_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "babel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_babel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1-py3-none-any.whl\",\"repo\":\"pip_39_babel_2_13_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Babel-2.13.1.tar.gz\",\"repo\":\"pip_39_babel_2_13_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "certifi": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_certifi\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22-py3-none-any.whl\",\"repo\":\"pip_39_certifi_2023_7_22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"certifi-2023.7.22.tar.gz\",\"repo\":\"pip_39_certifi_2023_7_22_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "chardet": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_chardet\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_chardet_4_0_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"chardet-4.0.0.tar.gz\",\"repo\":\"pip_39_chardet_4_0_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "colorama": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_colorama\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6-py2.py3-none-any.whl\",\"repo\":\"pip_39_colorama_0_4_6_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"colorama-0.4.6.tar.gz\",\"repo\":\"pip_39_colorama_0_4_6_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "dill": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_dill\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6-py3-none-any.whl\",\"repo\":\"pip_39_dill_0_3_6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"dill-0.3.6.tar.gz\",\"repo\":\"pip_39_dill_0_3_6_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "docutils": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_docutils\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1-py3-none-any.whl\",\"repo\":\"pip_39_docutils_0_20_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"docutils-0.20.1.tar.gz\",\"repo\":\"pip_39_docutils_0_20_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "idna": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_idna\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10-py2.py3-none-any.whl\",\"repo\":\"pip_39_idna_2_10_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"idna-2.10.tar.gz\",\"repo\":\"pip_39_idna_2_10_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "imagesize": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_imagesize\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_imagesize_1_4_1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"imagesize-1.4.1.tar.gz\",\"repo\":\"pip_39_imagesize_1_4_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0-py3-none-any.whl\",\"repo\":\"pip_39_importlib_metadata_8_4_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"importlib_metadata-8.4.0.tar.gz\",\"repo\":\"pip_39_importlib_metadata_8_4_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "isort": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_isort\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4-py3-none-any.whl\",\"repo\":\"pip_39_isort_5_11_4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"isort-5.11.4.tar.gz\",\"repo\":\"pip_39_isort_5_11_4_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "jinja2": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_jinja2\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4-py3-none-any.whl\",\"repo\":\"pip_39_jinja2_3_1_4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"jinja2-3.1.4.tar.gz\",\"repo\":\"pip_39_jinja2_3_1_4_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "lazy_object_proxy": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_lazy_object_proxy\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy-object-proxy-1.10.0.tar.gz\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_lazy_object_proxy_1_10_0_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "markupsafe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_markupsafe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_markupsafe_2_1_3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"MarkupSafe-2.1.3.tar.gz\",\"repo\":\"pip_39_markupsafe_2_1_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "mccabe": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_mccabe\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_mccabe_0_7_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"mccabe-0.7.0.tar.gz\",\"repo\":\"pip_39_mccabe_0_7_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "packaging": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_packaging\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2-py3-none-any.whl\",\"repo\":\"pip_39_packaging_23_2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"packaging-23.2.tar.gz\",\"repo\":\"pip_39_packaging_23_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pathspec": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pathspec\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3-py3-none-any.whl\",\"repo\":\"pip_39_pathspec_0_10_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pathspec-0.10.3.tar.gz\",\"repo\":\"pip_39_pathspec_0_10_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "platformdirs": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_platformdirs\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0-py3-none-any.whl\",\"repo\":\"pip_39_platformdirs_2_6_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"platformdirs-2.6.0.tar.gz\",\"repo\":\"pip_39_platformdirs_2_6_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pygments": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pygments\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1-py3-none-any.whl\",\"repo\":\"pip_39_pygments_2_16_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"Pygments-2.16.1.tar.gz\",\"repo\":\"pip_39_pygments_2_16_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pylint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9-py3-none-any.whl\",\"repo\":\"pip_39_pylint_2_15_9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-2.15.9.tar.gz\",\"repo\":\"pip_39_pylint_2_15_9_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pylint_print": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pylint_print\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint-print-1.0.1.tar.gz\",\"repo\":\"pip_39_pylint_print_1_0_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"pylint_print-1.0.1-py3-none-any.whl\",\"repo\":\"pip_39_pylint_print_1_0_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "python_dateutil": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_dateutil\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-dateutil-2.8.2.tar.gz\",\"repo\":\"pip_39_python_dateutil_2_8_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_dateutil-2.8.2-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_dateutil_2_8_2_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "python_magic": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_python_magic\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python-magic-0.4.27.tar.gz\",\"repo\":\"pip_39_python_magic_0_4_27_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"python_magic-0.4.27-py2.py3-none-any.whl\",\"repo\":\"pip_39_python_magic_0_4_27_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "pyyaml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_pyyaml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_pyyaml_6_0_1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"PyYAML-6.0.1.tar.gz\",\"repo\":\"pip_39_pyyaml_6_0_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "requests": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_requests\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_requests_2_25_1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"requests-2.25.1.tar.gz\",\"repo\":\"pip_39_requests_2_25_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "s3cmd": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_s3cmd\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_s3cmd_2_1_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"s3cmd-2.1.0.tar.gz\",\"repo\":\"pip_39_s3cmd_2_1_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "setuptools": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3-py3-none-any.whl\",\"repo\":\"pip_39_setuptools_65_6_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"setuptools-65.6.3.tar.gz\",\"repo\":\"pip_39_setuptools_65_6_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "six": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_six\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_six_1_16_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"six-1.16.0.tar.gz\",\"repo\":\"pip_39_six_1_16_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "snowballstemmer": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_snowballstemmer\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_snowballstemmer_2_2_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"snowballstemmer-2.2.0.tar.gz\",\"repo\":\"pip_39_snowballstemmer_2_2_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinx": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinx\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinx_7_2_6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinx-7.2.6.tar.gz\",\"repo\":\"pip_39_sphinx_7_2_6_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_applehelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_applehelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1_0_7_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_applehelp-1.0.7.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_applehelp_1_0_7_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_devhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_devhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1_0_5_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_devhelp-1.0.5.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_devhelp_1_0_5_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_htmlhelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_htmlhelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2_0_4_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_htmlhelp-2.0.4.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_htmlhelp_2_0_4_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_jsmath": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_jsmath\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib-jsmath-1.0.1.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1_0_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_jsmath_1_0_1_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_qthelp": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_qthelp\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1_0_6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_qthelp-1.0.6.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_qthelp_1_0_6_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "sphinxcontrib_serializinghtml": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_sphinxcontrib_serializinghtml\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1_1_9_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"sphinxcontrib_serializinghtml-1.1.9.tar.gz\",\"repo\":\"pip_39_sphinxcontrib_serializinghtml_1_1_9_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tabulate": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tabulate\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0-py3-none-any.whl\",\"repo\":\"pip_39_tabulate_0_9_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tabulate-0.9.0.tar.gz\",\"repo\":\"pip_39_tabulate_0_9_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tomli": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomli\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1-py3-none-any.whl\",\"repo\":\"pip_39_tomli_2_0_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomli-2.0.1.tar.gz\",\"repo\":\"pip_39_tomli_2_0_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "tomlkit": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_tomlkit\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6-py3-none-any.whl\",\"repo\":\"pip_39_tomlkit_0_11_6_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"tomlkit-0.11.6.tar.gz\",\"repo\":\"pip_39_tomlkit_0_11_6_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "typing_extensions": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_typing_extensions\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2-py3-none-any.whl\",\"repo\":\"pip_39_typing_extensions_4_12_2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"typing_extensions-4.12.2.tar.gz\",\"repo\":\"pip_39_typing_extensions_4_12_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_urllib3\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18-py2.py3-none-any.whl\",\"repo\":\"pip_39_urllib3_1_26_18_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"urllib3-1.26.18.tar.gz\",\"repo\":\"pip_39_urllib3_1_26_18_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "websockets": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_websockets\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_websockets_11_0_3_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3-py3-none-any.whl\",\"repo\":\"pip_39_websockets_11_0_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"websockets-11.0.3.tar.gz\",\"repo\":\"pip_39_websockets_11_0_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "wheel": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wheel\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0-py3-none-any.whl\",\"repo\":\"pip_39_wheel_0_40_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wheel-0.40.0.tar.gz\",\"repo\":\"pip_39_wheel_0_40_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "wrapt": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_wrapt\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_manylinux_2_5_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1-cp39-cp39-win_amd64.whl\",\"repo\":\"pip_39_wrapt_1_14_1_cp39_cp39_win_amd64\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"wrapt-1.14.1.tar.gz\",\"repo\":\"pip_39_wrapt_1_14_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "yamllint": "[{\"config_setting\":\"//_config:is_python_3.10\",\"filename\":null,\"repo\":\"pip_310_yamllint\",\"target_platforms\":null,\"version\":\"3.10\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0-py2.py3-none-any.whl\",\"repo\":\"pip_39_yamllint_1_28_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"yamllint-1.28.0.tar.gz\",\"repo\":\"pip_39_yamllint_1_28_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]",
+                "zipp": "[{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0-py3-none-any.whl\",\"repo\":\"pip_39_zipp_3_20_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.9\"},{\"config_setting\":\"//_config:is_python_3.9\",\"filename\":\"zipp-3.20.0.tar.gz\",\"repo\":\"pip_39_zipp_3_20_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.9\"}]"
               },
               "packages": [
                 "alabaster",
@@ -4536,7 +4487,7 @@
               }
             }
           },
-          "pip_39_chardet_4.0.0.tar.gz": {
+          "pip_39_pyyaml_6_0_1_cp39_cp39_musllinux_1_1_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4554,69 +4505,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "chardet-4.0.0.tar.gz",
+              "filename": "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "chardet==4.0.0",
-              "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
               "urls": [
-                "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz"
-              ]
-            }
-          },
-          "pip_39_docutils_0.20.1_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "docutils-0.20.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "docutils==0.20.1",
-              "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_dill_0.3.6_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "dill-0.3.6-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "dill==0.3.6",
-              "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/40/da/a175a35cf5583580e90ac3e2a3dbca90e43011593ae62ce63f79d7b28d92/PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
               ]
             }
           },
@@ -4641,7 +4536,7 @@
               "requirement": "python-dateutil==2.8.2     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             }
           },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_x86_64": {
+          "pip_39_pyyaml_6_0_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4659,41 +4554,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl",
+              "filename": "PyYAML-6.0.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
               "urls": [
-                "https://files.pythonhosted.org/packages/62/9b/4908a57acf39d8811836bc6776b309c2e07d63791485589acf0b6d7bc0c6/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_tomli_2.0.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "tomli-2.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "tomli==2.0.1 ;python_version < '3.11'",
-              "sha256": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
+                "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
               ]
             }
           },
@@ -4739,7 +4606,7 @@
               "requirement": "tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             }
           },
-          "pip_39_sphinx_7.2.6.tar.gz": {
+          "pip_39_jinja2_3_1_4_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4757,26 +4624,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinx-7.2.6.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
+              "filename": "jinja2-3.1.4.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinx==7.2.6",
-              "sha256": "9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5",
+              "requirement": "jinja2==3.1.4",
+              "sha256": "4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
               "urls": [
-                "https://files.pythonhosted.org/packages/73/8e/6e51da4b26665b4b92b1944ea18b2d9c825e753e19180cc5bdc818d0ed3b/sphinx-7.2.6.tar.gz"
+                "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz"
               ]
             }
           },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_macosx_10_9_universal2": {
+          "pip_39_websockets_11_0_3_cp39_cp39_musllinux_1_1_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4794,17 +4652,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl",
+              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+              "requirement": "websockets==11.0.3",
+              "sha256": "97b52894d948d2f6ea480171a27122d77af14ced35f62e5c892ca2fae9344311",
               "urls": [
-                "https://files.pythonhosted.org/packages/6a/86/654dc431513cd4417dfcead8102f22bece2d6abf2f584f0e1cc1524f7b94/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl"
+                "https://files.pythonhosted.org/packages/72/89/0d150939f2e592ed78c071d69237ac1c872462cc62a750c5f592f3d4ab18/websockets-11.0.3-cp39-cp39-musllinux_1_1_x86_64.whl"
               ]
             }
           },
-          "pip_39_colorama_0.4.6_py2_none_any": {
+          "pip_39_lazy_object_proxy_1_10_0_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4822,21 +4680,21 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "colorama-0.4.6-py2.py3-none-any.whl",
+              "filename": "lazy-object-proxy-1.10.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "colorama==0.4.6",
-              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69",
               "urls": [
-                "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/2c/f0/f02e2d150d581a294efded4020094a371bbab42423fe78625ac18854d89b/lazy-object-proxy-1.10.0.tar.gz"
               ]
             }
           },
-          "pip_39_wheel_0.40.0_py3_none_any": {
+          "pip_39_requests_2_25_1_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
-              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
                 "PIP_INDEX_URL"
@@ -4851,13 +4709,102 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wheel-0.40.0-py3-none-any.whl",
+              "filename": "requests-2.25.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wheel==0.40.0",
-              "sha256": "d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247",
+              "requirement": "requests==2.25.1",
+              "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
               "urls": [
-                "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz"
+              ],
+              "whl_patches": {
+                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
+              }
+            }
+          },
+          "pip_39_mccabe_0_7_0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "mccabe-0.7.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "mccabe==0.7.0",
+              "sha256": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_python_dateutil_2_8_2_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "python-dateutil-2.8.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "python-dateutil==2.8.2",
+              "sha256": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
+              ]
+            }
+          },
+          "pip_39_wrapt_1_14_1_cp39_cp39_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/3c/110e52b9da396a4ef3a0521552a1af9c7875a762361f48678c1ac272fd7e/wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl"
               ]
             }
           },
@@ -4882,7 +4829,7 @@
               "requirement": "platformdirs==3.5.1     --hash=sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f     --hash=sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
             }
           },
-          "pip_39_six_1.16.0.tar.gz": {
+          "pip_39_setuptools_65_6_3_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -4900,13 +4847,69 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "six-1.16.0.tar.gz",
+              "filename": "setuptools-65.6.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "six==1.16.0",
-              "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+              "requirement": "setuptools==65.6.3",
+              "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
               "urls": [
-                "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+                "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_markupsafe_2_1_3_cp39_cp39_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "markupsafe==2.1.3",
+              "sha256": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_zipp_3_20_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
+              "sha256": "0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0e/af/9f2de5bd32549a1b705af7a7c054af3878816a1267cb389c03cc4f342a51/zipp-3.20.0.tar.gz"
               ]
             }
           },
@@ -4931,578 +4934,7 @@
               "requirement": "dill==0.3.6     --hash=sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0     --hash=sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             }
           },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
-              "urls": [
-                "https://files.pythonhosted.org/packages/03/65/3473d2cb84bb2cda08be95b97fc4f53e6bcd701a2d50ba7b7c905e1e9273/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_11.0.3_cp39_cp39_musllinux_1_1_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c4/f5/15998b164c183af0513bba744b51ecb08d396ff86c0db3b55d62624d1f15/websockets-11.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "pip_39_pathspec_0.10.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "pathspec-0.10.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pathspec==0.10.3",
-              "sha256": "3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_docutils_0.20.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "docutils-0.20.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "docutils==0.20.1",
-              "sha256": "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_websockets_11.0.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "6681ba9e7f8f3b19440921e99efbb40fc89f26cd71bf539e45d8c8a25c976dc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/47/96/9d5749106ff57629b54360664ae7eb9afd8302fad1680ead385383e33746/websockets-11.0.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_310_sphinxcontrib_jsmath": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "sphinxcontrib-jsmath==1.0.1     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
-            }
-          },
-          "pip_39_isort_5.11.4_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "isort-5.11.4-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "isort==5.11.4",
-              "sha256": "c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_sphinxcontrib_serializinghtml_1.1.9_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
-              "sha256": "9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/95/d6/2e0bda62b2a808070ac922d21a950aa2cb5e4fcfb87e5ff5f86bc43a2201/sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl"
-              ]
-            }
-          },
-          "pip_39_markupsafe_2.1.3_cp39_cp39_musllinux_1_1_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ab/20/f59423543a8422cb8c69a579ebd0ef2c9dafa70cc8142b7372b5b4073caa/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "pip_310_tomlkit": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "tomlkit==0.11.8     --hash=sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171     --hash=sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"
-            }
-          },
-          "pip_310_markupsafe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "markupsafe==2.1.3     --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e     --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e     --hash=sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431     --hash=sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686     --hash=sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c     --hash=sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559     --hash=sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc     --hash=sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb     --hash=sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939     --hash=sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c     --hash=sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0     --hash=sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4     --hash=sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9     --hash=sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575     --hash=sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba     --hash=sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d     --hash=sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd     --hash=sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3     --hash=sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00     --hash=sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155     --hash=sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac     --hash=sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52     --hash=sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f     --hash=sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8     --hash=sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b     --hash=sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007     --hash=sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24     --hash=sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea     --hash=sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198     --hash=sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0     --hash=sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee     --hash=sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be     --hash=sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2     --hash=sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1     --hash=sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707     --hash=sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6     --hash=sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c     --hash=sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58     --hash=sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823     --hash=sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779     --hash=sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636     --hash=sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c     --hash=sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad     --hash=sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee     --hash=sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc     --hash=sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2     --hash=sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48     --hash=sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7     --hash=sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e     --hash=sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b     --hash=sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa     --hash=sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5     --hash=sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e     --hash=sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb     --hash=sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9     --hash=sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57     --hash=sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc     --hash=sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc     --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2     --hash=sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
-            }
-          },
-          "pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "8c82f11964f010053e13daafdc7154ce7385ecc538989a354ccc7067fd7028fd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8f/f2/8a3eb016be19743c7eb9e67c855df0fdfa5912534ffaf83a05b62667d761/websockets-11.0.3-cp39-cp39-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "pip_39_websockets_11.0.3_cp39_cp39_macosx_10_9_universal2": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "777354ee16f02f643a4c7f2b3eff8027a33c9861edc691a2003531f5da4f6bc8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/21/cb9dfbbea8dc0ad89ced52630e7e61edb425fb9fdc6002f8d0c5dd26b94b/websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl"
-              ]
-            }
-          },
-          "pip_39_urllib3_1.26.18.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "urllib3-1.26.18.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
-              ]
-            }
-          },
-          "pip_39_imagesize_1.4.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "imagesize-1.4.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "imagesize==1.4.1",
-              "sha256": "69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz"
-              ]
-            }
-          },
-          "pip_39_snowballstemmer_2.2.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "snowballstemmer-2.2.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "snowballstemmer==2.2.0",
-              "sha256": "09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz"
-              ]
-            }
-          },
-          "pip_310_mccabe": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "mccabe==0.7.0     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
-            }
-          },
-          "pip_39_packaging_23.2.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "packaging-23.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "packaging==23.2",
-              "sha256": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
-              ]
-            }
-          },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_win_amd64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
-              "urls": [
-                "https://files.pythonhosted.org/packages/84/4d/82704d1ab9290b03da94e6425f5e87396b999fd7eb8e08f3a92c158402bf/PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
-              ]
-            }
-          },
-          "pip_39_astroid_2.12.13.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "astroid-2.12.13.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "astroid==2.12.13",
-              "sha256": "1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/61/d0/e7cfca72ec7d6c5e0da725c003db99bb056e9b6c2f4ee6fae1145adf28a6/astroid-2.12.13.tar.gz"
-              ]
-            }
-          },
-          "pip_310_sphinxcontrib_applehelp": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_*",
-                "osx_*",
-                "windows_*",
-                "linux_x86_64",
-                "host"
-              ],
-              "extra_pip_args": [
-                "--extra-index-url",
-                "https://pypi.org/simple/"
-              ],
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
-              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
-              "repo": "pip_310",
-              "requirement": "sphinxcontrib-applehelp==1.0.7     --hash=sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d     --hash=sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
-            }
-          },
-          "pip_39_sphinxcontrib_applehelp_1.0.7_py3_none_any": {
+          "pip_39_sphinxcontrib_applehelp_1_0_7_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5539,7 +4971,7 @@
               ]
             }
           },
-          "pip_39_mccabe_0.7.0.tar.gz": {
+          "pip_39_astroid_2_12_13_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5557,17 +4989,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "mccabe-0.7.0.tar.gz",
+              "filename": "astroid-2.12.13.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "mccabe==0.7.0",
-              "sha256": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+              "requirement": "astroid==2.12.13",
+              "sha256": "1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7",
               "urls": [
-                "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
+                "https://files.pythonhosted.org/packages/61/d0/e7cfca72ec7d6c5e0da725c003db99bb056e9b6c2f4ee6fae1145adf28a6/astroid-2.12.13.tar.gz"
               ]
             }
           },
-          "pip_39_colorama_0.4.6.tar.gz": {
+          "pip_39_dill_0_3_6_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5585,17 +5017,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "colorama-0.4.6.tar.gz",
+              "filename": "dill-0.3.6-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "colorama==0.4.6",
-              "sha256": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+              "requirement": "dill==0.3.6",
+              "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
               "urls": [
-                "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+                "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_jinja2_3.1.4.tar.gz": {
+          "pip_39_tabulate_0_9_0_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5613,17 +5045,38 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "jinja2-3.1.4.tar.gz",
+              "filename": "tabulate-0.9.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "jinja2==3.1.4",
-              "sha256": "4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+              "requirement": "tabulate==0.9.0",
+              "sha256": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
               "urls": [
-                "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz"
+                "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
               ]
             }
           },
-          "pip_39_pylint_print_1.0.1.tar.gz": {
+          "pip_310_sphinxcontrib_jsmath": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "sphinxcontrib-jsmath==1.0.1     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            }
+          },
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_win_amd64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5641,17 +5094,273 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "pylint-print-1.0.1.tar.gz",
+              "filename": "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pylint-print==1.0.1",
-              "sha256": "30aa207e9718ebf4ceb47fb87012092e6d8743aab932aa07aa14a73e750ad3d0",
+              "requirement": "lazy-object-proxy==1.10.0",
+              "sha256": "a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd",
               "urls": [
-                "https://files.pythonhosted.org/packages/60/76/8fd24bfcbd5130b487990c6ec5eab2a053f1ec8f7d33ef6c38fee7e22b70/pylint-print-1.0.1.tar.gz"
+                "https://files.pythonhosted.org/packages/fe/30/40879041ed6a3364bfa862c4237aa7fe94dcd4affa2175718acbbf4d29b9/lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl"
               ]
             }
           },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_musllinux_1_1_x86_64": {
+          "pip_310_tomlkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "tomlkit==0.11.8     --hash=sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171     --hash=sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"
+            }
+          },
+          "pip_39_sphinx_7_2_6_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinx-7.2.6-py3-none-any.whl",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinx==7.2.6",
+              "sha256": "1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b2/b6/8ed35256aa530a9d3da15d20bdc0ba888d5364441bb50a5a83ee7827affe/sphinx-7.2.6-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_310_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "markupsafe==2.1.3     --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e     --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e     --hash=sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431     --hash=sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686     --hash=sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c     --hash=sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559     --hash=sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc     --hash=sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb     --hash=sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939     --hash=sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c     --hash=sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0     --hash=sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4     --hash=sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9     --hash=sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575     --hash=sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba     --hash=sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d     --hash=sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd     --hash=sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3     --hash=sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00     --hash=sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155     --hash=sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac     --hash=sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52     --hash=sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f     --hash=sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8     --hash=sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b     --hash=sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007     --hash=sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24     --hash=sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea     --hash=sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198     --hash=sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0     --hash=sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee     --hash=sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be     --hash=sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2     --hash=sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1     --hash=sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707     --hash=sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6     --hash=sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c     --hash=sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58     --hash=sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823     --hash=sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779     --hash=sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636     --hash=sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c     --hash=sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad     --hash=sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee     --hash=sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc     --hash=sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2     --hash=sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48     --hash=sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7     --hash=sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e     --hash=sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b     --hash=sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa     --hash=sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5     --hash=sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e     --hash=sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb     --hash=sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9     --hash=sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57     --hash=sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc     --hash=sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc     --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2     --hash=sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
+            }
+          },
+          "pip_39_platformdirs_2_6_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "platformdirs-2.6.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "platformdirs==2.6.0",
+              "sha256": "b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ec/4c/9af851448e55c57b30a13a72580306e628c3b431d97fdae9e0b8d4fa3685/platformdirs-2.6.0.tar.gz"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_serializinghtml_1_1_9_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-serializinghtml==1.1.9",
+              "sha256": "9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/95/d6/2e0bda62b2a808070ac922d21a950aa2cb5e4fcfb87e5ff5f86bc43a2201/sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_websockets_11_0_3_cp39_cp39_macosx_10_9_universal2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "websockets==11.0.3",
+              "sha256": "777354ee16f02f643a4c7f2b3eff8027a33c9861edc691a2003531f5da4f6bc8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c0/21/cb9dfbbea8dc0ad89ced52630e7e61edb425fb9fdc6002f8d0c5dd26b94b/websockets-11.0.3-cp39-cp39-macosx_10_9_universal2.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1_14_1_cp39_cp39_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bb/70/73c54e24ea69a8b06ae9649e61d5e64f2b4bdfc6f202fc7794abeac1ed20/wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "pip_39_sphinxcontrib_jsmath_1_0_1_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-jsmath==1.0.1",
+              "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1_14_1_cp39_cp39_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "wrapt==1.14.1",
+              "sha256": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_musllinux_1_1_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5679,6 +5388,113 @@
               ]
             }
           },
+          "pip_39_typing_extensions_4_12_2_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "typing_extensions-4.12.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "typing-extensions==4.12.2 ;python_version < '3.10'",
+              "sha256": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
+              ]
+            }
+          },
+          "pip_310_mccabe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "mccabe==0.7.0     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            }
+          },
+          "pip_310_sphinxcontrib_applehelp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "experimental_target_platforms": [
+                "linux_*",
+                "osx_*",
+                "windows_*",
+                "linux_x86_64",
+                "host"
+              ],
+              "extra_pip_args": [
+                "--extra-index-url",
+                "https://pypi.org/simple/"
+              ],
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pip_310",
+              "requirement": "sphinxcontrib-applehelp==1.0.7     --hash=sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d     --hash=sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
+            }
+          },
+          "pip_39_babel_2_13_1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "Babel-2.13.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "babel==2.13.1",
+              "sha256": "7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed",
+              "urls": [
+                "https://files.pythonhosted.org/packages/86/14/5dc2eb02b7cc87b2f95930310a2cc5229198414919a116b564832c747bc1/Babel-2.13.1-py3-none-any.whl"
+              ]
+            }
+          },
           "pip_310_pygments": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -5700,7 +5516,7 @@
               "requirement": "pygments==2.16.1     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
             }
           },
-          "pip_39_markupsafe_2.1.3.tar.gz": {
+          "pip_39_alabaster_0_7_13_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5718,13 +5534,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "MarkupSafe-2.1.3.tar.gz",
+              "filename": "alabaster-0.7.13.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "markupsafe==2.1.3",
-              "sha256": "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+              "requirement": "alabaster==0.7.13",
+              "sha256": "a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2",
               "urls": [
-                "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
+                "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz"
               ]
             }
           },
@@ -5738,7 +5554,7 @@
               }
             }
           },
-          "pip_39_pyyaml_6.0.1_cp39_cp39_macosx_10_9_x86_64": {
+          "pip_39_python_magic_0_4_27_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5756,20 +5572,21 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl",
+              "filename": "python_magic-0.4.27-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "pyyaml==6.0.1",
-              "sha256": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+              "requirement": "python-magic==0.4.27",
+              "sha256": "c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3",
               "urls": [
-                "https://files.pythonhosted.org/packages/57/c5/5d09b66b41d549914802f482a2118d925d876dc2a35b2d127694c1345c34/PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+                "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl"
               ]
             }
           },
-          "pip_39_wrapt_1.14.1_cp39_cp39_musllinux_1_1_x86_64": {
+          "pip_39_requests_2_25_1_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:requests.json",
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
                 "PIP_INDEX_URL"
@@ -5784,14 +5601,19 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl",
+              "filename": "requests-2.25.1-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "wrapt==1.14.1",
-              "sha256": "34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+              "requirement": "requests==2.25.1",
+              "sha256": "c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e",
               "urls": [
-                "https://files.pythonhosted.org/packages/f9/3c/110e52b9da396a4ef3a0521552a1af9c7875a762361f48678c1ac272fd7e/wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl"
-              ]
+                "https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl"
+              ],
+              "whl_patches": {
+                "@@//patches:empty.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_metadata.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}",
+                "@@//patches:requests_record.patch": "{\"patch_strip\":1,\"whls\":[\"requests-2.25.1-py2.py3-none-any.whl\"]}"
+              }
             }
           },
           "pip_310_certifi": {
@@ -5836,10 +5658,11 @@
               "requirement": "pyyaml==6.0     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293     --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b     --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57     --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b     --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4     --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07     --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba     --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9     --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287     --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513     --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0     --hash=sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782     --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0     --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92     --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f     --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2     --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc     --hash=sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1     --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c     --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86     --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4     --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c     --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34     --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b     --hash=sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d     --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c     --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb     --hash=sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7     --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737     --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3     --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d     --hash=sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358     --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53     --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78     --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803     --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a     --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             }
           },
-          "pip_39_sphinxcontrib_applehelp_1.0.7.tar.gz": {
+          "pip_39_wheel_0_40_0_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
+              "annotation": "@@rules_python~~pip~whl_mods_hub//:wheel.json",
               "dep_template": "@pip//{name}:{target}",
               "envsubst": [
                 "PIP_INDEX_URL"
@@ -5854,26 +5677,17 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "sphinxcontrib_applehelp-1.0.7.tar.gz",
-              "group_deps": [
-                "sphinx",
-                "sphinxcontrib_qthelp",
-                "sphinxcontrib_htmlhelp",
-                "sphinxcontrib_devhelp",
-                "sphinxcontrib_applehelp",
-                "sphinxcontrib_serializinghtml"
-              ],
-              "group_name": "sphinx",
+              "filename": "wheel-0.40.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "sphinxcontrib-applehelp==1.0.7",
-              "sha256": "39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa",
+              "requirement": "wheel==0.40.0",
+              "sha256": "d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247",
               "urls": [
-                "https://files.pythonhosted.org/packages/1c/5a/fce19be5d4db26edc853a0c34832b39db7b769b7689da027529767b0aa98/sphinxcontrib_applehelp-1.0.7.tar.gz"
+                "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_jinja2_3.1.4_py3_none_any": {
+          "pip_39_packaging_23_2_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5891,13 +5705,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "jinja2-3.1.4-py3-none-any.whl",
+              "filename": "packaging-23.2.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "jinja2==3.1.4",
-              "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
+              "requirement": "packaging==23.2",
+              "sha256": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
               "urls": [
-                "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
               ]
             }
           },
@@ -5922,7 +5736,7 @@
               "requirement": "chardet==4.0.0     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             }
           },
-          "pip_39_alabaster_0.7.13_py3_none_any": {
+          "pip_39_zipp_3_20_0_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5940,17 +5754,73 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "alabaster-0.7.13-py3-none-any.whl",
+              "filename": "zipp-3.20.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "alabaster==0.7.13",
-              "sha256": "1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
+              "requirement": "zipp==3.20.0 ;python_version < '3.10'",
+              "sha256": "58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d",
               "urls": [
-                "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/da/cc/b9958af9f9c86b51f846d8487440af495ecf19b16e426fce1ed0b0796175/zipp-3.20.0-py3-none-any.whl"
               ]
             }
           },
-          "pip_39_lazy_object_proxy_1.10.0_cp39_cp39_macosx_10_9_x86_64": {
+          "pip_39_pyyaml_6_0_1_cp39_cp39_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+              "urls": [
+                "https://files.pythonhosted.org/packages/84/4d/82704d1ab9290b03da94e6425f5e87396b999fd7eb8e08f3a92c158402bf/PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
+              ]
+            }
+          },
+          "pip_39_pyyaml_6_0_1_cp39_cp39_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "pyyaml==6.0.1",
+              "sha256": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ac/6c/967d91a8edf98d2b2b01d149bd9e51b8f9fb527c98d80ebb60c6b21d60c4/PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "pip_39_lazy_object_proxy_1_10_0_cp39_cp39_macosx_10_9_x86_64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -5978,34 +5848,6 @@
               ]
             }
           },
-          "pip_39_websockets_11.0.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@pip//{name}:{target}",
-              "envsubst": [
-                "PIP_INDEX_URL"
-              ],
-              "experimental_target_platforms": [
-                "cp39_linux_aarch64",
-                "cp39_linux_arm",
-                "cp39_linux_ppc",
-                "cp39_linux_s390x",
-                "cp39_linux_x86_64",
-                "cp39_osx_aarch64",
-                "cp39_osx_x86_64",
-                "cp39_windows_x86_64"
-              ],
-              "filename": "websockets-11.0.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
-              "repo": "pip_39",
-              "requirement": "websockets==11.0.3",
-              "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz"
-              ]
-            }
-          },
           "pip_310_urllib3": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6027,7 +5869,7 @@
               "requirement": "urllib3==1.26.18     --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07     --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             }
           },
-          "pip_39_platformdirs_2.6.0_py3_none_any": {
+          "pip_39_s3cmd_2_1_0_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -6045,13 +5887,13 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "platformdirs-2.6.0-py3-none-any.whl",
+              "filename": "s3cmd-2.1.0-py2.py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
-              "requirement": "platformdirs==2.6.0",
-              "sha256": "1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
+              "requirement": "s3cmd==2.1.0",
+              "sha256": "49cd23d516b17974b22b611a95ce4d93fe326feaa07320bd1d234fed68cbccfa",
               "urls": [
-                "https://files.pythonhosted.org/packages/87/69/cd019a9473bcdfb38983e2d550ccb239264fc4c2fc32c42ac1b1cc2506b6/platformdirs-2.6.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/26/44/19e08f69b2169003f7307565f19449d997895251c6a6566ce21d5d636435/s3cmd-2.1.0-py2.py3-none-any.whl"
               ]
             }
           },
@@ -6076,6 +5918,71 @@
               "requirement": "six==1.16.0     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             }
           },
+          "pip_39_sphinxcontrib_devhelp_1_0_5_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_devhelp-1.0.5.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-devhelp==1.0.5",
+              "sha256": "63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/f2/6425b6db37e7c2254ad661c90a871061a078beaddaf9f15a00ba9c3a1529/sphinxcontrib_devhelp-1.0.5.tar.gz"
+              ]
+            }
+          },
+          "pip_39_certifi_2023_7_22_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "certifi-2023.7.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "certifi==2023.7.22",
+              "sha256": "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+              "urls": [
+                "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
+              ]
+            }
+          },
           "pip_310_wheel": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6098,7 +6005,7 @@
               "requirement": "wheel==0.40.0     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
             }
           },
-          "pip_39_wrapt_1.14.1_cp39_cp39_win_amd64": {
+          "pip_39_colorama_0_4_6_py2_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -6116,13 +6023,41 @@
                 "cp39_osx_x86_64",
                 "cp39_windows_x86_64"
               ],
-              "filename": "wrapt-1.14.1-cp39-cp39-win_amd64.whl",
+              "filename": "colorama-0.4.6-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "colorama==0.4.6",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "pip_39_wrapt_1_14_1_cp39_cp39_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
               "repo": "pip_39",
               "requirement": "wrapt==1.14.1",
-              "sha256": "dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+              "sha256": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
               "urls": [
-                "https://files.pythonhosted.org/packages/5b/02/5ac7ea3b6722c84a2882d349ac581a9711b4047fe7a58475903832caa295/wrapt-1.14.1-cp39-cp39-win_amd64.whl"
+                "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
@@ -6147,6 +6082,34 @@
               "requirement": "jinja2==3.1.4     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
             }
           },
+          "pip_39_urllib3_1_26_18_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "urllib3-1.26.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "urllib3==1.26.18",
+              "sha256": "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
+              ]
+            }
+          },
           "pip_310_websockets": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -6166,6 +6129,43 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
               "repo": "pip_310",
               "requirement": "websockets==11.0.3     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f     --hash=sha256:0ac56b661e60edd453585f4bd68eb6a29ae25b5184fd5ba51e97652580458998     --hash=sha256:0ee68fe502f9031f19d495dae2c268830df2760c0524cbac5d759921ba8c8e82     --hash=sha256:1553cb82942b2a74dd9b15a018dce645d4e68674de2ca31ff13ebc2d9f283788     --hash=sha256:1a073fc9ab1c8aff37c99f11f1641e16da517770e31a37265d2755282a5d28aa     --hash=sha256:1d2256283fa4b7f4c7d7d3e84dc2ece74d341bce57d5b9bf385df109c2a1a82f     --hash=sha256:1d5023a4b6a5b183dc838808087033ec5df77580485fc533e7dab2567851b0a4     --hash=sha256:1fdf26fa8a6a592f8f9235285b8affa72748dc12e964a5518c6c5e8f916716f7     --hash=sha256:2529338a6ff0eb0b50c7be33dc3d0e456381157a31eefc561771ee431134a97f     --hash=sha256:279e5de4671e79a9ac877427f4ac4ce93751b8823f276b681d04b2156713b9dd     --hash=sha256:2d903ad4419f5b472de90cd2d40384573b25da71e33519a67797de17ef849b69     --hash=sha256:332d126167ddddec94597c2365537baf9ff62dfcc9db4266f263d455f2f031cb     --hash=sha256:34fd59a4ac42dff6d4681d8843217137f6bc85ed29722f2f7222bd619d15e95b     --hash=sha256:3580dd9c1ad0701169e4d6fc41e878ffe05e6bdcaf3c412f9d559389d0c9e016     --hash=sha256:3ccc8a0c387629aec40f2fc9fdcb4b9d5431954f934da3eaf16cdc94f67dbfac     --hash=sha256:41f696ba95cd92dc047e46b41b26dd24518384749ed0d99bea0a941ca87404c4     --hash=sha256:42cc5452a54a8e46a032521d7365da775823e21bfba2895fb7b77633cce031bb     --hash=sha256:4841ed00f1026dfbced6fca7d963c4e7043aa832648671b5138008dc5a8f6d99     --hash=sha256:4b253869ea05a5a073ebfdcb5cb3b0266a57c3764cf6fe114e4cd90f4bfa5f5e     --hash=sha256:54c6e5b3d3a8936a4ab6870d46bdd6ec500ad62bde9e44462c32d18f1e9a8e54     --hash=sha256:619d9f06372b3a42bc29d0cd0354c9bb9fb39c2cbc1a9c5025b4538738dbffaf     --hash=sha256:6505c1b31274723ccaf5f515c1824a4ad2f0d191cec942666b3d0f3aa4cb4007     --hash=sha256:660e2d9068d2bedc0912af508f30bbeb505bbbf9774d98def45f68278cea20d3     --hash=sha256:6681ba9e7f8f3b19440921e99efbb40fc89f26cd71bf539e45d8c8a25c976dc6     --hash=sha256:68b977f21ce443d6d378dbd5ca38621755f2063d6fdb3335bda981d552cfff86     --hash=sha256:69269f3a0b472e91125b503d3c0b3566bda26da0a3261c49f0027eb6075086d1     --hash=sha256:6f1a3f10f836fab6ca6efa97bb952300b20ae56b409414ca85bff2ad241d2a61     --hash=sha256:7622a89d696fc87af8e8d280d9b421db5133ef5b29d3f7a1ce9f1a7bf7fcfa11     --hash=sha256:777354ee16f02f643a4c7f2b3eff8027a33c9861edc691a2003531f5da4f6bc8     --hash=sha256:84d27a4832cc1a0ee07cdcf2b0629a8a72db73f4cf6de6f0904f6661227f256f     --hash=sha256:8531fdcad636d82c517b26a448dcfe62f720e1922b33c81ce695d0edb91eb931     --hash=sha256:86d2a77fd490ae3ff6fae1c6ceaecad063d3cc2320b44377efdde79880e11526     --hash=sha256:88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016     --hash=sha256:8a34e13a62a59c871064dfd8ffb150867e54291e46d4a7cf11d02c94a5275bae     --hash=sha256:8c82f11964f010053e13daafdc7154ce7385ecc538989a354ccc7067fd7028fd     --hash=sha256:92b2065d642bf8c0a82d59e59053dd2fdde64d4ed44efe4870fa816c1232647b     --hash=sha256:97b52894d948d2f6ea480171a27122d77af14ced35f62e5c892ca2fae9344311     --hash=sha256:9d9acd80072abcc98bd2c86c3c9cd4ac2347b5a5a0cae7ed5c0ee5675f86d9af     --hash=sha256:9f59a3c656fef341a99e3d63189852be7084c0e54b75734cde571182c087b152     --hash=sha256:aa5003845cdd21ac0dc6c9bf661c5beddd01116f6eb9eb3c8e272353d45b3288     --hash=sha256:b16fff62b45eccb9c7abb18e60e7e446998093cdcb50fed33134b9b6878836de     --hash=sha256:b30c6590146e53149f04e85a6e4fcae068df4289e31e4aee1fdf56a0dead8f97     --hash=sha256:b58cbf0697721120866820b89f93659abc31c1e876bf20d0b3d03cef14faf84d     --hash=sha256:b67c6f5e5a401fc56394f191f00f9b3811fe843ee93f4a70df3c389d1adf857d     --hash=sha256:bceab846bac555aff6427d060f2fcfff71042dba6f5fca7dc4f75cac815e57ca     --hash=sha256:bee9fcb41db2a23bed96c6b6ead6489702c12334ea20a297aa095ce6d31370d0     --hash=sha256:c114e8da9b475739dde229fd3bc6b05a6537a88a578358bc8eb29b4030fac9c9     --hash=sha256:c1f0524f203e3bd35149f12157438f406eff2e4fb30f71221c8a5eceb3617b6b     --hash=sha256:c792ea4eabc0159535608fc5658a74d1a81020eb35195dd63214dcf07556f67e     --hash=sha256:c7f3cb904cce8e1be667c7e6fef4516b98d1a6a0635a58a57528d577ac18a128     --hash=sha256:d67ac60a307f760c6e65dad586f556dde58e683fab03323221a4e530ead6f74d     --hash=sha256:dcacf2c7a6c3a84e720d1bb2b543c675bf6c40e460300b628bab1b1efc7c034c     --hash=sha256:de36fe9c02995c7e6ae6efe2e205816f5f00c22fd1fbf343d4d18c3d5ceac2f5     --hash=sha256:def07915168ac8f7853812cc593c71185a16216e9e4fa886358a17ed0fd9fcf6     --hash=sha256:df41b9bc27c2c25b486bae7cf42fccdc52ff181c8c387bfd026624a491c2671b     --hash=sha256:e052b8467dd07d4943936009f46ae5ce7b908ddcac3fda581656b1b19c083d9b     --hash=sha256:e063b1865974611313a3849d43f2c3f5368093691349cf3c7c8f8f75ad7cb280     --hash=sha256:e1459677e5d12be8bbc7584c35b992eea142911a6236a3278b9b5ce3326f282c     --hash=sha256:e1a99a7a71631f0efe727c10edfba09ea6bee4166a6f9c19aafb6c0b5917d09c     --hash=sha256:e590228200fcfc7e9109509e4d9125eace2042fd52b595dd22bbc34bb282307f     --hash=sha256:e6316827e3e79b7b8e7d8e3b08f4e331af91a48e794d5d8b099928b6f0b85f20     --hash=sha256:e7837cb169eca3b3ae94cc5787c4fed99eef74c0ab9506756eea335e0d6f3ed8     --hash=sha256:e848f46a58b9fcf3d06061d17be388caf70ea5b8cc3466251963c8345e13f7eb     --hash=sha256:ed058398f55163a79bb9f06a90ef9ccc063b204bb346c4de78efc5d15abfe602     --hash=sha256:f2e58f2c36cc52d41f2659e4c0cbf7353e28c8c9e63e30d8c6d3494dc9fdedcf     --hash=sha256:f467ba0050b7de85016b43f5a22b46383ef004c4f672148a8abf32bc999a87f0     --hash=sha256:f61bdb1df43dc9c131791fbc2355535f9024b9a04398d3bd0684fc16ab07df74     --hash=sha256:fb06eea71a00a7af0ae6aefbb932fb8a7df3cb390cc217d51a9ad7343de1b8d0     --hash=sha256:ffd7dcaf744f25f82190856bc26ed81721508fc5cbf2a330751e135ff1283564"
+            }
+          },
+          "pip_39_sphinxcontrib_htmlhelp_2_0_4_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "envsubst": [
+                "PIP_INDEX_URL"
+              ],
+              "experimental_target_platforms": [
+                "cp39_linux_aarch64",
+                "cp39_linux_arm",
+                "cp39_linux_ppc",
+                "cp39_linux_s390x",
+                "cp39_linux_x86_64",
+                "cp39_osx_aarch64",
+                "cp39_osx_x86_64",
+                "cp39_windows_x86_64"
+              ],
+              "filename": "sphinxcontrib_htmlhelp-2.0.4.tar.gz",
+              "group_deps": [
+                "sphinx",
+                "sphinxcontrib_qthelp",
+                "sphinxcontrib_htmlhelp",
+                "sphinxcontrib_devhelp",
+                "sphinxcontrib_applehelp",
+                "sphinxcontrib_serializinghtml"
+              ],
+              "group_name": "sphinx",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pip_39",
+              "requirement": "sphinxcontrib-htmlhelp==2.0.4",
+              "sha256": "6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fd/2d/abf5cd4cc1d5cd9842748b15a28295e4c4a927facfa8a0e173bd3f151bc5/sphinxcontrib_htmlhelp-2.0.4.tar.gz"
+              ]
             }
           }
         },
@@ -6299,7 +6299,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "3xiJG0qOok3nehSJ+kW0/IeKzrjB0DW6hDAy8bEYgz0=",
+        "bzlTransitiveDigest": "LZuz462fRgQEfjiIxWUPAkwIoGek+M7BoqqxYrJA6vs=",
         "usagesDigest": "LYtSAPzhPjmfD9vF39mCED1UQSvHEo2Hv+aK5Z4ZWWc=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
@@ -6312,1983 +6312,7 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64le": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "34c03fa78e328c691f982b7c03d4423bdfd7da69cd707fe572f544cf74ac23ad",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ab/a7/375afcc710dbe2d64cfbd69e31f82f3e423d43737258af01f6a56d844085/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "36c95d4b70530b320b365659bb5034341316e6a9b30f0b25fa9c9eff4c27a204",
-              "urls": [
-                "https://files.pythonhosted.org/packages/eb/61/73a007c74c37895fdf66e0edcd881f5eaa17a348ff02f4bb4bc906d61085/nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_ppc64le": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
-              "urls": [
-                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pkginfo_1.10.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pkginfo-1.10.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.10.0",
-              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
-              "urls": [
-                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
-              "urls": [
-                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_classes_3.4.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.classes-3.4.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.4.0",
-              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_twine_5.1.1_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "twine-5.1.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==5.1.1",
-              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_s390x": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_2.2.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "urllib3-2.2.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==2.2.3",
-              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_secretstorage_3.3.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "secretstorage==3.3.3",
-              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
-              "urls": [
-                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_8.5.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==8.5.0",
-              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_2.32.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-2.32.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.32.3",
-              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_1.0.0_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==1.0.0",
-              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
-              "urls": [
-                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_more_itertools_10.5.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "more-itertools-10.5.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==10.5.0",
-              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
-              "urls": [
-                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_ppc64le": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_markdown_it_py_3.0.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "markdown-it-py-3.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==3.0.0",
-              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
-              "urls": [
-                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_mdurl_0.1.2.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jeepney_0.8.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "jeepney-0.8.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jeepney==0.8.0",
-              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_2.22.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "pycparser-2.22.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.22",
-              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_secretstorage_3.3.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "SecretStorage-3.3.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "secretstorage==3.3.3",
-              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
-              "urls": [
-                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
-              "urls": [
-                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_2.2.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "urllib3-2.2.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==2.2.3",
-              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rfc3986_2.0.0_py2_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rfc3986==2.0.0",
-              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_twine_5.1.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "twine-5.1.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==5.1.1",
-              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
-              "urls": [
-                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_2.22_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "pycparser-2.22-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.22",
-              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
-              "urls": [
-                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_2.18.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pygments-2.18.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.18.0",
-              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_0.21.2.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "docutils-0.21.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.21.2",
-              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_certifi_2024.8.30_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "certifi-2024.8.30-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2024.8.30",
-              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_armv7l": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
-              "urls": [
-                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rich_13.9.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rich-13.9.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.9.3",
-              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rich_13.9.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rich-13.9.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.9.3",
-              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_zipp_3.20.2.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "zipp-3.20.2.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.20.2",
-              "sha256": "bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29",
-              "urls": [
-                "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_8.5.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "importlib_metadata-8.5.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==8.5.0",
-              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_functools_4.1.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco_functools-4.1.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-functools==4.1.0",
-              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_backports_tarfile_1.2.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "backports_tarfile-1.2.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "backports-tarfile==1.2.0",
-              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
-              "urls": [
-                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
-              "urls": [
-                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_readme_renderer_44.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "readme_renderer-44.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==44.0",
-              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_rfc3986_2.0.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "rfc3986-2.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "rfc3986==2.0.0",
-              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_keyring_25.4.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "keyring-25.4.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==25.4.1",
-              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
-              "urls": [
-                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_0.2.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32-ctypes-0.2.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.3",
-              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
-              "urls": [
-                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_classes_3.4.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.4.0",
-              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_readme_renderer_44.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "readme_renderer-44.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==44.0",
-              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
-              "urls": [
-                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_2.18.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pygments-2.18.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.18.0",
-              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
-              "urls": [
-                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
-              "urls": [
-                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_more_itertools_10.5.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "more_itertools-10.5.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==10.5.0",
-              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
-              "urls": [
-                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pkginfo_1.10.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pkginfo-1.10.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.10.0",
-              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
-              "urls": [
-                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_idna_3.10.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "idna-3.10.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.10",
-              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jeepney_0.8.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "jeepney-0.8.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jeepney==0.8.0",
-              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_1.0.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-toolbelt-1.0.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==1.0.0",
-              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_ppc64le": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
-              "urls": [
-                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_0.21.2_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "docutils-0.21.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.21.2",
-              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
-              "urls": [
-                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_context_6.0.1.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco_context-6.0.1.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-context==6.0.1",
-              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
-              "urls": [
-                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_functools_4.1.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-functools==4.1.0",
-              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_win_amd64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "nh3==0.2.18",
-              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
-              "urls": [
-                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_markdown_it_py_3.0.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==3.0.0",
-              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
-              "urls": [
-                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_s390x": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.17.1",
-              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_win_amd64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
-              "urls": [
-                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_certifi_2024.8.30.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "certifi-2024.8.30.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2024.8.30",
-              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_mdurl_0.1.2_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "mdurl-0.1.2-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_11_0_arm64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_0.2.3_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_windows_x86_64"
-              ],
-              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.3",
-              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
-              "urls": [
-                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_s390x": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
-              "urls": [
-                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_backports_tarfile_1.2.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "backports-tarfile==1.2.0",
-              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
-              "urls": [
-                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_aarch64": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64"
-              ],
-              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==43.0.3",
-              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
-              "urls": [
-                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_jaraco_context_6.0.1_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-context==6.0.1",
-              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_zipp_3.20.2_py3_none_any": {
+          "rules_python_publish_deps_311_zipp_3_20_2_py3_none_any": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8313,7 +6337,617 @@
               ]
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_s390x": {
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_10_9_universal2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_2_18_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_1_0_0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "urls": [
+                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_musllinux_1_1_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_3_0_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_3_3_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+              "urls": [
+                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
+              "urls": [
+                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_2_32_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+              "urls": [
+                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_2_22_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_2_32_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_0_1_2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_25_4_1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
+              "urls": [
+                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_13_9_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_2_2_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_2_18_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_2024_8_30_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_25_4_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_armv7l": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_2_0_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_3_4_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_s390x": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8338,42 +6972,1411 @@
               ]
             }
           },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "36c95d4b70530b320b365659bb5034341316e6a9b30f0b25fa9c9eff4c27a204",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/61/73a007c74c37895fdf66e0edcd881f5eaa17a348ff02f4bb4bc906d61085/nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_musllinux_1_2_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
+              "urls": [
+                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_10_5_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more-itertools-10.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_ppc64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_3_0_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown-it-py-3.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_6_0_1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_1_2_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports_tarfile-1.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
+              "urls": [
+                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_0_21_2_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_macosx_10_12_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_0_1_2_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_8_5_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_0_21_2_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_8_5_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_4_1_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_28_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_5_1_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_ppc64le": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "34c03fa78e328c691f982b7c03d4423bdfd7da69cd707fe572f544cf74ac23ad",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/a7/375afcc710dbe2d64cfbd69e31f82f3e423d43737258af01f6a56d844085/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_2024_8_30_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_44_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_0_8_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_3_20_2_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_1_10_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_13_9_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_2_2_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_10_9_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_1_2_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_2_0_0_py2_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_0_2_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_2_22_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_musllinux_1_2_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_musllinux_1_1_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_s390x": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_11_0_arm64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_28_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_0_2_3_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32-ctypes-0.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_44_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_armv7l": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
+              "urls": [
+                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_3_10_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_win_amd64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_5_1_1_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_x86_64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_0_8_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_3_3_3_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_3_4_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_4_1_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco_functools-4.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_10_5_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more_itertools-10.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
+              "urls": [
+                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
+              ]
+            }
+          },
           "rules_python_publish_deps": {
             "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
             "ruleClassName": "hub_repository",
             "attributes": {
               "repo_name": "rules_python_publish_deps",
               "whl_map": {
-                "backports_tarfile": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1.2.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1.2.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "certifi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_2024.8.30_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_2024.8.30.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1_cp311_cp311_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_1.17.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "charset_normalizer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cryptography": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_manylinux_2_28_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3_cp39_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_43.0.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "docutils": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_0.21.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_0.21.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_3.10_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_3.10.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8.5.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8.5.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_classes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3.4.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3.4.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_context": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6.0.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6.0.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_functools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4.1.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4.1.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jeepney": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_0.8.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_0.8.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "keyring": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_25.4.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_25.4.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "markdown_it_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3.0.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "mdurl": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_0.1.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_0.1.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "more_itertools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more-itertools-10.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10.5.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10.5.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "nh3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_nh3_0.2.18.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pkginfo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1.10.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1.10.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pycparser": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_2.22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_2.22.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pygments": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_2.18.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_2.18.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pywin32_ctypes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0.2.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0.2.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "readme_renderer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44.0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_2.32.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_2.32.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests_toolbelt": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rfc3986": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2.0.0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2.0.0.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rich": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_13.9.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_13.9.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "secretstorage": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3.3.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3.3.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "twine": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_5.1.1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_5.1.1.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_2.2.3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_2.2.3.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "zipp": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_3.20.2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_3.20.2.tar.gz\",\"target_platforms\":null,\"version\":\"3.11\"}]"
+                "backports_tarfile": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1_2_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_1_2_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "certifi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_2024_8_30_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2024.8.30.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_2024_8_30_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_musllinux_1_1_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_musllinux_1_1_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.17.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_1_17_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "charset_normalizer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_10_9_universal2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_10_9_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_macosx_11_0_arm64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_3_4_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "cryptography": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_28_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_manylinux_2_28_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_cp39_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-43.0.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_43_0_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "docutils": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_0_21_2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.21.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_0_21_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_3_10_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.10.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_3_10_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8_5_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_8_5_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_classes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3_4_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_3_4_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_context": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6_0_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_6_0_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jaraco_functools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4_1_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_4_1_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "jeepney": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_0_8_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_0_8_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "keyring": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_25_4_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-25.4.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_25_4_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "markdown_it_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3_0_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_3_0_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "mdurl": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_0_1_2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_0_1_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "more_itertools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more-itertools-10.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10_5_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_10_5_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "nh3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_macosx_10_12_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_ppc64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_ppc64le\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_s390x\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_manylinux_2_17_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_aarch64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_armv7l\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_x86_64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_win_amd64\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"nh3-0.2.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_nh3_0_2_18_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pkginfo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1_10_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.10.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_1_10_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pycparser": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_2_22_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_2_22_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pygments": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_2_18_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pygments-2.18.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_2_18_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "pywin32_ctypes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0_2_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_0_2_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "readme_renderer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44_0_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-44.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_44_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "requests": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_2_32_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.32.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_2_32_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "requests_toolbelt": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1_0_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_1_0_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "rfc3986": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2_0_0_py2_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_2_0_0_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "rich": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_13_9_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.9.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_13_9_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "secretstorage": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3_3_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_3_3_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "twine": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_5_1_1_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-5.1.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_5_1_1_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_2_2_3_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-2.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_2_2_3_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "zipp": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_3_20_2_py3_none_any\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.20.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_3_20_2_tar_gz\",\"target_platforms\":null,\"version\":\"3.11\"}]"
               },
               "packages": [
                 "backports_tarfile",
@@ -8404,7 +8407,7 @@
               "groups": {}
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_musllinux_1_2_x86_64": {
+          "rules_python_publish_deps_311_idna_3_10_tar_gz": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8419,142 +8422,17 @@
                 "cp311_osx_x86_64",
                 "cp311_windows_x86_64"
               ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
-              "urls": [
-                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_2.32.3.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "requests-2.32.3.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.32.3",
-              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
-              "urls": [
-                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0.tar.gz": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0.tar.gz",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
-              "urls": [
-                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
-              "urls": [
-                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_keyring_25.4.1_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "keyring-25.4.1-py3-none-any.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==25.4.1",
-              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
-              "urls": [
-                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_idna_3.10_py3_none_any": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "idna-3.10-py3-none-any.whl",
+              "filename": "idna-3.10.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
               "requirement": "idna==3.10",
-              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
               "urls": [
-                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_charset_normalizer_3.4.0_cp311_cp311_macosx_10_9_universal2": {
+          "rules_python_publish_deps_311_nh3_0_2_18_cp37_abi3_musllinux_1_2_aarch64": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
@@ -8569,38 +8447,160 @@
                 "cp311_osx_x86_64",
                 "cp311_windows_x86_64"
               ],
-              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl",
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.4.0",
-              "sha256": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
-              "urls": [
-                "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_nh3_0.2.18_cp37_abi3_musllinux_1_2_armv7l": {
-            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "cp311_linux_aarch64",
-                "cp311_linux_arm",
-                "cp311_linux_ppc",
-                "cp311_linux_s390x",
-                "cp311_linux_x86_64",
-                "cp311_osx_aarch64",
-                "cp311_osx_x86_64",
-                "cp311_windows_x86_64"
-              ],
-              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "rules_python_publish_deps_311",
               "requirement": "nh3==0.2.18",
-              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
+              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
               "urls": [
-                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
+                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_0_2_18_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_1_10_0_py3_none_any": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
+              "urls": [
+                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_6_0_1_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco_context-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_1_17_1_cp311_cp311_manylinux_2_17_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_1_0_0_tar_gz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-toolbelt-1.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_3_4_0_cp311_cp311_musllinux_1_2_aarch64": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
               ]
             }
           }

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -290,7 +290,7 @@ def _create_whl_repos(
                     # This is no-op because pip is not used to download the wheel.
                     whl_library_args.pop("download_only", None)
 
-                    repo_name = whl_repo_name(pip_name, distribution.filename, distribution.sha256)
+                    repo_name = whl_repo_name(pip_name, distribution.filename)
                     whl_library_args["requirement"] = requirement.srcs.requirement
                     whl_library_args["urls"] = [distribution.url]
                     whl_library_args["sha256"] = distribution.sha256

--- a/python/private/pypi/whl_repo_name.bzl
+++ b/python/private/pypi/whl_repo_name.bzl
@@ -19,7 +19,7 @@ load("//python/private:normalize_name.bzl", "normalize_name")
 load(":parse_whl_name.bzl", "parse_whl_name")
 
 def _normalize_version(version):
-    version = version.replace("-", ".")
+    version = version.replace("-", "_")
     version = version.replace("+", "_")
     return version
 
@@ -54,4 +54,4 @@ def whl_repo_name(prefix, filename):
         parts.append(abi_tag)
         parts.append(platform_tag)
 
-    return "_".join(parts)
+    return "_".join(parts).replace(".", "_")

--- a/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
+++ b/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
@@ -20,14 +20,14 @@ load("//python/private/pypi:whl_repo_name.bzl", "whl_repo_name")  # buildifier: 
 _tests = []
 
 def _test_simple(env):
-    got = whl_repo_name("prefix", "foo-1.2.3-py3-none-any.whl", "deadbeef")
-    env.expect.that_str(got).equals("prefix_foo_py3_none_any_deadbeef")
+    got = whl_repo_name("prefix", "foo-1.2.3-py3-none-any.whl")
+    env.expect.that_str(got).equals("prefix_foo_1.2.3_py3_none_any")
 
 _tests.append(_test_simple)
 
 def _test_sdist(env):
-    got = whl_repo_name("prefix", "foo-1.2.3.tar.gz", "deadbeef000deadbeef")
-    env.expect.that_str(got).equals("prefix_foo_sdist_deadbeef")
+    got = whl_repo_name("prefix", "foo-1.2.3.tar.gz")
+    env.expect.that_str(got).equals("prefix_foo_1.2.3.tar.gz")
 
 _tests.append(_test_sdist)
 
@@ -35,13 +35,25 @@ def _test_platform_whl(env):
     got = whl_repo_name(
         "prefix",
         "foo-1.2.3-cp39.cp310-abi3-manylinux1_x86_64.manylinux_2_17_x86_64.whl",
-        "deadbeef000deadbeef",
     )
 
     # We only need the first segment of each
-    env.expect.that_str(got).equals("prefix_foo_cp39_abi3_manylinux_2_5_x86_64_deadbeef")
+    env.expect.that_str(got).equals("prefix_foo_1.2.3_cp39_abi3_manylinux_2_5_x86_64")
 
 _tests.append(_test_platform_whl)
+
+def _test_whl_local_version(env):
+    got = whl_repo_name(
+        "prefix",
+        "foo-1.2.3+7.g9c9466d-cp39-abi3-manylinux1_x86_64.manylinux_2_17_x86_64.whl",
+    )
+
+    # We only need the first segment of each
+    env.expect.that_str(got).equals(
+        "prefix_foo_1.2.3_7.g9c9466d_cp39_abi3_manylinux_2_5_x86_64",
+    )
+
+_tests.append(_test_whl_local_version)
 
 def whl_repo_name_test_suite(name):
     """Create the test suite.


### PR DESCRIPTION
Initially the repo name generate was very conservative and we had sha256
as the endings of the repo names. With this change we have more human
readable repository names. In order to still comply with the bazel label
rules, we are normalizing the versions to only have `_` and `.`
characters.

This is an alternative fix to the error message seen in
https://github.com/bazelbuild/rules_python/pull/1837#issuecomment-2143270349
