### PR TITLE
test: Enable non-ABI3 libs linking test for Windows

### DIFF
--- a/tests/cc/current_py_cc_libs/BUILD.bazel
+++ b/tests/cc/current_py_cc_libs/BUILD.bazel
@@ -20,14 +20,6 @@ current_py_cc_libs_test_suite(name = "current_py_cc_libs_tests")
 cc_test(
     name = "python_libs_linking_test",
     srcs = ["python_libs_linking_test.cc"],
-    # Windows fails with linking errors, but its not clear why; someone
-    # with more C + Windows experience will have to figure it out.
-    # - rickeylev@
-    target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "@platforms//os:osx": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",
         "@rules_python//python/cc:current_py_cc_libs",
@@ -41,10 +33,9 @@ cc_test(
 # for libs/python3.lib.
 # buildifier: disable=native-cc
 cc_test(
-    name = "python_libs_linking_windows_test",
+    name = "python_abi3_libs_linking_windows_test",
     srcs = ["python_libs_linking_test.cc"],
     defines = ["Py_LIMITED_API=0x030A0000"],
-    env = {"HELLO": "world"},
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",


### PR DESCRIPTION
Also explicitly include ABI3 in the name of the other Windows-only testcase, since that is the whole point of the test, and no ABI3-only libs exist on non-Windows platforms.

-----------

Follow-up of #1820.