### PR TITLE
chore: update version strings in docs.

### DIFF
--- a/python/config_settings/transition.bzl
+++ b/python/config_settings/transition.bzl
@@ -15,7 +15,7 @@
 """The transition module contains the rule definitions to wrap py_binary and py_test and transition
 them to the desired target platform.
 
-:::{versionchanged} VERSION_NEXT_PATCH
+:::{versionchanged} 1.1.0
 The `py_binary` and `py_test` symbols are aliases to the regular rules. Usages
 of them should be changed to load the regular rules directly.
 :::

--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -383,7 +383,7 @@ These are dependencies that satisfy imports guarded by `typing.TYPE_CHECKING`.
 These are build-time only dependencies and not included as part of a runnable
 program (packaging rules may include them, however).
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.1.0
 :::
 """,
             providers = [
@@ -399,7 +399,7 @@ These are typically `.pyi` files, but other file types for type-checker specific
 formats are allowed. These files are build-time only dependencies and not included
 as part of a runnable program (packaging rules may include them, however).
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.1.0
 :::
 """,
             allow_files = True,

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -151,7 +151,7 @@ may be silently ignored, or an error may occur, depending on the toolchain
 configuration.
 :::
 
-:::{versionchanged} VERSION_NEXT_PATCH
+:::{versionchanged} 1.1.0
 
 This attribute was changed from only accepting `PY2` and `PY3` values to
 accepting arbitrary Python versions.

--- a/python/private/py_runtime_info.bzl
+++ b/python/private/py_runtime_info.bzl
@@ -147,7 +147,7 @@ the same conventions as the standard CPython interpreter.
 
 The runtime's ABI flags, i.e. `sys.abiflags`.
 
-:::{versionadded} 0.41.0
+:::{versionadded} 1.0.0
 :::
 """,
         "bootstrap_template": """
@@ -281,7 +281,7 @@ are (only) `"PY2"` and `"PY3"`.
 The template to use for the binary-specific site-init hook run by the
 interpreter at startup.
 
-:::{versionadded} 0.41.0
+:::{versionadded} 1.0.0
 :::
 """,
         "stage2_bootstrap_template": """


### PR DESCRIPTION
* Change "VERSION_NEXT" markers to upcoming 1.1.0 release
* Change incorrect 0.41.0 mention to 1.0.0