### PR TITLE
docs: mention calling register_toolchains in custom toolchain docs

### DIFF
--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -444,7 +444,16 @@ toolchain(
     ],
     exec_comaptible_with = ["@platforms/os:linux"]
 )
+
+# File: MODULE.bazel or WORKSPACE.bazel
+# These toolchains will considered before others
+register_toolchains("//toolchains:all")
 ```
+
+When registering custom toolchains, be aware of the the [toolchain registration
+order](https://bazel.build/extending/toolchains#toolchain-resolution). In brief,
+toolchain order is the BFS-order of the modules; see the bazel docs for a more
+detailed description.
 
 :::{note}
 The toolchain() calls should be in a separate BUILD file from everything else.


### PR DESCRIPTION
Mention where register_toolchains() should be when defining custom toolchains. Also link
to the Bazel docs about toolchains.

This stems from Slack discussion where someone was trying to define custom toolchains and
got hung up on the last step or registering them.