### PR TITLE
fix: skip precompiling if using Bazel-builtin PyRuntimeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ A brief description of the categories of changes:
 
 {#v0-0-0-fixed}
 ### Fixed
-* Nothing yet
+* (precompiling) Skip precompiling (instead of erroring) if the legacy
+  `@bazel_tools//tools/python:autodetecting_toolchain` is being used
+  ([#2364](https://github.com/bazelbuild/rules_python/issues/2364)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/common_bazel.bzl
+++ b/python/private/common_bazel.bzl
@@ -166,10 +166,13 @@ def _precompile(ctx, src, *, use_pycache):
 
     stem = src.basename[:-(len(src.extension) + 1)]
     if use_pycache:
-        if not target_toolchain.pyc_tag:
-            # This is most likely because of a "runtime toolchain", i.e. the
-            # autodetecting toolchain, or some equivalent toolchain that can't
-            # assume to know the runtime Python version at build time.
+        if not hasattr(target_toolchain, "pyc_tag") or not target_toolchain.pyc_tag:
+            # This is likely one of two situations:
+            # 1. The pyc_tag attribute is missing because it's the Bazel-builtin
+            #    PyRuntimeInfo object.
+            # 2. It's a "runtime toolchain", i.e. the autodetecting toolchain,
+            #    or some equivalent toolchain that can't assume to know the
+            #    runtime Python version at build time.
             # Instead of failing, just don't generate any pyc.
             return None
         pyc_path = "__pycache__/{stem}.{tag}.pyc".format(


### PR DESCRIPTION
When the `@bazel_tools//python/tools:python_autodetecting` toolchain is used, it returns
the Bazel-builtin PyRuntimeInfo provider. Because this provider doesn't support the
additional fields needed for precompiling (`pyc_tag`, among others), it would result in
an attribute error.

To fix, detect the absence of the `pyc_tag` attribute and return early, as is done when
the pyc_tag field is empty.

Fixes https://github.com/bazelbuild/rules_python/issues/2364