### PR TITLE
chore: use per-rule loads in pip_compile.bzl

### DIFF
--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -218,7 +218,8 @@ bzl_library(
     srcs = ["pip_compile.bzl"],
     deps = [
         ":deps_bzl",
-        "//python:defs_bzl",
+        "//python:py_binary_bzl",
+        "//python:py_test_bzl",
     ],
 )
 

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -19,7 +19,8 @@ NOTE @aignas 2024-06-23: We are using the implementation specific name here to
 make it possible to have multiple tools inside the `pypi` directory
 """
 
-load("//python:defs.bzl", _py_binary = "py_binary", _py_test = "py_test")
+load("//python:py_binary.bzl", _py_binary = "py_binary")
+load("//python:py_test.bzl", _py_test = "py_test")
 
 def pip_compile(
         name,


### PR DESCRIPTION
This is for overall code hygiene, but also because it seems to make some progress on Bazel 9
being able to load files in WORKSPACE mode (something about defs.bzl triggers loading
more symbols which can't be found)

Work towards https://github.com/bazelbuild/rules_python/issues/2469