### PR TITLE
fix: add missing api distribution target

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -30,6 +30,7 @@ licenses(["notice"])
 filegroup(
     name = "distribution",
     srcs = glob(["**"]) + [
+        "//python/private/api:distribution",
         "//python/private/proto:distribution",
         "//python/private/pypi:distribution",
         "//python/private/whl_filegroup:distribution",

--- a/python/private/api/BUILD.bazel
+++ b/python/private/api/BUILD.bazel
@@ -19,6 +19,11 @@ package(
     default_visibility = ["//:__subpackages__"],
 )
 
+filegroup(
+    name = "distribution",
+    srcs = glob(["**"]),
+)
+
 py_common_api(
     name = "py_common_api",
     # NOTE: Not actually public. Implicit dependency of public rules.


### PR DESCRIPTION
The distribution file groups are mostly used by integration tests, not releases, so these
filegroups missing doesn't usually cause a problem.

This was found when importing rules_python into Google, where filegroups of the rules sources
are fed into various tests.