### PR TITLE
tests: skip workspace-specific examples for bazel 9

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,7 @@ buildifier:
     - "--noenable_bzlmod"
     - "--test_tag_filters=-integration-test"
 .common_workspace_flags: &common_workspace_flags
+  skip_in_bazel_downstream_pipeline: "Bazel 9 doesn't support workspace"
   test_flags:
     - "--noenable_bzlmod"
     - "--enable_workspace"

--- a/examples/pip_repository_annotations/.bazelrc
+++ b/examples/pip_repository_annotations/.bazelrc
@@ -3,5 +3,5 @@ try-import %workspace%/user.bazelrc
 
 # This example is WORKSPACE specific. The equivalent functionality
 # is in examples/bzlmod as the `whl_mods` feature.
-build --experimental_enable_bzlmod=false
+build --experimental_enable_bzlmod=false --enable_workspace=true
 common:bazel7.x --incompatible_python_disallow_native_rules

--- a/examples/py_proto_library/.bazelrc
+++ b/examples/py_proto_library/.bazelrc
@@ -1,3 +1,3 @@
 # The equivalent bzlmod behavior is covered by examples/bzlmod/py_proto_library
-common --noenable_bzlmod
+common --noenable_bzlmod --enable_workspace=true
 common:bazel7.x --incompatible_python_disallow_native_rules


### PR DESCRIPTION
Bazel 9 won't support workspace builds, so skip them in the Bazel@head pipeline. The bzlmod
equivalents of these examples is covered elsewhere.

Along the way, enable workspace by default in the examples for a bit of futureproofing.

Work towards https://github.com/bazelbuild/rules_python/issues/2469