### PR TITLE
deps: upgrade to stardoc 0.7.2 for Bazel 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Other changes:
   otherwise empty) virtual env is used to customize `sys.path` initialization.
 * (deps) bazel_skylib 1.7.0 (workspace; bzlmod already specifying that version)
 * (deps) bazel_features 1.21.0; necessary for compatiblity with Bazel 8 rc3
+* (deps) stardoc 0.7.2 to support Bazel 8.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -71,7 +71,7 @@ pip.parse(
 use_repo(pip, "rules_python_publish_deps")
 
 # Not a dev dependency to allow usage of //sphinxdocs code, which refers to stardoc repos.
-bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.2", repo_name = "io_bazel_stardoc")
 
 # ===== DEV ONLY DEPS AND SETUP BELOW HERE =====
 bazel_dep(name = "rules_bazel_integration_test", version = "0.26.1", dev_dependency = True)


### PR DESCRIPTION
Stardoc 0.7.2 fixes a bug with Bazel 8 where a symbol was undefined. Upgrading to that
version makes the Bazel 8 CI job that builds our docs pass.

Fixes https://github.com/bazelbuild/rules_python/issues/2448