### PR TITLE
tests: make workspace CI jobs enable workspace mode

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -142,7 +142,7 @@ tasks:
     platform: macos
   windows_workspace:
     <<: *reusable_config
-    <<: *common_workspace_flags_min_bazel
+    <<: *common_workspace_flags
     name: "Default: Windows, workspace"
     platform: windows
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -132,6 +132,7 @@ tasks:
     bazel: last_rc
   ubuntu_workspace:
     <<: *reusable_config
+    <<: *common_workspace_flags
     name: "Default: Ubuntu, workspace"
     platform: ubuntu2004
   mac_workspace:
@@ -141,6 +142,7 @@ tasks:
     platform: macos
   windows_workspace:
     <<: *reusable_config
+    <<: *common_workspace_flags
     name: "Default: Windows, workspace"
     platform: windows
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -145,6 +145,27 @@ tasks:
     <<: *common_workspace_flags
     name: "Default: Windows, workspace"
     platform: windows
+    # Most of tests/integration are failing on Windows w/workspace. Skip them
+    # for now until we can look into it.
+    build_targets:
+      - "--"
+      - "..."
+      # As a regression test for #225, check that wheel targets still build when
+      # their package path is qualified with the repo name.
+      - "@rules_python//examples/wheel/..."
+    build_flags:
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
+      - "--keep_going"
+      - "--build_tag_filters=-integration-test"
+      - "--config=bazel7.x"
+    test_targets:
+      - "--"
+      - "..."
+    test_flags:
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
+      - "--test_tag_filters=-integration-test"
 
   debian:
     <<: *reusable_config

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -142,7 +142,7 @@ tasks:
     platform: macos
   windows_workspace:
     <<: *reusable_config
-    <<: *common_workspace_flags
+    <<: *common_workspace_flags_min_bazel
     name: "Default: Windows, workspace"
     platform: windows
 

--- a/tests/integration/local_toolchains/test.py
+++ b/tests/integration/local_toolchains/test.py
@@ -18,8 +18,9 @@ class LocalToolchainTest(unittest.TestCase):
             [shell_path, "-c", "import sys; print(sys.executable)"],
             text=True,
         )
-        expected = expected.strip()
-        self.assertEqual(expected, sys.executable)
+        expected = expected.strip().lower()
+        # Normalize case: Windows may have case differences
+        self.assertEqual(expected.lower(), sys.executable.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The CI setups claiming to run in WORKSPACE mode were wrong. This fixes it.

Disable integration tests on Windows WORKSPACE mode. They are failing: https://buildkite.com/bazel/rules-python-python/builds/9791#01934eac-3a03-445d-ad53-6683371ca289
Example failure: `java.lang.UnsatisfiedLinkError: 'int com.google.devtools.build.lib.windows.WindowsFileOperations.nativeIsSymlinkOrJunction(java.lang.String, boolean[], java.lang.String[])'`
