### PR TITLE
Updated pip and packaging versions to work with free-threading packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Unreleased changes template.
 * (rules) The version-aware rules have been folded into the base rules and
   the version-aware rules are now simply aliases for the base rules. The
   `python_version` attribute is still used to specify the Python version.
+* (pypi) Updated versions of packages: `pip` to 24.3.1 and
+  `packaging` to 24.2.
 
 {#v0-0-0-deprecations}
 #### Deprecations

--- a/python/private/pypi/deps.bzl
+++ b/python/private/pypi/deps.bzl
@@ -51,8 +51,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__packaging",
-        "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
-        "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+        "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
+        "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
     ),
     (
         "pypi__pep517",
@@ -61,8 +61,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__pip",
-        "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
-        "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+        "https://files.pythonhosted.org/packages/ef/7d/500c9ad20238fcfcb4cb9243eede163594d7020ce87bd9610c9e02771876/pip-24.3.1-py3-none-any.whl",
+        "3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed",
     ),
     (
         "pypi__pip_tools",


### PR DESCRIPTION
We had an issue to install jaxlib with bazel when running the following command (using rules_python v0.39):
```bash
          bazel test \
              --repo_env=HERMETIC_PYTHON_VERSION=3.13-ft \
              --repo_env=JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES \
              --repo_env=JAX_ENABLE_X64=$JAX_ENABLE_X64 \
              --repo_env=JAX_SKIP_SLOW_TESTS=$JAX_SKIP_SLOW_TESTS \
              --repo_env=PYTHON_GIL=$PYTHON_GIL \
              --repo_env=TSAN_OPTIONS="halt_on_error=1" \
              --//jax:build_jaxlib=false \
              --nocache_test_results \
              --test_output=all \
              //tests:cpu_tests
```

According to @vam-google, this was due to old pip/packaging versions. We updated them and this helped to make work the whole building/testing pipeline: https://github.com/jax-ml/jax/pull/24898
So, we would like to upstream the patch: https://github.com/jax-ml/jax/pull/24898/files#diff-e3dc8d7d2bf5d057f95b86bcff7360b6c99fa1f458882fd112b58da4aceb53e4

