### PR TITLE
refactor(pypi): A better error message when the wheel select hits no_match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ Unreleased changes template.
 * (pypi) Using {bzl:obj}`pip_parse.experimental_requirement_cycles` and
   {bzl:obj}`pip_parse.use_hub_alias_dependencies` together now works when
   using WORKSPACE files.
+* The error messages when the wheel distributions do not match anything
+  are now printing more details and include the currently active flag
+  values. Fixes [#2466](https://github.com/bazelbuild/rules_python/issues/2466).
 
 [pep-695]: https://peps.python.org/pep-0695/
 

--- a/docs/api/rules_python/python/config_settings/index.md
+++ b/docs/api/rules_python/python/config_settings/index.md
@@ -248,7 +248,7 @@ Fail the build if the current build configuration does not match the
 Values:
 * `fail`: Will fail in the build action ensuring that we get the error
   message no matter the action cache.
-* ``: The default value, that will just print a warning.
+* ``: (empty string) The default value, that will just print a warning.
 
 :::{seealso}
 {obj}`pip.parse`

--- a/docs/api/rules_python/python/config_settings/index.md
+++ b/docs/api/rules_python/python/config_settings/index.md
@@ -240,3 +240,21 @@ instead.
 :::
 
 ::::
+
+::::{bzl:flag} current_config
+Fail the build if the current build configuration does not match the
+{obj}`pip.parse` defined wheels.
+
+Values:
+* `fail`: Will fail in the build action ensuring that we get the error
+  message no matter the action cache.
+* ``: The default value, that will just print a warning.
+
+:::{seealso}
+{obj}`pip.parse`
+:::
+
+:::{versionadded} 1.1.0
+:::
+
+::::

--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -29,6 +29,15 @@ filegroup(
 construct_config_settings(
     name = "construct_config_settings",
     default_version = DEFAULT_PYTHON_VERSION,
+    documented_flags = [
+        ":pip_whl",
+        ":pip_whl_glibc_version",
+        ":pip_whl_muslc_version",
+        ":pip_whl_osx_arch",
+        ":pip_whl_osx_version",
+        ":py_freethreaded",
+        ":py_linux_libc",
+    ],
     minor_mapping = MINOR_MAPPING,
     versions = PYTHON_VERSIONS,
 )

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -17,12 +17,21 @@
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//python/private:text_util.bzl", "render")
 load(":semver.bzl", "semver")
 
 _PYTHON_VERSION_FLAG = Label("//python/config_settings:python_version")
 _PYTHON_VERSION_MAJOR_MINOR_FLAG = Label("//python/config_settings:python_version_major_minor")
 
-def construct_config_settings(*, name, default_version, versions, minor_mapping):  # buildifier: disable=function-docstring
+_DEBUG_ENV_MESSAGE_TEMPLATE = """\
+The current configuration rules_python config flags is:
+    {flags}
+
+If the value is missing, then the default value is being used, see documentation:
+{docs_url}/python/config_settings
+"""
+
+def construct_config_settings(*, name, default_version, versions, minor_mapping, documented_flags):  # buildifier: disable=function-docstring
     """Create a 'python_version' config flag and construct all config settings used in rules_python.
 
     This mainly includes the targets that are used in the toolchain and pip hub
@@ -33,6 +42,8 @@ def construct_config_settings(*, name, default_version, versions, minor_mapping)
         default_version: {type}`str` the default value for the `python_version` flag.
         versions: {type}`list[str]` A list of versions to build constraint settings for.
         minor_mapping: {type}`dict[str, str]` A mapping from `X.Y` to `X.Y.Z` python versions.
+        documented_flags: {type}`list[str]` The labels of the documented settings
+            that affect build configuration.
     """
     _ = name  # @unused
     _python_version_flag(
@@ -44,6 +55,7 @@ def construct_config_settings(*, name, default_version, versions, minor_mapping)
     _python_version_major_minor_flag(
         name = _PYTHON_VERSION_MAJOR_MINOR_FLAG.name,
         build_setting_default = "",
+        python_version_flag = _PYTHON_VERSION_FLAG,
         visibility = ["//visibility:public"],
     )
 
@@ -101,6 +113,25 @@ def construct_config_settings(*, name, default_version, versions, minor_mapping)
             visibility = ["//visibility:public"],
         )
 
+    _current_config(
+        name = "current_config",
+        build_setting_default = "",
+        settings = documented_flags + [_PYTHON_VERSION_FLAG.name],
+        visibility = ["//visibility:private"],
+    )
+    native.config_setting(
+        name = "is_not_matching_current_config",
+        # We use the rule above instead of @platforms//:incompatible so that the
+        # printing of the current env always happens when the _current_config rule
+        # is executed.
+        #
+        # NOTE: This should in practise only happen if there is a missing compatible
+        # `whl_library` in the hub repo created by `pip.parse`.
+        flag_values = {"current_config": "will-never-match"},
+        # Only public so that PyPI hub repo can access it
+        visibility = ["//visibility:public"],
+    )
+
 def _python_version_flag_impl(ctx):
     value = ctx.build_setting_value
     return [
@@ -122,7 +153,7 @@ _python_version_flag = rule(
 )
 
 def _python_version_major_minor_flag_impl(ctx):
-    input = ctx.attr._python_version_flag[config_common.FeatureFlagInfo].value
+    input = _flag_value(ctx.attr.python_version_flag)
     if input:
         version = semver(input)
         value = "{}.{}".format(version.major, version.minor)
@@ -135,8 +166,45 @@ _python_version_major_minor_flag = rule(
     implementation = _python_version_major_minor_flag_impl,
     build_setting = config.string(flag = False),
     attrs = {
-        "_python_version_flag": attr.label(
-            default = _PYTHON_VERSION_FLAG,
-        ),
+        "python_version_flag": attr.label(mandatory = True),
+    },
+)
+
+def _flag_value(s):
+    if config_common.FeatureFlagInfo in s:
+        return s[config_common.FeatureFlagInfo].value
+    else:
+        return s[BuildSettingInfo].value
+
+def _print_current_config_impl(ctx):
+    flags = "\n".join([
+        "{}: \"{}\"".format(k, v)
+        for k, v in sorted({
+            str(setting.label): _flag_value(setting)
+            for setting in ctx.attr.settings
+        }.items())
+    ])
+
+    msg = ctx.attr._template.format(
+        docs_url = "https://rules-python.readthedocs.io/en/latest/api/rules_python",
+        flags = render.indent(flags).lstrip(),
+    )
+    if ctx.build_setting_value and ctx.build_setting_value != "fail":
+        fail("Only 'fail' and empty build setting values are allowed for {}".format(
+            str(ctx.label),
+        ))
+    elif ctx.build_setting_value:
+        fail(msg)
+    else:
+        print(msg)  # buildifier: disable=print
+
+    return [config_common.FeatureFlagInfo(value = "")]
+
+_current_config = rule(
+    implementation = _print_current_config_impl,
+    build_setting = config.string(flag = True),
+    attrs = {
+        "settings": attr.label_list(mandatory = True),
+        "_template": attr.string(default = _DEBUG_ENV_MESSAGE_TEMPLATE),
     },
 )

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -165,7 +165,9 @@ _python_version_major_minor_flag = rule(
     implementation = _python_version_major_minor_flag_impl,
     build_setting = config.string(flag = False),
     attrs = {
-        "_python_version_flag": attr.label(default = _PYTHON_VERSION_FLAG),
+        "_python_version_flag": attr.label(
+            default = _PYTHON_VERSION_FLAG,
+        ),
     },
 )
 

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -55,7 +55,6 @@ def construct_config_settings(*, name, default_version, versions, minor_mapping,
     _python_version_major_minor_flag(
         name = _PYTHON_VERSION_MAJOR_MINOR_FLAG.name,
         build_setting_default = "",
-        python_version_flag = _PYTHON_VERSION_FLAG,
         visibility = ["//visibility:public"],
     )
 
@@ -153,7 +152,7 @@ _python_version_flag = rule(
 )
 
 def _python_version_major_minor_flag_impl(ctx):
-    input = _flag_value(ctx.attr.python_version_flag)
+    input = _flag_value(ctx.attr._python_version_flag)
     if input:
         version = semver(input)
         value = "{}.{}".format(version.major, version.minor)
@@ -166,7 +165,7 @@ _python_version_major_minor_flag = rule(
     implementation = _python_version_major_minor_flag_impl,
     build_setting = config.string(flag = False),
     attrs = {
-        "python_version_flag": attr.label(mandatory = True),
+        "_python_version_flag": attr.label(default = _PYTHON_VERSION_FLAG),
     },
 )
 

--- a/python/private/pypi/pkg_aliases.bzl
+++ b/python/private/pypi/pkg_aliases.bzl
@@ -116,6 +116,7 @@ def pkg_aliases(
                 ),
             ),
             visibility = ["//visibility:private"],
+            tags = ["manual"],
         )
         actual["//conditions:default"] = _INCOMPATIBLE
 

--- a/tests/pypi/pkg_aliases/pkg_aliases_test.bzl
+++ b/tests/pypi/pkg_aliases/pkg_aliases_test.bzl
@@ -67,7 +67,7 @@ def _test_config_setting_aliases(env):
         },
         extra_aliases = ["my_special"],
         native = struct(
-            alias = lambda name, actual, visibility = None: got.update({name: actual}),
+            alias = lambda *, name, actual, visibility = None, tags = None: got.update({name: actual}),
         ),
         select = mock_select,
     )
