### PR TITLE
fix: py_proto_library: external runfiles

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -18,6 +18,7 @@ examples/bzlmod/other_module/bazel-bin
 examples/bzlmod/other_module/bazel-other_module
 examples/bzlmod/other_module/bazel-out
 examples/bzlmod/other_module/bazel-testlogs
+examples/bzlmod/py_proto_library/foo_external
 examples/bzlmod_build_file_generation/bazel-bzlmod_build_file_generation
 examples/multi_python_versions/bazel-multi_python_versions
 examples/pip_parse/bazel-pip_parse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Unreleased changes template.
 * (pypi) Using {bzl:obj}`pip_parse.experimental_requirement_cycles` and
   {bzl:obj}`pip_parse.use_hub_alias_dependencies` together now works when
   using WORKSPACE files.
+* (py_proto_library) Fix import paths in Bazel 8.
 
 [pep-695]: https://peps.python.org/pep-0695/
 

--- a/examples/bzlmod/.bazelignore
+++ b/examples/bzlmod/.bazelignore
@@ -1,1 +1,2 @@
 other_module
+py_proto_library/foo_external

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_python", version = "0.0.0")
 local_path_override(
     module_name = "rules_python",
@@ -270,6 +271,12 @@ bazel_dep(name = "other_module", version = "", repo_name = "our_other_module")
 local_path_override(
     module_name = "other_module",
     path = "other_module",
+)
+
+bazel_dep(name = "foo_external", version = "")
+local_path_override(
+    module_name = "foo_external",
+    path = "py_proto_library/foo_external",
 )
 
 # example test dependencies

--- a/examples/bzlmod/py_proto_library/BUILD.bazel
+++ b/examples/bzlmod/py_proto_library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 load("@rules_python//python:py_test.bzl", "py_test")
 
 py_test(
@@ -15,4 +16,19 @@ py_test(
     deps = [
         "//py_proto_library/example.com/another_proto:message_proto_py_pb2",
     ],
+)
+
+# Regression test for https://github.com/bazelbuild/rules_python/issues/2515
+#
+# This test failed before https://github.com/bazelbuild/rules_python/pull/2516
+# when ran with --legacy_external_runfiles=False (default in Bazel 8.0.0).
+native_test(
+    name = "external_import_test",
+    src = "@foo_external//:py_binary_with_proto",
+    # Incompatible with Windows: native_test wrapping a py_binary doesn't work
+    # on Windows.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/examples/bzlmod/py_proto_library/foo_external/BUILD.bazel
+++ b/examples/bzlmod/py_proto_library/foo_external/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "proto_lib",
+    srcs = ["nested/foo/my_proto.proto"],
+    strip_import_prefix = "/nested/foo",
+)
+
+py_proto_library(
+    name = "a_proto",
+    deps = [":proto_lib"],
+)
+
+py_binary(
+    name = "py_binary_with_proto",
+    srcs = ["py_binary_with_proto.py"],
+    deps = [":a_proto"],
+)

--- a/examples/bzlmod/py_proto_library/foo_external/MODULE.bazel
+++ b/examples/bzlmod/py_proto_library/foo_external/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "foo_external",
+    version = "0.0.1",
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "protobuf", version = "28.2", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "7.0.2")

--- a/examples/bzlmod/py_proto_library/foo_external/nested/foo/my_proto.proto
+++ b/examples/bzlmod/py_proto_library/foo_external/nested/foo/my_proto.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package my_proto;
+
+message MyMessage {
+}

--- a/examples/bzlmod/py_proto_library/foo_external/py_binary_with_proto.py
+++ b/examples/bzlmod/py_proto_library/foo_external/py_binary_with_proto.py
@@ -1,0 +1,5 @@
+import sys
+
+if __name__ == "__main__":
+    import my_proto_pb2
+    sys.exit(0)

--- a/python/private/proto/py_proto_library.bzl
+++ b/python/private/proto/py_proto_library.bzl
@@ -98,7 +98,12 @@ def _py_proto_aspect_impl(target, ctx):
             proto_root = proto_root[len(ctx.bin_dir.path) + 1:]
 
         plugin_output = ctx.bin_dir.path + "/" + proto_root
-        proto_root = ctx.workspace_name + "/" + proto_root
+
+        # Import path within the runfiles tree
+        if proto_root.startswith("external/"):
+            proto_root = proto_root[len("external") + 1:]
+        else:
+            proto_root = ctx.workspace_name + "/" + proto_root
 
         proto_common.compile(
             actions = ctx.actions,


### PR DESCRIPTION
Previously, the import path within the runfiles was only correct for the case --legacy_external_runfiles=True (which copied the runfiles into `$RUNFILES/<main repo>/external/<external repo>/<path>` in addition to `$RUNFILES/<external repo>/<path>`. This flag was flipped to False in Bazel 8.0.0.

Fixes https://github.com/bazelbuild/rules_python/issues/2515.

Tested locally against the minimal reproducer in that issue.
