### PR TITLE
chore: replace rules_proto with com_google_protobuf

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,10 @@ load("//:internal_dev_deps.bzl", "rules_python_internal_deps")
 
 rules_python_internal_deps()
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 
 rules_jvm_external_deps()

--- a/examples/bzlmod/py_proto_library/example.com/another_proto/BUILD.bazel
+++ b/examples/bzlmod/py_proto_library/example.com/another_proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 py_proto_library(

--- a/examples/bzlmod/py_proto_library/example.com/proto/BUILD.bazel
+++ b/examples/bzlmod/py_proto_library/example.com/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 py_proto_library(

--- a/examples/py_proto_library/WORKSPACE
+++ b/examples/py_proto_library/WORKSPACE
@@ -25,19 +25,6 @@ python_register_toolchains(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_proto",
-    sha256 = "904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c",
-    strip_prefix = "rules_proto-6.0.0-rc1",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz",
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-rules_proto_dependencies()
-
-rules_proto_toolchains()
-
-http_archive(
     name = "com_google_protobuf",
     sha256 = "4fc5ff1b2c339fb86cd3a25f0b5311478ab081e65ad258c6789359cd84d421f8",
     strip_prefix = "protobuf-26.1",

--- a/examples/py_proto_library/example.com/another_proto/BUILD.bazel
+++ b/examples/py_proto_library/example.com/another_proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 py_proto_library(

--- a/examples/py_proto_library/example.com/proto/BUILD.bazel
+++ b/examples/py_proto_library/example.com/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 py_proto_library(

--- a/internal_dev_setup.bzl
+++ b/internal_dev_setup.bzl
@@ -21,7 +21,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 load("@rules_bazel_integration_test//bazel_integration_test:repo_defs.bzl", "bazel_binaries")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
 load("//:version.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load("//python:versions.bzl", "MINOR_MAPPING", "TOOL_VERSIONS")
@@ -45,9 +44,6 @@ def rules_python_internal_setup():
     pypi_deps()
 
     bazel_skylib_workspace()
-
-    rules_proto_dependencies()
-    rules_proto_toolchains()
 
     protobuf_deps()
 

--- a/python/private/proto/BUILD.bazel
+++ b/python/private/proto/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+load("@com_google_protobuf//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -31,6 +31,8 @@ bzl_library(
     visibility = ["//python:__pkg__"],
     deps = [
         "//python:py_info_bzl",
+        "@com_google_protobuf//bazel/common:proto_common_bzl",
+        "@com_google_protobuf//bazel/common:proto_info_bzl",
         "@rules_proto//proto:defs",
     ],
 )

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -14,7 +14,8 @@
 
 """The implementation of the `py_proto_library` rule and its aspect."""
 
-load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
+load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//python:py_info.bzl", "PyInfo")
 load("//python/api:api.bzl", _py_common = "py_common")
 


### PR DESCRIPTION
rules_proto is deprecated and recent versions simply forward onto com_google_protobuf.
Older versions (e.g. 6.x used by us today), however, use the rules_proto or native
(Bazel builtin) implementation. When those older versions are used with Bazel 9,
which has removed various proto things, errors occur.

To fix, switch to using com_google_protobuf directly. More recent versions of rules_proto
just forward onto com_google_protobuf anyways, so this just removes the extra dependency
and having to deal with WORKSPACE setup.

Work towards https://github.com/bazelbuild/rules_python/issues/2469