### PR TITLE
chore: remove find_requirements re-export from bazel_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Unreleased changes template.
 
 {#v0-0-0-removed}
 ### Removed
-* Nothing removed.
+* `find_requirements` in `//python:defs.bzl` has been removed.
 
 {#v1-0-0}
 ## [1.0.0] - 2024-12-05

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -71,7 +71,6 @@ bzl_library(
         ":py_runtime_info_bzl",
         ":py_runtime_pair_bzl",
         ":py_test_bzl",
-        "//python/private:bazel_tools_bzl",
     ],
 )
 

--- a/python/defs.bzl
+++ b/python/defs.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Core rules for building Python projects."""
 
-load("@bazel_tools//tools/python:srcs_version.bzl", _find_requirements = "find_requirements")
 load("//python:py_binary.bzl", _py_binary = "py_binary")
 load("//python:py_info.bzl", _PyInfo = "PyInfo")
 load("//python:py_library.bzl", _py_library = "py_library")
@@ -34,11 +33,7 @@ current_py_toolchain = _current_py_toolchain
 
 py_import = _py_import
 
-# Re-exports of Starlark-defined symbols in @bazel_tools//tools/python.
-
 py_runtime_pair = _py_runtime_pair
-
-find_requirements = _find_requirements
 
 py_library = _py_library
 


### PR DESCRIPTION
This removes re-exporting the `find_requirements` aspect from `@bazel_tools`.

The find_requirements aspect is only useful for analyzing the `srcs_version` relationship
between targets, which was only needed as part of the Python 2 to 3 upgrade. With Python
2 no longer supported, it's defunct.

Removing it entirely because I can't find any real references to it in the wild. It looks
entirely unused.