### PR TITLE
feat: Add feature to expose whether the native rules are used

### DIFF
--- a/python/features.bzl
+++ b/python/features.bzl
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Allows detecting of rules_python features that aren't easily detected."""
 
+load("@rules_python_internal//:rules_python_config.bzl", "config")
+
 # This is a magic string expanded by `git archive`, as set by `.gitattributes`
 # See https://git-scm.com/docs/git-archive/2.29.0#Documentation/git-archive.txt-export-subst
 _VERSION_PRIVATE = "$Format:%(describe:tags=true)$"
@@ -20,4 +22,5 @@ _VERSION_PRIVATE = "$Format:%(describe:tags=true)$"
 features = struct(
     version = _VERSION_PRIVATE if "$Format" not in _VERSION_PRIVATE else "",
     precompile = True,
+    uses_builtin_rules = not config.enable_pystar,
 )


### PR DESCRIPTION
Internally rules_python decides whether the implementation should use the legacy builtin rules from bazel or not.
The rules_python attributes have diverged from the builtin rules e.g. `precompile` and so a consumer of this library that wants to support bazel versions that are still using the legacy builtin rules needs a method to be able to query whether the rules are being used.

This change adds a entry to features.bzl to expose whether the legacy builtin rules are being used.
