### PR TITLE
fix: Don't fail in override from a non-root module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ Unreleased changes template.
 
 {#v0-0-0-changed}
 ### Changed
-* Nothing changed.
+* (pypi) {obj}`pip.override` will now be ignored instead of raising an error,
+  fixes [#2550](https://github.com/bazelbuild/rules_python/issues/2550).
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -387,7 +387,9 @@ You cannot use both the additive_build_content and additive_build_content_file a
     for module in module_ctx.modules:
         for attr in module.tags.override:
             if not module.is_root:
-                fail("overrides are only supported in root modules")
+                # Overrides are only supported in root modules. Silently
+                # ignore the override:
+                continue
 
             if not attr.file.endswith(".whl"):
                 fail("Only whl overrides are supported at this time")


### PR DESCRIPTION
This patch enable calls to pypi override from a non-root module without failing. The call will instead be silently ignored.

Fixes #2550