### PR TITLE
chore: update release check to ignore VERSION_NEXT substring in CONTRIBUTING.md

### DIFF
--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -17,7 +17,8 @@ set -o errexit -o nounset -o pipefail
 
 # Exclude dot directories, specifically, this file so that we don't
 # find the substring we're looking for in our own file.
-if grep --exclude-dir=.* VERSION_NEXT_ -r; then
+# Exclude CONTRIBUTING.md because it documents how to use these strings.
+if grep --exclude=CONTRIBUTING.md --exclude-dir=.* VERSION_NEXT_ -r; then
   echo
   echo "Found VERSION_NEXT markers indicating version needs to be specified"
   exit 1


### PR DESCRIPTION
Otherwise the release action fails, thinking there are version markers.