### PR TITLE
feat(pypi): support freethreaded in experimental_index_url

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -124,6 +124,13 @@ dev_pip.parse(
 dev_pip.parse(
     download_only = True,
     experimental_index_url = "https://pypi.org/simple",
+    hub_name = "dev_pip",
+    python_version = "3.13.0",
+    requirements_lock = "//docs:requirements.txt",
+)
+dev_pip.parse(
+    download_only = True,
+    experimental_index_url = "https://pypi.org/simple",
     hub_name = "pypiserver",
     python_version = "3.11",
     requirements_lock = "//examples/wheel:requirements_server.txt",

--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -106,6 +106,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "is_py_non_freethreaded",
+    flag_values = {":py_freethreaded": FreeThreadedFlag.NO},
+    visibility = ["//visibility:public"],
+)
+
 # pip.parse related flags
 
 string_flag(

--- a/python/private/pypi/pkg_aliases.bzl
+++ b/python/private/pypi/pkg_aliases.bzl
@@ -298,7 +298,9 @@ def get_filename_config_settings(
         else:
             py = "py3"
 
-        if parsed.abi_tag.startswith("cp"):
+        if parsed.abi_tag.startswith("cp") and parsed.abi_tag.endswith("t"):
+            abi = "cpt"
+        elif parsed.abi_tag.startswith("cp"):
             abi = "cp"
         else:
             abi = parsed.abi_tag

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -287,7 +287,7 @@ def _whl_library_impl(rctx):
                 p.target_platform
                 for p in whl_target_platforms(
                     platform_tag = parsed_whl.platform_tag,
-                    abi_tag = parsed_whl.abi_tag,
+                    abi_tag = parsed_whl.abi_tag.strip("tm"),
                 )
             ]
 

--- a/python/private/pypi/whl_target_platforms.bzl
+++ b/python/private/pypi/whl_target_platforms.bzl
@@ -89,6 +89,10 @@ def select_whls(*, whls, want_platforms = [], logger = None):
         want_abis[abi] = None
         want_abis[abi + "m"] = None
 
+        # Also add freethreaded wheels if we find them since we started supporting them
+        _want_platforms["{}t_{}".format(abi, os_cpu)] = None
+        want_abis[abi + "t"] = None
+
     want_platforms = sorted(_want_platforms)
 
     candidates = {}

--- a/tests/pypi/config_settings/config_settings_tests.bzl
+++ b/tests/pypi/config_settings/config_settings_tests.bzl
@@ -39,6 +39,7 @@ _flag = struct(
     pip_whl_osx_arch = lambda x: (str(Label("//python/config_settings:pip_whl_osx_arch")), str(x)),
     py_linux_libc = lambda x: (str(Label("//python/config_settings:py_linux_libc")), str(x)),
     python_version = lambda x: (str(Label("//python/config_settings:python_version")), str(x)),
+    py_freethreaded = lambda x: (str(Label("//python/config_settings:py_freethreaded")), str(x)),
 )
 
 def _analysis_test(*, name, dist, want, config_settings = [_flag.platform("linux_aarch64")]):
@@ -286,6 +287,38 @@ def _test_py_none_any_versioned(name):
 
 _tests.append(_test_py_none_any_versioned)
 
+def _test_cp_whl_is_not_prefered_over_py3_non_freethreaded(name):
+    _analysis_test(
+        name = name,
+        dist = {
+            "is_cp3.7_cp3x_abi3_any": "py3_abi3",
+            "is_cp3.7_cp3x_cpt_any": "cp",
+            "is_cp3.7_cp3x_none_any": "py3",
+        },
+        want = "py3_abi3",
+        config_settings = [
+            _flag.py_freethreaded("no"),
+        ],
+    )
+
+_tests.append(_test_cp_whl_is_not_prefered_over_py3_non_freethreaded)
+
+def _test_cp_whl_is_not_prefered_over_py3_freethreaded(name):
+    _analysis_test(
+        name = name,
+        dist = {
+            "is_cp3.7_cp3x_abi3_any": "py3_abi3",
+            "is_cp3.7_cp3x_cp_any": "cp",
+            "is_cp3.7_cp3x_none_any": "py3",
+        },
+        want = "py3",
+        config_settings = [
+            _flag.py_freethreaded("yes"),
+        ],
+    )
+
+_tests.append(_test_cp_whl_is_not_prefered_over_py3_freethreaded)
+
 def _test_cp_cp_whl(name):
     _analysis_test(
         name = name,
@@ -412,6 +445,7 @@ def _test_windows(name):
         name = name,
         dist = {
             "is_cp3.7_cp3x_cp_windows_x86_64": "whl",
+            "is_cp3.7_cp3x_cpt_windows_x86_64": "whl_freethreaded",
         },
         want = "whl",
         config_settings = [
@@ -420,6 +454,22 @@ def _test_windows(name):
     )
 
 _tests.append(_test_windows)
+
+def _test_windows_freethreaded(name):
+    _analysis_test(
+        name = name,
+        dist = {
+            "is_cp3.7_cp3x_cp_windows_x86_64": "whl",
+            "is_cp3.7_cp3x_cpt_windows_x86_64": "whl_freethreaded",
+        },
+        want = "whl_freethreaded",
+        config_settings = [
+            _flag.platform("windows_x86_64"),
+            _flag.py_freethreaded("yes"),
+        ],
+    )
+
+_tests.append(_test_windows_freethreaded)
 
 def _test_osx(name):
     _analysis_test(

--- a/tests/pypi/pkg_aliases/pkg_aliases_test.bzl
+++ b/tests/pypi/pkg_aliases/pkg_aliases_test.bzl
@@ -288,6 +288,14 @@ def _test_multiplatform_whl_aliases_filename(env):
             version = "3.1",
         ): "foo-py3-0.0.1",
         whl_config_setting(
+            filename = "foo-0.0.1-cp313-cp313-any.whl",
+            version = "3.1",
+        ): "foo-cp-0.0.1",
+        whl_config_setting(
+            filename = "foo-0.0.1-cp313-cp313t-any.whl",
+            version = "3.1",
+        ): "foo-cpt-0.0.1",
+        whl_config_setting(
             filename = "foo-0.0.2-py3-none-any.whl",
             version = "3.1",
             target_platforms = [
@@ -303,6 +311,8 @@ def _test_multiplatform_whl_aliases_filename(env):
         osx_versions = [],
     )
     want = {
+        "//_config:is_cp3.1_cp3x_cp_any": "foo-cp-0.0.1",
+        "//_config:is_cp3.1_cp3x_cpt_any": "foo-cpt-0.0.1",
         "//_config:is_cp3.1_py3_none_any": "foo-py3-0.0.1",
         "//_config:is_cp3.1_py3_none_any_linux_aarch64": "foo-0.0.2",
         "//_config:is_cp3.1_py3_none_any_linux_x86_64": "foo-0.0.2",

--- a/tests/pypi/whl_target_platforms/select_whl_tests.bzl
+++ b/tests/pypi/whl_target_platforms/select_whl_tests.bzl
@@ -27,6 +27,10 @@ WHL_LIST = [
     "pkg-0.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
     "pkg-0.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     "pkg-0.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+    "pkg-0.0.1-cp313-cp313t-musllinux_1_1_x86_64.whl",
+    "pkg-0.0.1-cp313-cp313-musllinux_1_1_x86_64.whl",
+    "pkg-0.0.1-cp313-abi3-musllinux_1_1_x86_64.whl",
+    "pkg-0.0.1-cp313-none-musllinux_1_1_x86_64.whl",
     "pkg-0.0.1-cp311-cp311-musllinux_1_1_aarch64.whl",
     "pkg-0.0.1-cp311-cp311-musllinux_1_1_i686.whl",
     "pkg-0.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl",
@@ -268,6 +272,22 @@ def _test_prefer_manylinux_wheels(env):
     )
 
 _tests.append(_test_prefer_manylinux_wheels)
+
+def _test_freethreaded_wheels(env):
+    # Check we prefer platform specific wheels
+    got = _select_whls(whls = WHL_LIST, want_platforms = ["cp313_linux_x86_64"])
+    _match(
+        env,
+        got,
+        "pkg-0.0.1-cp313-cp313t-musllinux_1_1_x86_64.whl",
+        "pkg-0.0.1-cp313-cp313-musllinux_1_1_x86_64.whl",
+        "pkg-0.0.1-cp313-abi3-musllinux_1_1_x86_64.whl",
+        "pkg-0.0.1-cp313-none-musllinux_1_1_x86_64.whl",
+        "pkg-0.0.1-cp39-abi3-any.whl",
+        "pkg-0.0.1-py3-none-any.whl",
+    )
+
+_tests.append(_test_freethreaded_wheels)
 
 def select_whl_test_suite(name):
     """Create the test suite.


### PR DESCRIPTION
With this we:
* Fix the previous behaviour where `abi3` wheels would be selected when
  freethreaded builds are selected. Whilst this may work in practise
  sometimes, I am not sure it has been supported by reading PEP703.
* Start selecting `cp313t` wheels when we scan what is available on PyPI.
* Ensure that the `whl_library` repository rule handles `cp313t` wheel
  extraction.
* Generate `cp313t` config_settings so that we can use them in
  `pkg_aliases`.
* Generate `cp313t` references in `pkg_aliases` macro.
* Add the 3.13 deps to dev_pip for testing.

Also tested by manually running:
```
$ bazel cquery --//python/config_settings:python_version=3.13 --//python/config_settings:py_freethreaded=yes 'kind("py_library rule", deps(@dev_pip//markupsafe))'
INFO: Analyzed target @@_main~pip~dev_pip//markupsafe:markupsafe (3 packages loaded, 4091 targets configured).
INFO: Found 1 target...
@@_main~pip~dev_pip_313_markupsafe_cp313_cp313t_manylinux_2_17_x86_64_c0ef13ea//:pkg (008c5a5)
$bazel build --//python/config_settings:python_version=3.13 --//python/config_settings:py_freethreaded=yes @dev_pip//markupsafe
```

Fixes #2386
