### PR TITLE
fix: correctly obtain relative path required for the venv created by `--bootstrap_impl=script`

### DIFF
--- a/python/private/py_executable_bazel.bzl
+++ b/python/private/py_executable_bazel.bzl
@@ -372,7 +372,7 @@ def _create_venv(ctx, executable, output_prefix, imports, runtime_details):
         interpreter_actual_path = runtime.interpreter.short_path  # Always relative to .runfiles/${workspace}
 
         escapes = 2  # To escape out of ${target}.venv/bin
-        escapes += executable.short_path.count("/") # To escape into .runfiles/${workspace}
+        escapes += executable.short_path.count("/")  # To escape into .runfiles/${workspace}
 
         parent = "/".join([".."] * escapes)
         rel_path = parent + "/" + interpreter_actual_path

--- a/python/private/py_executable_bazel.bzl
+++ b/python/private/py_executable_bazel.bzl
@@ -360,7 +360,8 @@ def relative_path(from_, to):
     to_parts = to.split("/")
 
     # Strip common leading parts from both paths
-    for _ in range(len(to)):
+    n = min(len(from_parts), len(to_parts))
+    for _ in range(n):
         if from_parts[0] == to_parts[0]:
             from_parts.pop(0)
             to_parts.pop(0)

--- a/python/private/py_executable_bazel.bzl
+++ b/python/private/py_executable_bazel.bzl
@@ -360,9 +360,7 @@ def relative_path(from_, to):
     to_parts = to.split("/")
 
     # Strip common leading parts from both paths
-    # (no while loops in starlark :( )
-    n = min(len(from_parts), len(to_parts))
-    for _ in range(n):
+    for _ in range(len(to)):
         if from_parts[0] == to_parts[0]:
             from_parts.pop(0)
             to_parts.pop(0)

--- a/python/private/py_executable_bazel.bzl
+++ b/python/private/py_executable_bazel.bzl
@@ -344,8 +344,6 @@ def _create_zip_main(ctx, *, stage2_bootstrap, runtime_details, venv):
     )
     return output
 
