### PR TITLE
fix(pypi): Fix use_hub_alias_dependencies with WORKSPACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ Unreleased changes template.
   Fixes [#2450](https://github.com/bazelbuild/rules_python/issues/2450).
 * (gazelle) Gazelle will now correctly parse Python3.12 files that use [PEP 695 Type
   Parameter Syntax][pep-695]. (#2396)
+* (pypi) Using {bzl:obj}`pip_parse.experimental_requirement_cycles` and
+  {bzl:obj}`pip_parse.use_hub_alias_dependencies` together now works when
+  using WORKSPACE files.
 
 [pep-695]: https://peps.python.org/pep-0695/
 

--- a/python/private/pypi/pip_repository.bzl
+++ b/python/private/pypi/pip_repository.bzl
@@ -178,6 +178,7 @@ def _pip_repository_impl(rctx):
             for pkg in bzl_packages or []
         },
         extra_hub_aliases = rctx.attr.extra_hub_aliases,
+        requirement_cycles = requirement_cycles,
     )
     for path, contents in aliases.items():
         rctx.file(path, contents)


### PR DESCRIPTION
The code path pip_parse follows when using a WORKSPACE file with
use_hub_alias_dependencies enabled forgets to pass requirement cycles
along to alias creation, leading to the _groups package never being
created and aliases skipping them.  Requirement cycles are just ignored
entirely.  In this patch we attempt to fix that so grouping works more
or less the same way as it does under bzlmod with that flag enabled.