### PR TITLE
fix(whl_library): track sources in whl_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Unreleased changes template.
   are now printing more details and include the currently active flag
   values. Fixes [#2466](https://github.com/bazelbuild/rules_python/issues/2466).
 * (py_proto_library) Fix import paths in Bazel 8.
+* (whl_library) Now the changes to the dependencies are correctly tracked when
+  PyPI packages used in {bzl:obj}`whl_library` during the `repository_rule` phase
+  change. Fixes [#2468](https://github.com/bazelbuild/rules_python/issues/2468).
 
 [pep-695]: https://peps.python.org/pep-0695/
 

--- a/python/private/pypi/deps.bzl
+++ b/python/private/pypi/deps.bzl
@@ -124,6 +124,13 @@ py_library(
 
 # Collate all the repository names so they can be easily consumed
 all_repo_names = [name for (name, _, _) in _RULE_DEPS]
+record_files = {
+    name: Label("@{}//:{}.dist-info/RECORD".format(
+        name,
+        url.rpartition("/")[-1].partition("-py3-none")[0],
+    ))
+    for (name, url, _) in _RULE_DEPS
+}
 
 def pypi_deps():
     """

--- a/python/private/pypi/evaluate_markers.bzl
+++ b/python/private/pypi/evaluate_markers.bzl
@@ -14,13 +14,14 @@
 
 """A simple function that evaluates markers using a python interpreter."""
 
+load(":deps.bzl", "record_files")
 load(":pypi_repo_utils.bzl", "pypi_repo_utils")
 
 # Used as a default value in a rule to ensure we fetch the dependencies.
 SRCS = [
     # When the version, or any of the files in `packaging` package changes,
     # this file will change as well.
-    Label("@pypi__packaging//:packaging-24.0.dist-info/RECORD"),
+    record_files["pypi__packaging"],
     Label("//python/private/pypi/requirements_parser:resolve_target_platforms.py"),
     Label("//python/private/pypi/whl_installer:platform.py"),
 ]

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -19,7 +19,7 @@ load("//python/private:envsubst.bzl", "envsubst")
 load("//python/private:is_standalone_interpreter.bzl", "is_standalone_interpreter")
 load("//python/private:repo_utils.bzl", "REPO_DEBUG_ENV_VAR", "repo_utils")
 load(":attrs.bzl", "ATTRS", "use_isolated")
-load(":deps.bzl", "all_repo_names")
+load(":deps.bzl", "all_repo_names", "record_files")
 load(":generate_whl_library_build_bazel.bzl", "generate_whl_library_build_bazel")
 load(":parse_whl_name.bzl", "parse_whl_name")
 load(":patch_whl.bzl", "patch_whl")
@@ -242,7 +242,7 @@ def _whl_library_impl(rctx):
         else:
             op_tmpl = "whl_library.ResolveRequirement({name}, {requirement})"
 
-        repo_utils.execute_checked(
+        pypi_repo_utils.execute_checked(
             rctx,
             # truncate the requirement value when logging it / reporting
             # progress since it may contain several ' --hash=sha256:...
@@ -250,6 +250,7 @@ def _whl_library_impl(rctx):
             op = op_tmpl.format(name = rctx.attr.name, requirement = rctx.attr.requirement.split(" ", 1)[0]),
             arguments = args,
             environment = environment,
+            srcs = rctx.attr._python_srcs,
             quiet = rctx.attr.quiet,
             timeout = rctx.attr.timeout,
             logger = logger,
@@ -291,13 +292,14 @@ def _whl_library_impl(rctx):
                 )
             ]
 
-    repo_utils.execute_checked(
+    pypi_repo_utils.execute_checked(
         rctx,
         op = "whl_library.ExtractWheel({}, {})".format(rctx.attr.name, whl_path),
         arguments = args + [
             "--whl-file",
             whl_path,
         ] + ["--platform={}".format(p) for p in target_platforms],
+        srcs = rctx.attr._python_srcs,
         environment = environment,
         quiet = rctx.attr.quiet,
         timeout = rctx.attr.timeout,
@@ -449,6 +451,16 @@ attr makes `extra_pip_args` and `download_only` ignored.""",
             Label("@" + repo + "//:BUILD.bazel")
             for repo in all_repo_names
         ],
+    ),
+    "_python_srcs": attr.label_list(
+        # Used as a default value in a rule to ensure we fetch the dependencies.
+        default = [
+            Label("//python/private/pypi/whl_installer:platform.py"),
+            Label("//python/private/pypi/whl_installer:wheel.py"),
+            Label("//python/private/pypi/whl_installer:wheel_installer.py"),
+            Label("//python/private/pypi/whl_installer:arguments.py"),
+            Label("//python/private/pypi/whl_installer:namespace_pkgs.py"),
+        ] + record_files.values(),
     ),
     "_rule_name": attr.string(default = "whl_library"),
 }, **ATTRS)


### PR DESCRIPTION
This is reusing a bit of code used in `evaluate_markers` and makes use
of the RECORD files in the `whl` files that we use to extract whls in
`whl_library`. This should be merged before #2514 to avoid any cache
invalidation issues downstream.

Fixes #2468
