### PR TITLE
chore: change bcr presubmit to drop bazel 6, add last_rc (bazel 8)

### DIFF
--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -16,7 +16,8 @@ bcr_test_module:
   module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    bazel: [6.x, 7.x]
+    # last_rc is to get latest 8.x release. Replace with 8.x when available.
+    bazel: [7.x, last_rc]
   tasks:
     run_tests:
       name: "Run test module"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -16,7 +16,8 @@ bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    bazel: [6.x, 7.x]
+    # last_rc is to get latest 8.x release. Replace with 8.x when available.
+    bazel: [7.x, last_rc]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
This removes Bazel 6 and adds last_rc (Bazel 8) in our BCR presubmit config. Right now, BCR releases fail because they try to test with Bazel 6, which doesn't work.