-# Return a relative path from one path to another, where both paths are each
-# relative paths from a common root.
 def relative_path(from_, to):
     """Compute a relative path from one path to another.
 

--- a/python/private/py_executable_bazel.bzl
+++ b/python/private/py_executable_bazel.bzl
@@ -347,6 +347,17 @@ def _create_zip_main(ctx, *, stage2_bootstrap, runtime_details, venv):
 # Return a relative path from one path to another, where both paths are each
 # relative paths from a common root.
 def relative_path(from_, to):
+    """Compute a relative path from one path to another.
+
+    Args:
+        from_: {type}`str` the starting directory. Note that it should be
+            a directory because relative-symlinks are relative to the
+            directory the symlink resides in.
+        to: {type}`str` the path that `from_` wants to point to
+
+    Returns:
+        {type}`str` a relative path
+    """
     from_parts = from_.split("/")
     to_parts = to.split("/")
 

--- a/python/private/stage1_bootstrap_template.sh
+++ b/python/private/stage1_bootstrap_template.sh
@@ -135,6 +135,7 @@ fi
 if [[ ! -x "$python_exe" ]]; then
   if [[ ! -e "$python_exe" ]]; then
     echo >&2 "ERROR: Python interpreter not found: $python_exe"
+    ls -l $python_exe >&2
     exit 1
   elif [[ ! -x "$python_exe" ]]; then
     echo >&2 "ERROR: Python interpreter not executable: $python_exe"

--- a/tests/bootstrap_impls/BUILD.bazel
+++ b/tests/bootstrap_impls/BUILD.bazel
@@ -89,4 +89,4 @@ sh_py_run_test(
     target_compatible_with = _SUPPORTS_BOOTSTRAP_SCRIPT,
 )
 
-relative_path_test_suite(name = "relative_path_test")
+relative_path_test_suite(name = "relative_path_tests")

--- a/tests/bootstrap_impls/BUILD.bazel
+++ b/tests/bootstrap_impls/BUILD.bazel
@@ -87,3 +87,7 @@ sh_py_run_test(
     sh_src = "sys_executable_inherits_sys_path_test.sh",
     target_compatible_with = _SUPPORTS_BOOTSTRAP_SCRIPT,
 )
+
+load(":venv_relative_path_tests.bzl", "relative_path_test_suite")
+
+relative_path_test_suite("relative_path_test")

--- a/tests/bootstrap_impls/BUILD.bazel
+++ b/tests/bootstrap_impls/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
 load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test", "sh_py_run_test")
+load(":venv_relative_path_tests.bzl", "relative_path_test_suite")
 
 _SUPPORTS_BOOTSTRAP_SCRIPT = select({
     "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -88,6 +89,4 @@ sh_py_run_test(
     target_compatible_with = _SUPPORTS_BOOTSTRAP_SCRIPT,
 )
 
-load(":venv_relative_path_tests.bzl", "relative_path_test_suite")
-
-relative_path_test_suite("relative_path_test")
+relative_path_test_suite(name = "relative_path_test")

--- a/tests/bootstrap_impls/a/b/c/BUILD.bazel
+++ b/tests/bootstrap_impls/a/b/c/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
-load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test", "sh_py_run_test")
+load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test")
 
 _SUPPORTS_BOOTSTRAP_SCRIPT = select({
     "@platforms//os:windows": ["@platforms//:incompatible"],

--- a/tests/bootstrap_impls/a/b/c/BUILD.bazel
+++ b/tests/bootstrap_impls/a/b/c/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable=bzl-visibility
+load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test", "sh_py_run_test")
+
+_SUPPORTS_BOOTSTRAP_SCRIPT = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+}) if IS_BAZEL_7_OR_HIGHER else ["@platforms//:incompatible"]
+
+py_reconfig_test(
+    name = "nested_dir_test",
+    srcs = ["nested_dir_test.py"],
+    bootstrap_impl = "script",
+    main = "nested_dir_test.py",
+    target_compatible_with = _SUPPORTS_BOOTSTRAP_SCRIPT,
+)

--- a/tests/bootstrap_impls/a/b/c/nested_dir_test.py
+++ b/tests/bootstrap_impls/a/b/c/nested_dir_test.py
@@ -1,0 +1,22 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test that the binary being a different directory depth than the underlying interpreter works."""
+
+import unittest
+
+class RunsTest(unittest.TestCase):
+    def test_runs(self):
+        pass
+
+unittest.main()

--- a/tests/bootstrap_impls/a/b/c/nested_dir_test.py
+++ b/tests/bootstrap_impls/a/b/c/nested_dir_test.py
@@ -15,8 +15,10 @@
 
 import unittest
 
+
 class RunsTest(unittest.TestCase):
     def test_runs(self):
         pass
+
 
 unittest.main()

