### PR TITLE
docs: Fix toolchain implementation file name

### DIFF
--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -376,7 +376,7 @@ Here, we show an example for a semi-complicated toolchain suite, one that is:
 Defining toolchains for this might look something like this:
 
 ```
-# File: toolchain_impls/BUILD
+# File: toolchain_impl/BUILD
 load("@rules_python//python:py_cc_toolchain.bzl", "py_cc_toolchain")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
 load("@rules_python//python:py_runtime.bzl", "py_runtime")


### PR DESCRIPTION
The code example comment uses `toolchain_impls` (extra s), while the target references
use `toolchain_impl` (no s). This made me go back and double-check when reading the
custom toolchain example (especially the definitions in L425ff).

Remove the extra "s" in the comment so it matches what the target references are.