### PR TITLE
feat: add attrs/fields for the runtime's ABI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ A brief description of the categories of changes:
 * (toolchain) Support for freethreaded Python toolchains is now available. Use
   the config flag `//python/config_settings:py_freethreaded` to toggle the
   selection of the free-threaded toolchains.
+* (toolchain) {obj}`py_runtime.abi_flags` attribute and
+  {obj}`PyRuntimeInfo.abi_flags` field added.
 
 {#v0-0-0-removed}
 ### Removed

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -475,6 +475,7 @@ bzl_library(
     srcs = ["py_runtime_rule.bzl"],
     deps = [
         ":attributes_bzl",
+        ":flags_bzl",
         ":py_internal_bzl",
         ":py_runtime_info_bzl",
         ":reexports_bzl",

--- a/python/private/py_runtime_info.bzl
+++ b/python/private/py_runtime_info.bzl
@@ -67,7 +67,8 @@ def _PyRuntimeInfo_init(
         bootstrap_template = None,
         interpreter_version_info = None,
         stage2_bootstrap_template = None,
-        zip_main_template = None):
+        zip_main_template = None,
+        abi_flags = ""):
     if (interpreter_path and interpreter) or (not interpreter_path and not interpreter):
         fail("exactly one of interpreter or interpreter_path must be specified")
 
@@ -105,6 +106,7 @@ def _PyRuntimeInfo_init(
         stub_shebang = DEFAULT_STUB_SHEBANG
 
     return {
+        "abi_flags": abi_flags,
         "bootstrap_template": bootstrap_template,
         "coverage_files": coverage_files,
         "coverage_tool": coverage_tool,
@@ -133,6 +135,11 @@ the same conventions as the standard CPython interpreter.
 """,
     init = _PyRuntimeInfo_init,
     fields = {
+        "abi_flags": """
+:type: str
+
+The runtime's ABI flags, i.e. `sys.abiflags`.
+""",
         "bootstrap_template": """
 :type: File
 


### PR DESCRIPTION
This adds attributes and fields for storing the runtimes ABI flags value, i.e. `sys.abiflags`.

For freethreaded interpreters, the abi flags contain `t`, which is used creating e.g.
virtualenvs.

The attribute can be directly specified, or if it's not, will be computed based on the
`--py_freethreaded` flag.