### PR TITLE
chore: change the parse_all_requirements_files default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ A brief description of the categories of changes:
 {#v0-0-0-changed}
 ### Changed
 * (deps) bazel_skylib 1.6.1 -> 1.7.1
+* (pypi) The naming scheme for the `bzlmod` spoke repositories have changed as
+  all of the given `requirements.txt` files are now parsed by `default`, to
+  temporarily restore the behavior, you can use
+  {bzl:obj}`pip.parse.extra_hub_aliases`, which will be removed or made noop in
+  the future.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1393,7 +1393,7 @@
     },
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "0Qn7Q9FuTxYCxMKm2DsW7mbXYcxL71sS/l1baXvY1vA=",
+        "bzlTransitiveDigest": "V0b+JF59twRuc1t2aujwxPmb29degf+X0HjTZzFI2lo=",
         "usagesDigest": "GGeczTmsfE4YHAy32dV/jfOfbYmpyu/QGe35drFuZ5E=",
         "recordedFileInputs": {
           "@@other_module~//requirements_lock_3_11.txt": "a7d0061366569043d5efcf80e34a32c732679367cb3c831c4cdc606adc36d314",
@@ -3244,7 +3244,9 @@
               "whl_map": {
                 "absl_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"other_module_pip_311_absl_py\",\"target_platforms\":null,\"version\":\"3.11\"}]"
               },
-              "packages": [],
+              "packages": [
+                "absl_py"
+              ],
               "groups": {}
             }
           },
@@ -6588,7 +6590,7 @@
     },
     "@@rules_python~//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "SnuwsgZv1SGZz4jVPvwaEUwPTnea18fXIueD9vSR3sQ=",
+        "bzlTransitiveDigest": "9R8+CXzaV+FOv5NSr6mNrvF+hvnyouGXJh9E0JxC/7Q=",
         "usagesDigest": "O2O2oBIbKEglN2K3FECsRxUKVS/zg/6a86F3MO1ZtmY=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -786,7 +786,7 @@ find in case extra indexes are specified.
             default = True,
         ),
         "parse_all_requirements_files": attr.bool(
-            default = False,
+            default = True,
             doc = """\
 A temporary flag to enable users to make `pip` extension result always
 the same independent of the whether transitive dependencies use {bzl:attr}`experimental_index_url` or not.


### PR DESCRIPTION
With this PR we are changing the defaults in the upcoming `0.39` version, and
if all goes well, the release after that will be `1.0`.

Work towards #1361
