### PR TITLE
fix(uv): Fix sha256 for uv binary for aarch64-apple-darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ Other changes:
 * (pypi): Correctly handle multiple versions of the same package in the requirements
   files which is useful when including different PyTorch builds (e.g. <pytorch+cpu> vs <pytorch+cu118> ) for different target platforms.
   Fixes ([2337](https://github.com/bazelbuild/rules_python/issues/2337)).
+* (uv): Correct the sha256sum for the `uv` binary for aarch64-apple-darwin.
+  Fixes ([2411](https://github.com/bazelbuild/rules_python/issues/2411)).
 
 {#v0-0-0-added}
 ### Added

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -9623,7 +9623,7 @@
     },
     "@@rules_python~//python/uv:extensions.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "umgu1yR4Wmqb1pJa+9hAcs9dPbeqBsPLceKiaEg3DdQ=",
+        "bzlTransitiveDigest": "wVkXn96Vi6Bn1BRJ4R0bOAbUFvh4k54kimcXSd11Y3g=",
         "usagesDigest": "wWx9DCrTsAgJQmDRUcO+EJrPKJEDsXpZbjzC0HVdde0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/python/uv/private/versions.bzl
+++ b/python/uv/private/versions.bzl
@@ -70,7 +70,7 @@ UV_PLATFORMS = {
 UV_TOOL_VERSIONS = {
     "0.4.25": {
         "aarch64-apple-darwin": struct(
-            sha256 = "35786030f926e3d34d186edc0ea3989698e57755852af9ae4b39da5109abcbfa",
+            sha256 = "bb2ff4348114ef220ca52e44d5086640c4a1a18f797a5f1ab6f8559fc37b1230",
         ),
         "aarch64-unknown-linux-gnu": struct(
             sha256 = "4485852eb8013530c4275cd222c0056ce123f92742321f012610f1b241463f39",


### PR DESCRIPTION
`uv` cannot be used on aarch64-apple-darwin computers because the sha256sum is incorrect.

The correct version can be seen [here](https://github.com/astral-sh/uv/releases/download/0.4.25/uv-aarch64-apple-darwin.tar.gz.sha256).

Fixes #2411
