### PR TITLE
fix: Make sure wheelmaker uses the default shell env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ Unreleased changes template.
 
 {#v0-0-0-fixed}
 ### Fixed
-* Nothing fixed.
+* (py_wheel) Use the default shell environment when building wheels to allow
+  toolchains that search PATH to be used for the wheel builder tool.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -514,6 +514,8 @@ def _py_wheel_impl(ctx):
         outputs = [outfile, name_file],
         arguments = [args],
         executable = ctx.executable._wheelmaker,
+        # The default shell env is used to better support toolchains that look
+        # up python at runtime using PATH.
         use_default_shell_env = True,
         progress_message = "Building wheel {}".format(ctx.label),
     )

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -514,6 +514,7 @@ def _py_wheel_impl(ctx):
         outputs = [outfile, name_file],
         arguments = [args],
         executable = ctx.executable._wheelmaker,
+        use_default_shell_env = True,
         progress_message = "Building wheel {}".format(ctx.label),
     )
     return [


### PR DESCRIPTION
Clean macOS installs place `python` in `/usr/local/bin`, which is not searched by default when calling `actions.run()`. This caused builds to fail when they were executing python tools on an unmodified macOS host.