@@ -116,7 +116,7 @@ def _test_config_setting_aliases_many(env):
         },
         extra_aliases = ["my_special"],
         native = struct(
-            alias = lambda name, actual, visibility = None: got.update({name: actual}),
+            alias = lambda *, name, actual, visibility = None, tags = None: got.update({name: actual}),
             config_setting = lambda **_: None,
         ),
         select = mock_select,
@@ -174,7 +174,7 @@ def _test_multiplatform_whl_aliases(env):
         },
         extra_aliases = [],
         native = struct(
-            alias = lambda name, actual, visibility = None: got.update({name: actual}),
+            alias = lambda *, name, actual, visibility = None, tags = None: got.update({name: actual}),
         ),
         select = mock_select,
         glibc_versions = [],


### PR DESCRIPTION
With this change we get the current values of the python configuration
values printed in addition to the message printed previously. This
should help us advise users who don't have their builds configured
correctly.

We are adding an extra `build_setting` which we can set in order to get
an error message instead of a `DEBUG` warning. This has been documented
as part of our config settings and in the `no_match_error` in the
`select` statement.

Example output now
```console
$ bazel cquery --@rules_python//python/config_settings:python_version=3.12 @dev_pip//sphinx
WARNING: Build option --//python/config_settings:current_config has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
DEBUG: /home/aignas/src/github/aignas/rules_python/python/private/config_settings.bzl:200:14: The current configuration rules_python config flags is:
    @@//python/config_settings:pip_whl: "auto"
    @@//python/config_settings:pip_whl_glibc_version: ""
    @@//python/config_settings:pip_whl_muslc_version: ""
    @@//python/config_settings:pip_whl_osx_arch: "arch"
    @@//python/config_settings:pip_whl_osx_version: ""
    @@//python/config_settings:py_freethreaded: "no"
    @@//python/config_settings:py_linux_libc: "glibc"
    @@//python/config_settings:python_version: "3.12"

If the value is missing, then the default value is being used, see documentation:
https://rules-python.readthedocs.io/en/latest/api/rules_python/python/config_settings
ERROR: /home/aignas/.cache/bazel/_bazel_aignas/6f0de8c9128ee8d5dbf27ba6dcc48bdd/external/+pip+dev_pip/sphinx/BUILD.bazel:6:12: configurable attribute "actual" in @@+pip+dev_pip//sphinx:_no_match_error doesn't match this configuration: No matching wheel for current configuration's Python version.

The current build configuration's settings do not match any of the Python wheels available for this distribution. This distribution supports the following configuration settings:
    //_config:is_cp3.11_py3_none_any
    //_config:is_cp3.13_py3_none_any

To determine the current build configuration flag values, see the debug message above or re-run the build with:
    --@@//python/config_settings:current_config=fail

For other configuration, run:
    `bazel config <config id>` (shown further below)

This instance of @@+pip+dev_pip//sphinx:_no_match_error has configuration identifier 29ffcf8. To inspect its configuration, run: bazel config 29ffcf8.

For more help, see https://bazel.build/docs/configurable-attributes#faq-select-choose-condition.

ERROR: Analysis of target '@@+pip+dev_pip//sphinx:sphinx' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.100s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```

Fixes #2466
