### PR TITLE
refactor(pypi): further cleanup of `pip.parse` code

### DIFF
--- a/python/private/pypi/whl_repo_name.bzl
+++ b/python/private/pypi/whl_repo_name.bzl
@@ -18,18 +18,17 @@
 load("//python/private:normalize_name.bzl", "normalize_name")
 load(":parse_whl_name.bzl", "parse_whl_name")
 
-def whl_repo_name(prefix, filename, sha256):
+def whl_repo_name(filename, sha256):
     """Return a valid whl_library repo name given a distribution filename.
 
     Args:
-        prefix: {type}`str` the prefix of the whl_library.
         filename: {type}`str` the filename of the distribution.
         sha256: {type}`str` the sha256 of the distribution.
 
     Returns:
         a string that can be used in {obj}`whl_library`.
     """
-    parts = [prefix]
+    parts = []
 
     if not filename.endswith(".whl"):
         # Then the filename is basically foo-3.2.1.<ext>
@@ -51,11 +50,10 @@ def whl_repo_name(prefix, filename, sha256):
 
     return "_".join(parts)
 
-def pypi_repo_name(prefix, whl_name, *target_platforms):
+def pypi_repo_name(whl_name, *target_platforms):
     """Return a valid whl_library given a requirement line.
 
     Args:
-        prefix: {type}`str` the prefix of the whl_library.
         whl_name: {type}`str` the whl_name to use.
         *target_platforms: {type}`list[str]` the target platforms to use in the name.
 
@@ -63,7 +61,6 @@ def pypi_repo_name(prefix, whl_name, *target_platforms):
         {type}`str` that can be used in {obj}`whl_library`.
     """
     parts = [
-        prefix,
         normalize_name(whl_name),
     ]
     parts.extend([p.partition("_")[-1] for p in target_platforms])

--- a/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
+++ b/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
@@ -20,26 +20,25 @@ load("//python/private/pypi:whl_repo_name.bzl", "whl_repo_name")  # buildifier: 
 _tests = []
 
 def _test_simple(env):
-    got = whl_repo_name("prefix", "foo-1.2.3-py3-none-any.whl", "deadbeef")
-    env.expect.that_str(got).equals("prefix_foo_py3_none_any_deadbeef")
+    got = whl_repo_name("foo-1.2.3-py3-none-any.whl", "deadbeef")
+    env.expect.that_str(got).equals("foo_py3_none_any_deadbeef")
 
 _tests.append(_test_simple)
 
 def _test_sdist(env):
-    got = whl_repo_name("prefix", "foo-1.2.3.tar.gz", "deadbeef000deadbeef")
-    env.expect.that_str(got).equals("prefix_foo_sdist_deadbeef")
+    got = whl_repo_name("foo-1.2.3.tar.gz", "deadbeef000deadbeef")
+    env.expect.that_str(got).equals("foo_sdist_deadbeef")
 
 _tests.append(_test_sdist)
 
 def _test_platform_whl(env):
     got = whl_repo_name(
-        "prefix",
         "foo-1.2.3-cp39.cp310-abi3-manylinux1_x86_64.manylinux_2_17_x86_64.whl",
         "deadbeef000deadbeef",
     )
 
     # We only need the first segment of each
-    env.expect.that_str(got).equals("prefix_foo_cp39_abi3_manylinux_2_5_x86_64_deadbeef")
+    env.expect.that_str(got).equals("foo_cp39_abi3_manylinux_2_5_x86_64_deadbeef")
 
 _tests.append(_test_platform_whl)
 


### PR DESCRIPTION
Summary:
- Move the `whl_library` creation into a separate function and remove
  the `TODO` note.
- Move the creation of the `get_index_urls` functions into outer
  `parse_modules` function and simplify the reproducible extension
  setting logic.
- Remove the `prefix` parameter from the `*repo_name` functions.
- Add an extra error message, for ensuring that invariants are met.

Work towards #260
