### PR TITLE
chore: auto compute prelease setting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,6 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          prerelease: ${{ contains(github.ref, '-rc') }}
           fail_on_unmatched_files: true
           files: rules_python-*.tar.gz


### PR DESCRIPTION
This makes the release workflow automatically compute the prelease setting based on the
tag name being processed. It looks for the "-rc" text in the tag to do this.