--- a/tests/bootstrap_impls/venv_relative_path_tests.bzl
+++ b/tests/bootstrap_impls/venv_relative_path_tests.bzl
@@ -31,20 +31,6 @@ def _relative_path_test(env):
 
     env.expect.that_str(
         relative_path(
-            from_ = "../a/b",
-            to = "../c/d",
-        ),
-    ).equals("../../c/d")
-
-    env.expect.that_str(
-        relative_path(
-            from_ = "../a/b",
-            to = "../../c/d",
-        ),
-    ).equals("../../../c/d")
-
-    env.expect.that_str(
-        relative_path(
             from_ = "a/b/c",
             to = "a/d",
         ),

--- a/tests/bootstrap_impls/venv_relative_path_tests.bzl
+++ b/tests/bootstrap_impls/venv_relative_path_tests.bzl
@@ -1,0 +1,121 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Unit tests for yaml.bzl"
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//python/private:py_executable_bazel.bzl", "relative_path")  # buildifier: disable=bzl-visibility
+
+def _relative_path_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic test cases
+
+    asserts.equals(
+        env,
+        "../../c/d",
+        relative_path(
+            from_ = "a/b",
+            to = "c/d",
+        ),
+    )
+
+    asserts.equals(
+        env,
+        "../../c/d",
+        relative_path(
+            from_ = "../a/b",
+            to = "../c/d",
+        ),
+    )
+
+    asserts.equals(
+        env,
+        "../../../c/d",
+        relative_path(
+            from_ = "../a/b",
+            to = "../../c/d",
+        ),
+    )
+
+    asserts.equals(
+        env,
+        "../../d",
+        relative_path(
+            from_ = "a/b/c",
+            to = "a/d",
+        ),
+    )
+
+    asserts.equals(
+        env,
+        "d/e",
+        relative_path(
+            from_ = "a/b/c",
+            to = "a/b/c/d/e",
+        ),
+    )
+
+    # Real examples
+
+    # external py_binary uses external python runtime
+    asserts.equals(
+        env,
+        "../../../../../rules_python~~python~python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        relative_path(
+            from_ = "../rules_python~/python/private/_py_console_script_gen_py.venv/bin",
+            to = "../rules_python~~python~python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        ),
+    )
+
+    # internal py_binary uses external python runtime
+    asserts.equals(
+        env,
+        "../../../../rules_python~~python~python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        relative_path(
+            from_ = "test/version_default.venv/bin",
+            to = "../rules_python~~python~python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        ),
+    )
+
+    # external py_binary uses internal python runtime
+    # asserts.equals(
+    #    env,
+    #    "???",
+    #    relative_path(
+    #        from_ = "../rules_python~/python/private/_py_console_script_gen_py.venv/bin",
+    #        to = "python/python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+    #    ),
+    #)
+    # ^ TODO: Technically we can infer ".." to be the workspace name?
+
+    # internal py_binary uses internal python runtime
+    asserts.equals(
+        env,
+        "../../../python/python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        relative_path(
+            from_ = "scratch/main.venv/bin",
+            to = "python/python_3_9_x86_64-unknown-linux-gnu/bin/python3",
+        ),
+    )
+
+    return unittest.end(env)
+
+relative_path_test = unittest.make(
+    _relative_path_test_impl,
+    attrs = {},
+)
+
+def relative_path_test_suite(name):
+    unittest.suite(name, relative_path_test)

--- a/tests/bootstrap_impls/venv_relative_path_tests.bzl
+++ b/tests/bootstrap_impls/venv_relative_path_tests.bzl
@@ -14,7 +14,7 @@
 
 "Unit tests for yaml.bzl"
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//python/private:py_executable_bazel.bzl", "relative_path")  # buildifier: disable=bzl-visibility
 
 def _relative_path_test_impl(ctx):
@@ -117,5 +117,5 @@ relative_path_test = unittest.make(
     attrs = {},
 )
 
-def relative_path_test_suite(name):
+def relative_path_test_suite(*, name):
     unittest.suite(name, relative_path_test)


### PR DESCRIPTION
Computing the relative path from the venv interpreter to the underlying interpreter was
incorrectly using the actual interpreter's directory depth, not the venv interpreter's
directory depth, when computing the distance from the venv interpreter to the runfiles root.
The net effect is the correct relative path would only be computed for binaries with
the same directory depth as the actual interpreter (e.g. 2).

This went undetected in CI because the tests for this logic just happen to have the
same directory depth as the actual interpreter used.

To fix, compute the relative path to the runfiles root using the venv interpreter
directory. Also added a test in a more nested directory to test this case.

Along the way:
* Change relative path computation to compute a minimum relative path.
* Fix the internals to pass a runfiles-root relative path, not main-repo relative path,
  for the actual interpreter, as intended.


Fixes https://github.com/bazelbuild/rules_python/issues/2169