### PR TITLE
tests: make multi_python_versions pass with Bazel 9 workspace

### DIFF
--- a/examples/multi_python_versions/tests/BUILD.bazel
+++ b/examples/multi_python_versions/tests/BUILD.bazel
@@ -131,7 +131,7 @@ py_test(
     data = [":version_3_10"],
     env = {
         "SUBPROCESS_VERSION_CHECK": "3.10",
-        "SUBPROCESS_VERSION_PY_BINARY": "$(rootpath :version_3_10)",
+        "SUBPROCESS_VERSION_PY_BINARY": "$(rootpaths :version_3_10)",
         "VERSION_CHECK": "3.9",
     },
     main = "cross_version_test.py",
@@ -143,7 +143,7 @@ py_test_3_10(
     data = [":version_3_9"],
     env = {
         "SUBPROCESS_VERSION_CHECK": "3.9",
-        "SUBPROCESS_VERSION_PY_BINARY": "$(rootpath :version_3_9)",
+        "SUBPROCESS_VERSION_PY_BINARY": "$(rootpaths :version_3_9)",
         "VERSION_CHECK": "3.10",
     },
     main = "cross_version_test.py",
@@ -155,7 +155,7 @@ sh_test(
     data = [":version_default"],
     env = {
         "VERSION_CHECK": "3.9",  # The default defined in the WORKSPACE.
-        "VERSION_PY_BINARY": "$(rootpath :version_default)",
+        "VERSION_PY_BINARY": "$(rootpaths :version_default)",
     },
 )
 
@@ -165,7 +165,7 @@ sh_test(
     data = [":version_3_8"],
     env = {
         "VERSION_CHECK": "3.8",
-        "VERSION_PY_BINARY": "$(rootpath :version_3_8)",
+        "VERSION_PY_BINARY": "$(rootpaths :version_3_8)",
     },
 )
 
@@ -175,7 +175,7 @@ sh_test(
     data = [":version_3_9"],
     env = {
         "VERSION_CHECK": "3.9",
-        "VERSION_PY_BINARY": "$(rootpath :version_3_9)",
+        "VERSION_PY_BINARY": "$(rootpaths :version_3_9)",
     },
 )
 
@@ -185,7 +185,7 @@ sh_test(
     data = [":version_3_10"],
     env = {
         "VERSION_CHECK": "3.10",
-        "VERSION_PY_BINARY": "$(rootpath :version_3_10)",
+        "VERSION_PY_BINARY": "$(rootpaths :version_3_10)",
     },
 )
 

--- a/examples/multi_python_versions/tests/version_test.sh
+++ b/examples/multi_python_versions/tests/version_test.sh
@@ -16,7 +16,11 @@
 
 set -o errexit -o nounset -o pipefail
 
-version_py_binary=$("${VERSION_PY_BINARY}")
+# VERSION_PY_BINARY is a space separate list of the executable and its main
+# py file. We just want the executable.
+bin=($VERSION_PY_BINARY)
+bin="${bin[@]//*.py}"
+version_py_binary=$($bin)
 
 if [[ "${version_py_binary}" != "${VERSION_CHECK}" ]]; then
     echo >&2 "expected version '${VERSION_CHECK}' is different than returned '${version_py_binary}'"


### PR DESCRIPTION
This is basically part of #2395, but for the workspace test. Same as that PR, the `$(rootpath)`
expansion isn't valid for a target with multiple outputs. To fix, use `$(rootpaths)` and parse
out the particular value of interest.

Work towards https://github.com/bazelbuild/rules_python/issues/2469