### PR TITLE
fix: Propagate common kwargs to sphinx_run

### DIFF
--- a/sphinxdocs/private/sphinx.bzl
+++ b/sphinxdocs/private/sphinx.bzl
@@ -190,6 +190,7 @@ def sphinx_docs(
     sphinx_run(
         name = name + ".run",
         docs = name,
+        **common_kwargs
     )
 
     build_test(


### PR DESCRIPTION
This ensures tags like `manual` (and other attributes) are copied into the `{name}.run`
target and properly respected.


Fixes https://github.com/bazelbuild/rules_python/issues/2441
