### PR TITLE
fix: keep import path values if Bazel-builtin PyInfo is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ Unreleased changes template.
 
 {#v0-0-0-fixed}
 ### Fixed
-* Nothing yet.
+* (rules) Don't drop custom import paths if Bazel-builtin PyInfo is removed.
+  ([2414](https://github.com/bazelbuild/rules_python/issues/2414)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/common.bzl
+++ b/python/private/common.bzl
@@ -263,15 +263,22 @@ def filter_to_py_srcs(srcs):
     return [f for f in srcs if f.extension == "py"]
 
 def collect_imports(ctx, semantics):
-    return depset(direct = semantics.get_imports(ctx), transitive = [
-        dep[PyInfo].imports
-        for dep in ctx.attr.deps
-        if PyInfo in dep
-    ] + [
-        dep[BuiltinPyInfo].imports
-        for dep in ctx.attr.deps
-        if BuiltinPyInfo in dep
-    ] if BuiltinPyInfo != None else [])
+    """Collect the direct and transitive `imports` strings.
+
+    Args:
+        ctx: {type}`ctx` the current target ctx
+        semantics: semantics object for fetching direct imports.
+
+    Returns:
+        {type}`depset[str]` of import paths
+    """
+    transitive = []
+    for dep in ctx.attr.deps:
+        if PyInfo in dep:
+            transitive.append(dep[PyInfo].imports)
+        if BuiltinPyInfo != None and BuiltinPyInfo in dep:
+            transitive.append(dep[BuiltinPyInfo].imports)
+    return depset(direct = semantics.get_imports(ctx), transitive = transitive)
 
 def collect_runfiles(ctx, files = depset()):
     """Collects the necessary files from the rule's context.


### PR DESCRIPTION
The collect_imports() function added import strings from BuiltinPyInfo if it was non-None.
However, operator precedence caused the `if-else` ternary to ignore both list comprehensions
(one for PyInfo and one for BuiltinPyInfo) if BuiltinPyInfo was None.

To fix, I rewrote the function as a regular for loop to eliminate the ambiguous looking
ternary expression.

Fixes: https://github.com/bazelbuild/rules_python/issues/2414