### PR TITLE
tests: make some tests compatible with Bazel 9 fix various tests relying on Bazel builtin providers existing

### DIFF
--- a/tests/base_rules/base_tests.bzl
+++ b/tests/base_rules/base_tests.bzl
@@ -43,7 +43,7 @@ _produces_builtin_py_info = rule(
 )
 
 def _produces_py_info_impl(ctx):
-    return _create_py_info(ctx, BuiltinPyInfo)
+    return _create_py_info(ctx, PyInfo)
 
 _produces_py_info = rule(
     implementation = _produces_py_info_impl,
@@ -86,6 +86,9 @@ def _py_info_propagation_test_impl(env, target, provider_type):
     info.imports().contains("custom-import")
 
 def _test_py_info_propagation_builtin(name, config):
+    if not BuiltinPyInfo:
+        rt_util.skip_test(name = name)
+        return
     _py_info_propagation_setup(
         name,
         config,

--- a/tests/base_rules/py_info/py_info_tests.bzl
+++ b/tests/base_rules/py_info/py_info_tests.bzl
@@ -39,7 +39,7 @@ def _provide_py_info_impl(ctx):
         providers.append(PyInfo(**kwargs))
 
     # Handle Bazel 6 or if Bazel autoloading is enabled
-    if not config.enable_pystar or PyInfo != BuiltinPyInfo:
+    if not config.enable_pystar or (BuiltinPyInfo and PyInfo != BuiltinPyInfo):
         providers.append(BuiltinPyInfo(**{
             k: kwargs[k]
             for k in (

--- a/tests/config_settings/transition/multi_version_tests.bzl
+++ b/tests/config_settings/transition/multi_version_tests.bzl
@@ -49,7 +49,8 @@ def _test_py_test_with_transition(name):
 def _test_py_test_with_transition_impl(env, target):
     # Nothing to assert; we just want to make sure it builds
     env.expect.that_target(target).has_provider(PyInfo)
-    env.expect.that_target(target).has_provider(BuiltinPyInfo)
+    if BuiltinPyInfo:
+        env.expect.that_target(target).has_provider(BuiltinPyInfo)
 
 _tests.append(_test_py_test_with_transition)
 
@@ -70,7 +71,8 @@ def _test_py_binary_with_transition(name):
 def _test_py_binary_with_transition_impl(env, target):
     # Nothing to assert; we just want to make sure it builds
     env.expect.that_target(target).has_provider(PyInfo)
-    env.expect.that_target(target).has_provider(BuiltinPyInfo)
+    if BuiltinPyInfo:
+        env.expect.that_target(target).has_provider(BuiltinPyInfo)
 
 _tests.append(_test_py_binary_with_transition)
 

--- a/tests/py_runtime_pair/py_runtime_pair_tests.bzl
+++ b/tests/py_runtime_pair/py_runtime_pair_tests.bzl
@@ -76,6 +76,9 @@ def _test_basic_impl(env, target):
 _tests.append(_test_basic)
 
 def _test_builtin_py_info_accepted(name):
+    if not BuiltinPyRuntimeInfo:
+        rt_util.skip_test(name = name)
+        return
     rt_util.helper_target(
         _provides_builtin_py_runtime_info,
         name = name + "_runtime",


### PR DESCRIPTION
In Bazel 9, the builtin symbols don't exist. This fixes some tests that fail when those symbols
are missing.