### PR TITLE
chore: load specific bzl files instead of generic defs.bzl

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,7 @@ Once you've imported the rule set using either Bzlmod or WORKSPACE, you can then
 load the core rules in your `BUILD` files with the following:
 
 ```starlark
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 py_binary(
   name = "main",

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ components have examples in the {gh-path}`examples` directory.
 The core rules are currently available in Bazel as built-in symbols, but this
 form is deprecated. Instead, you should depend on rules_python in your
 `WORKSPACE` or `MODULE.bazel` file and load the Python rules from
-`@rules_python//python:defs.bzl` or load paths described in the API documentation.
+`@rules_python//python:<name>.bzl` or load paths described in the API documentation.
 
 A [buildifier](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 fix is available to automatically migrate `BUILD` and `.bzl` files to add the

--- a/examples/build_file_generation/BUILD.bazel
+++ b/examples/build_file_generation/BUILD.bazel
@@ -4,8 +4,10 @@
 # ruleset. When the symbol is loaded you can use the rule.
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@pip//:requirements.bzl", "all_whl_requirements")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 

--- a/examples/build_file_generation/random_number_generator/BUILD.bazel
+++ b/examples/build_file_generation/random_number_generator/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 py_library(
     name = "random_number_generator",

--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -9,7 +9,9 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@pip//:requirements.bzl", "all_data_requirements", "all_requirements", "all_whl_requirements", "requirement")
 load("@python_3_9//:defs.bzl", py_test_with_transition = "py_test")
 load("@python_versions//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 # This stanza calls a rule that generates targets for managing pip dependencies
 # with pip-compile for a particular python version.

--- a/examples/bzlmod/entry_points/tests/BUILD.bazel
+++ b/examples/bzlmod/entry_points/tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 # Below are targets for testing the `py_console_script_binary` feature and are
 # not part of the example how to use the feature.

--- a/examples/bzlmod/libs/my_lib/BUILD.bazel
+++ b/examples/bzlmod/libs/my_lib/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@pip//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "my_lib",

--- a/examples/bzlmod/other_module/other_module/pkg/BUILD.bazel
+++ b/examples/bzlmod/other_module/other_module/pkg/BUILD.bazel
@@ -2,7 +2,7 @@ load(
     "@python_3_11//:defs.bzl",
     py_binary_311 = "py_binary",
 )
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "lib",

--- a/examples/bzlmod/runfiles/BUILD.bazel
+++ b/examples/bzlmod/runfiles/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 py_test(
     name = "runfiles_test",

--- a/examples/bzlmod/tests/BUILD.bazel
+++ b/examples/bzlmod/tests/BUILD.bazel
@@ -2,7 +2,8 @@ load("@python_versions//3.10:defs.bzl", py_binary_3_10 = "py_binary", py_test_3_
 load("@python_versions//3.11:defs.bzl", py_binary_3_11 = "py_binary", py_test_3_11 = "py_test")
 load("@python_versions//3.9:defs.bzl", py_binary_3_9 = "py_binary", py_test_3_9 = "py_test")
 load("@pythons_hub//:versions.bzl", "MINOR_MAPPING")
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python//python/config_settings:transition.bzl", py_versioned_binary = "py_binary", py_versioned_test = "py_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 

--- a/examples/bzlmod/whl_mods/BUILD.bazel
+++ b/examples/bzlmod/whl_mods/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 exports_files(
     glob(["data/**"]),

--- a/examples/bzlmod_build_file_generation/BUILD.bazel
+++ b/examples/bzlmod_build_file_generation/BUILD.bazel
@@ -7,8 +7,10 @@
 # requirements.
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@pip//:requirements.bzl", "all_whl_requirements")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 

--- a/examples/bzlmod_build_file_generation/other_module/other_module/pkg/BUILD.bazel
+++ b/examples/bzlmod_build_file_generation/other_module/other_module/pkg/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "lib",

--- a/examples/bzlmod_build_file_generation/runfiles/BUILD.bazel
+++ b/examples/bzlmod_build_file_generation/runfiles/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 # gazelle:ignore
 py_test(

--- a/examples/multi_python_versions/libs/my_lib/BUILD.bazel
+++ b/examples/multi_python_versions/libs/my_lib/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@pypi//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "my_lib",

--- a/examples/multi_python_versions/tests/BUILD.bazel
+++ b/examples/multi_python_versions/tests/BUILD.bazel
@@ -6,7 +6,8 @@ load("@python//3.11:defs.bzl", py_binary_3_11 = "py_binary", py_test_3_11 = "py_
 load("@python//3.8:defs.bzl", py_binary_3_8 = "py_binary", py_test_3_8 = "py_test")
 load("@python//3.9:defs.bzl", py_binary_3_9 = "py_binary", py_test_3_9 = "py_test")
 load("@pythons_hub//:versions.bzl", "MINOR_MAPPING", "PYTHON_VERSIONS")
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python//python:versions.bzl", DEFAULT_MINOR_MAPPING = "MINOR_MAPPING", DEFAULT_TOOL_VERSIONS = "TOOL_VERSIONS")
 load("@rules_python//python/private:text_util.bzl", "render")  # buildifier: disable=bzl-visibility
 load("@rules_shell//shell:sh_test.bzl", "sh_test")

--- a/examples/pip_parse/BUILD.bazel
+++ b/examples/pip_parse/BUILD.bazel
@@ -1,11 +1,12 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 
 # Toolchain setup, this is optional.
 # Demonstrate that we can use the same python interpreter for the toolchain and executing pip in pip install (see WORKSPACE).
 #
-#load("@rules_python//python:defs.bzl", "py_runtime_pair")
+#load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 #
 #py_runtime(
 #    name = "python3_runtime",

--- a/examples/pip_parse_vendored/BUILD.bazel
+++ b/examples/pip_parse_vendored/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//:requirements.bzl", "all_data_requirements", "all_requirements", "all_whl_requirements", "requirement")
 
 # This rule adds a convenient way to update the requirements.txt

--- a/examples/pip_repository_annotations/BUILD.bazel
+++ b/examples/pip_repository_annotations/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 exports_files(
     glob(["data/**"]),

--- a/examples/py_proto_library/BUILD.bazel
+++ b/examples/py_proto_library/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 py_test(
     name = "pricetag_test",

--- a/examples/wheel/BUILD.bazel
+++ b/examples/wheel/BUILD.bazel
@@ -15,9 +15,10 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//examples/wheel/private:wheel_utils.bzl", "directory_writer", "make_variable_tags")
-load("//python:defs.bzl", "py_library", "py_test")
 load("//python:packaging.bzl", "py_package", "py_wheel")
 load("//python:pip.bzl", "compile_pip_requirements")
+load("//python:py_library.bzl", "py_library")
+load("//python:py_test.bzl", "py_test")
 load("//python:versions.bzl", "gen_python_config_settings")
 load("//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility

--- a/examples/wheel/lib/BUILD.bazel
+++ b/examples/wheel/lib/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//python:defs.bzl", "py_library")
+load("//python:py_library.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/wheel/private/BUILD.bazel
+++ b/examples/wheel/private/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 py_binary(
     name = "directory_writer",

--- a/python/private/proto/BUILD.bazel
+++ b/python/private/proto/BUILD.bazel
@@ -30,7 +30,7 @@ bzl_library(
     srcs = ["py_proto_library.bzl"],
     visibility = ["//python:__pkg__"],
     deps = [
-        "//python:defs_bzl",
+        "//python:py_info_bzl",
         "@rules_proto//proto:defs",
     ],
 )

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -15,7 +15,7 @@
 """The implementation of the `py_proto_library` rule and its aspect."""
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
-load("//python:defs.bzl", "PyInfo")
+load("//python:py_info.bzl", "PyInfo")
 load("//python/api:api.bzl", _py_common = "py_common")
 
 PY_PROTO_TOOLCHAIN = "@rules_python//python/proto:toolchain_type"

--- a/python/private/pypi/deps.bzl
+++ b/python/private/pypi/deps.bzl
@@ -100,7 +100,7 @@ _RULE_DEPS = [
 _GENERIC_WHEEL = """\
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python/private:glob_excludes.bzl", "glob_excludes")
 
 py_library(

--- a/python/private/pypi/generate_group_library_build_bazel.bzl
+++ b/python/private/pypi/generate_group_library_build_bazel.bzl
@@ -25,7 +25,7 @@ load(
 )
 
 _PRELUDE = """\
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 """
 
 _GROUP_TEMPLATE = """\

--- a/python/private/pypi/whl_installer/BUILD.bazel
+++ b/python/private/pypi/whl_installer/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//python:defs.bzl", "py_binary", "py_library")
+load("//python:py_binary.bzl", "py_binary")
+load("//python:py_library.bzl", "py_library")
 
 py_library(
     name = "lib",

--- a/python/private/whl_filegroup/BUILD.bazel
+++ b/python/private/whl_filegroup/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//python:defs.bzl", "py_binary")
+load("//python:py_binary.bzl", "py_binary")
 
 filegroup(
     name = "distribution",

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -14,11 +14,7 @@
 
 """Re-exports for some of the core Bazel Python rules.
 
-This file is deprecated; please use the exports in defs.bzl instead. This is to
-follow the new naming convention of putting core rules for a language
-underneath @rules_<LANG>//<LANG>:defs.bzl. The exports in this file will be
-disallowed in a future Bazel release by
-`--incompatible_load_python_rules_from_bzl`.
+This file is deprecated; please use the exports in `<name>.bzl` files instead.
 """
 
 def py_library(*args, **kwargs):

--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//python:defs.bzl", "py_library")
 load("//python:packaging.bzl", "py_wheel")
+load("//python:py_library.bzl", "py_library")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 
 filegroup(

--- a/tests/base_rules/base_tests.bzl
+++ b/tests/base_rules/base_tests.bzl
@@ -16,7 +16,7 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:truth.bzl", "matching")
 load("@rules_testing//lib:util.bzl", "PREVENT_IMPLICIT_BUILDING_TAGS", rt_util = "util")
-load("//python:defs.bzl", "PyInfo")
+load("//python:py_info.bzl", "PyInfo")
 load("//python/private:reexports.bzl", "BuiltinPyInfo")  # buildifier: disable=bzl-visibility
 load("//tests/base_rules:util.bzl", pt_util = "util")
 load("//tests/support:py_info_subject.bzl", "py_info_subject")

--- a/tests/base_rules/py_binary/py_binary_tests.bzl
+++ b/tests/base_rules/py_binary/py_binary_tests.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for py_binary."""
 
-load("//python:defs.bzl", "py_binary")
+load("//python:py_binary.bzl", "py_binary")
 load(
     "//tests/base_rules:py_executable_base_tests.bzl",
     "create_executable_tests",

--- a/tests/base_rules/py_library/py_library_tests.bzl
+++ b/tests/base_rules/py_library/py_library_tests.bzl
@@ -3,7 +3,8 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:truth.bzl", "matching")
 load("@rules_testing//lib:util.bzl", rt_util = "util")
-load("//python:defs.bzl", "PyRuntimeInfo", "py_library")
+load("//python:py_library.bzl", "py_library")
+load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
 load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", pt_util = "util")
 

--- a/tests/base_rules/py_test/py_test_tests.bzl
+++ b/tests/base_rules/py_test/py_test_tests.bzl
@@ -15,7 +15,7 @@
 
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:util.bzl", rt_util = "util")
-load("//python:defs.bzl", "py_test")
+load("//python:py_test.bzl", "py_test")
 load(
     "//tests/base_rules:py_executable_base_tests.bzl",
     "create_executable_tests",

--- a/tests/load_from_macro/BUILD.bazel
+++ b/tests/load_from_macro/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//python:defs.bzl", "py_library")
+load("//python:py_library.bzl", "py_library")
 load(":tags.bzl", "TAGS")
 
 licenses(["notice"])

--- a/tests/pycross/BUILD.bazel
+++ b/tests/pycross/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//python:defs.bzl", "py_test")
+load("//python:py_test.bzl", "py_test")
 load("//third_party/rules_pycross/pycross/private:wheel_library.bzl", "py_wheel_library")  # buildifier: disable=bzl-visibility
 
 py_wheel_library(

--- a/tests/pypi/generate_group_library_build_bazel/generate_group_library_build_bazel_tests.bzl
+++ b/tests/pypi/generate_group_library_build_bazel/generate_group_library_build_bazel_tests.bzl
@@ -21,7 +21,7 @@ _tests = []
 
 def _test_simple(env):
     want = """\
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 
 ## Group vbap
@@ -62,7 +62,7 @@ _tests.append(_test_simple)
 
 def _test_in_hub(env):
     want = """\
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 
 ## Group vbap

--- a/tests/pypi/whl_installer/BUILD.bazel
+++ b/tests/pypi/whl_installer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//python:defs.bzl", "py_test")
+load("//python:py_test.bzl", "py_test")
 
 alias(
     name = "lib",

--- a/tests/whl_filegroup/BUILD.bazel
+++ b/tests/whl_filegroup/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//python:defs.bzl", "py_library", "py_test")
 load("//python:packaging.bzl", "py_package", "py_wheel")
 load("//python:pip.bzl", "whl_filegroup")
+load("//python:py_library.bzl", "py_library")
+load("//python:py_test.bzl", "py_test")
 load(":whl_filegroup_tests.bzl", "whl_filegroup_test_suite")
 
 whl_filegroup_test_suite(name = "whl_filegroup_tests")

--- a/third_party/rules_pycross/pycross/private/wheel_library.bzl
+++ b/third_party/rules_pycross/pycross/private/wheel_library.bzl
@@ -16,7 +16,7 @@
 """Implementation of the py_wheel_library rule."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//python:defs.bzl", "PyInfo")
+load("//python:py_info.bzl", "PyInfo")
 load(":providers.bzl", "PyWheelInfo")
 
 def _py_wheel_library_impl(ctx):

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("//python:defs.bzl", "py_binary")
+load("//python:py_binary.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Update code and examples to load the object-specific bzl files instead of the
generic `defs.bzl`. This is mostly for code hygiene, but came out of trying to diagnose
why Bazel 9 workspace builds kept erroing with defs.bzl somehow related. Removing 
the internal usages of defs.bzl doesn't seem to fully fix it, but does seem to eliminate
some errors, make some progress, and narrow down what's going on.

Work towards https://github.com/bazelbuild/rules_python/issues/2469