### PR TITLE
tests: fix the job name for the debian bzlmod gazelle job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -301,7 +301,7 @@ tasks:
   integration_test_bzlmod_build_file_generation_debian:
     <<: *reusable_build_test_all
     <<: *coverage_targets_example_bzlmod_build_file_generation
-    name: "examples/bzlmod_build_file_integration: Debian"
+    name: "examples/bzlmod_build_file_generation: Debian"
     working_directory: examples/bzlmod_build_file_generation
     platform: debian11
   integration_test_bzlmod_build_file_generation_macos:


### PR DESCRIPTION
The name was using "integration" when it should have been "generation"