### PR TITLE
fix: upgrade to bazel_features 1.21.0 for Bazel 8 rc3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Other changes:
 * (binaries/tests) For {obj}`--bootstrap_impl=script`, a binary-specific (but
   otherwise empty) virtual env is used to customize `sys.path` initialization.
 * (deps) bazel_skylib 1.7.0 (workspace; bzlmod already specifying that version)
+* (deps) bazel_features 1.21.0; necessary for compatiblity with Bazel 8 rc3
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "bazel_features", version = "1.9.1")
+bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.16")
 bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
bazel_features has a bug where it doesn't detect Bazel 8 rc3 correctly. This is 
fixed in release 1.21.0.

From the discussion on https://github.com/bazel-contrib/bazel_features/issues/82,
it's likely this only occurs due to the "rc" notation of the Bazel release, so an
earlier bazel_features version will probably work fine once Bazel 8 is no longer rc.