### PR TITLE
fix: make bazel 9 workspace recognize rules_python as the main module

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,13 @@ workspace(name = "rules_python")
 # Everything below this line is used only for developing rules_python. Users
 # should not copy it to their WORKSPACE.
 
+# Necessary so that Bazel 9 recognizes this as rules_python and doesn't try
+# to load the version Bazel itself uses by default.
+local_repository(
+    name = "rules_python",
+    path = ".",
+)
+
 load("//:internal_dev_deps.bzl", "rules_python_internal_deps")
 
 rules_python_internal_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,7 @@ workspace(name = "rules_python")
 
 # Necessary so that Bazel 9 recognizes this as rules_python and doesn't try
 # to load the version Bazel itself uses by default.
+# buildifier: disable=duplicated-name
 local_repository(
     name = "rules_python",
     path = ".",


### PR DESCRIPTION
Building with Bazel 9 using WORKSPACE results in an odd error that `PyInfo`
isn't defined. Oddly, the error refers to `rules_python/python/private/reexports.bzl`
for rules_python 0.28.0. This seems to only happen when the main module is rules_python.

While Bazel 9 is supposed to drop workspace support, I've been advised it's better to
keep testing WORKSPACE support until closer to when Bazel 9 fully removes it.

My best guess about what's happening is Bazel's autoloading is triggering and somehow
defining rules_python before it's recognized that the main module is rules_python.
The autoloading appears to be triggered, eventually, by things in bazel_tools loading
rules_python.

While removing unnecessary `@bazel_tools` loads in rules_python helps, the particular
case I can't find a clean solution to is when
`@@rules_java//toolchains:toolchain_java11_definition` causes rules_python to be
loaded. This appears to end up loading rules_python via
`@bazel_tools//tools/jdk:BUILD`, which has has some py rules defined in it.

To fix/work around this issue, `local_repository` can be used to define the `rules_python`
repo before autoloading happens. This appears to take precedence over whatever logic
autoloading has.

Work towards https://github.com/bazelbuild/rules_python/issues/2469