### PR TITLE
fix: Fixing compile pip requirements when running on an RBE

### DIFF
--- a/python/private/pypi/dependency_resolver/dependency_resolver.py
+++ b/python/private/pypi/dependency_resolver/dependency_resolver.py
@@ -27,9 +27,9 @@ from piptools.scripts.compile import cli
 
 from python.runfiles import runfiles
 
-# Replace the os.replace function with shutil.copy to work around os.replace not being able to
+# Replace the os.replace function with shutil.move to work around os.replace not being able to
 # replace or move files across filesystems.
-os.replace = shutil.copy
+os.replace = shutil.move
 
 # Next, we override the annotation_style_split and annotation_style_line functions to replace the
 # backslashes in the paths with forward slashes. This is so that we can have the same requirements

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -21,6 +21,8 @@ make it possible to have multiple tools inside the `pypi` directory
 
 load("//python:defs.bzl", _py_binary = "py_binary", _py_test = "py_test")
 
+_DEFAULT_TAGS = ["no-sandbox", "no-remote-exec", "requires-network"]
+
 def pip_compile(
         name,
         srcs = None,
@@ -36,7 +38,7 @@ def pip_compile(
         requirements_linux = None,
         requirements_windows = None,
         visibility = ["//visibility:private"],
-        tags = None,
+        tags = _DEFAULT_TAGS,
         **kwargs):
     """Generates targets for managing pip dependencies with pip-compile.
 
@@ -75,6 +77,7 @@ def pip_compile(
         requirements_darwin: File of darwin specific resolve output to check validate if requirement.in has changes.
         requirements_windows: File of windows specific resolve output to check validate if requirement.in has changes.
         tags: tagging attribute common to all build rules, passed to both the _test and .update rules.
+            default: ["no-sandbox", "no-remote-exec", "requires-network"]
         visibility: passed to both the _test and .update rules.
         **kwargs: other bazel attributes passed to the "_test" rule.
     """
@@ -141,9 +144,6 @@ def pip_compile(
     ] + extra_deps
 
     tags = tags or []
-    tags.append("requires-network")
-    tags.append("no-remote-exec")
-    tags.append("no-sandbox")
     attrs = {
         "args": args,
         "data": data,


### PR DESCRIPTION
We have observed that making this change makes builds more likely to run successfully on an RBE.