### PR TITLE
feat: make pypi-generated targets include pyi files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Unreleased changes template.
   `python_version` attribute is still used to specify the Python version.
 * (pypi) Updated versions of packages: `pip` to 24.3.1 and
   `packaging` to 24.2.
+* (pypi) For pypi-generated targets, `*.pyi` files are included in the
+  `pyi_srcs` attribute instead of the `data` attribute.
 
 {#v0-0-0-deprecations}
 #### Deprecations
@@ -120,6 +122,7 @@ Unreleased changes template.
   only dependencies added. See {obj}`py_library.pyi_srcs` and
   `py_library.pyi_deps` (and the same named attributes for `py_binary` and
   `py_test`).
+* (pypi) pypi-generated targets set `pyi_srcs` to include `*.pyi` files.
 * (providers) {obj}`PyInfo` has new fields to aid static analysis tools:
   {obj}`direct_original_sources`, {obj}`direct_pyi_files`,
   {obj}`transitive_original_sources`, {obj}`transitive_pyi_files`.

--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -226,6 +226,7 @@ def whl_library_targets(
             "**/*.py",
             "**/*.pyc",
             "**/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNNN are created
+            "**/*.pyi",
             # RECORD is known to contain sha256 checksums of files which might include the checksums
             # of generated files produced when wheels are installed. The file is ignored to avoid
             # Bazel caching issues.
@@ -243,6 +244,9 @@ def whl_library_targets(
                 # Empty sources are allowed to support wheels that don't have any
                 # pure-Python code, e.g. pymssql, which is written in Cython.
                 allow_empty = True,
+            ),
+            pyi_srcs = native.glob(
+                ["site-packages/**/*.pyi"],
             ),
             data = data + native.glob(
                 ["site-packages/**/*"],

--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -247,6 +247,7 @@ def whl_library_targets(
             ),
             pyi_srcs = native.glob(
                 ["site-packages/**/*.pyi"],
+                allow_empty = True,
             ),
             data = data + native.glob(
                 ["site-packages/**/*"],

--- a/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
+++ b/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
@@ -245,12 +245,14 @@ def _test_whl_and_library_deps(env):
                 exclude = [],
                 allow_empty = True,
             ),
+            "pyi_srcs": _glob(["site-packages/**/*.pyi"], allow_empty = True),
             "data": [] + _glob(
                 ["site-packages/**/*"],
                 exclude = [
                     "**/*.py",
                     "**/*.pyc",
                     "**/*.pyc.*",
+                    "**/*.pyi",
                     "**/*.dist-info/RECORD",
                 ] + glob_excludes.version_dependent_exclusions(),
             ),

--- a/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
+++ b/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
@@ -316,12 +316,14 @@ def _test_group(env):
         {
             "name": "_pkg",
             "srcs": _glob(["site-packages/**/*.py"], exclude = [], allow_empty = True),
+            "pyi_srcs": _glob(["site-packages/**/*.pyi"], allow_empty = True),
             "data": [] + _glob(
                 ["site-packages/**/*"],
                 exclude = [
                     "**/*.py",
                     "**/*.pyc",
                     "**/*.pyc.*",
+                    "**/*.pyi",
                     "**/*.dist-info/RECORD",
                 ] + glob_excludes.version_dependent_exclusions(),
             ),


### PR DESCRIPTION
Make pypi-generated targets set `pyi_srcs` to include `*.pyi` files.

Work towards https://github.com/bazelbuild/rules_python/issues/2537