### PR TITLE
feat(pypi): only query SimpleAPI for pkgs that have shas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Unreleased changes template.
 * Bazel 6 support is dropped and Bazel 7.4.1 is the minimum supported
   version, per our Bazel support matrix. Earlier versions are not
   tested by CI, so functionality cannot be guaranteed.
+* ({bzl:obj}`pip.parse`) Only query SimpleAPI for packages that have
+  sha values in the `requirements.txt` file.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/python/private/pypi/parse_requirements.bzl
+++ b/python/private/pypi/parse_requirements.bzl
@@ -184,6 +184,7 @@ def parse_requirements(
                 req.distribution: None
                 for reqs in requirements_by_platform.values()
                 for req in reqs.values()
+                if req.srcs.shas
             }),
         )
 

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -575,7 +575,7 @@ some_pkg==0.0.1
             index_url = "pypi.org",
             index_url_overrides = {},
             netrc = None,
-            sources = ["simple", "some_pkg"],
+            sources = ["simple"],
         ),
         "cache": {},
         "parallel_download": False,


### PR DESCRIPTION
Later in the code we would only use the results of SimpleAPI
if the package has shas, so actually doing these calls is just
wasting time, because we would be dropping the results anyway.

Work towards #2100
