### PR TITLE
chore: ignore examples/pip_repository_annotations bazel-bin symlink

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -22,6 +22,7 @@ examples/bzlmod_build_file_generation/bazel-bzlmod_build_file_generation
 examples/multi_python_versions/bazel-multi_python_versions
 examples/pip_parse/bazel-pip_parse
 examples/pip_parse_vendored/bazel-pip_parse_vendored
+examples/pip_repository_annotations/bazel-pip_repository_annotations
 examples/py_proto_library/bazel-py_proto_library
 tests/integration/compile_pip_requirements/bazel-compile_pip_requirements
 tests/integration/ignore_root_user_error/bazel-ignore_root_user_error


### PR DESCRIPTION
If the examples/pip_repository_annotations had build performed in it, then outer invocations
try to traverse the symlink, wasting memory and causing errors.

To fix, add the path to `.bazelignore` so bazel doesn't try to visit it.