### PR TITLE
fix: Rename protobuf to com_google_protobuf

### DIFF
--- a/python/private/py_repositories.bzl
+++ b/python/private/py_repositories.bzl
@@ -62,7 +62,7 @@ def py_repositories():
 
     # Needed by rules_cc, triggerred by @rules_java_prebuilt in Bazel by using @rules_cc//cc:defs.bzl
     http_archive(
-        name = "protobuf",
+        name = "com_google_protobuf",
         sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
         strip_prefix = "protobuf-27.0",
         url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",


### PR DESCRIPTION
protobuf needs to be consistently called com_google_protobuf if repository needs to support both Bzlmod and WORKSPACE mode.
