### PR TITLE
fix: make coverage work with bootstrap=script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Unreleased changes template.
 * (gazelle) Providing multiple input requirements files to `gazelle_python_manifest` now works correctly.
 * (pypi) Handle trailing slashes in pip index URLs in environment variables,
   fixes [#2554](https://github.com/bazelbuild/rules_python/issues/2554).
+* (coverage) Coverage with `--bootstrap_impl=script` is fixed
+  ([#2572](https://github.com/bazelbuild/rules_python/issues/2572)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -557,6 +557,17 @@ def _create_venv(ctx, output_prefix, imports, runtime_details):
     site_init = ctx.actions.declare_file("{}/_bazel_site_init.py".format(site_packages))
     computed_subs = ctx.actions.template_dict()
     computed_subs.add_joined("%imports%", imports, join_with = ":", map_each = _map_each_identity)
+
+    if (ctx.configuration.coverage_enabled and
+        runtime and
+        runtime.coverage_tool):
+        coverage_tool_runfiles_path = "{}/{}".format(
+            ctx.workspace_name,
+            runtime.coverage_tool.short_path,
+        )
+    else:
+        coverage_tool_runfiles_path = ""
+
     ctx.actions.expand_template(
         template = runtime.site_init_template,
         output = site_init,
@@ -564,6 +575,7 @@ def _create_venv(ctx, output_prefix, imports, runtime_details):
             "%import_all%": "True" if ctx.fragments.bazel_py.python_import_all_repositories else "False",
             "%site_init_runfiles_path%": "{}/{}".format(ctx.workspace_name, site_init.short_path),
             "%workspace_name%": ctx.workspace_name,
+            "%coverage_tool%": coverage_tool_runfiles_path,
         },
         computed_substitutions = computed_subs,
     )

--- a/python/private/site_init_template.py
+++ b/python/private/site_init_template.py
@@ -163,7 +163,7 @@ def _setup_sys_path():
         if cov_tool:
             _print_verbose_coverage(f"Using toolchain coverage_tool {cov_tool}")
         elif cov_tool := os.environ.get("PYTHON_COVERAGE"):
-            _print_verbose_coverage(f"PYTHON_COVERAGE: {cov_tool}")
+            _print_verbose_coverage(f"Using env var coverage: PYTHON_COVERAGE={cov_tool}")
 
         if cov_tool:
             if os.path.isabs(cov_tool):
@@ -185,7 +185,7 @@ def _setup_sys_path():
             coverage_setup = True
         else:
             _print_verbose_coverage(
-                "Coverage was enabled, but python coverage tool was not configured. "
+                "Coverage was enabled, but the coverage tool was not found or valid. "
                 + "To enable coverage, consult the docs at "
                 + "https://rules-python.readthedocs.io/en/latest/coverage.html"
             )
@@ -194,3 +194,4 @@ def _setup_sys_path():
 
 
 COVERAGE_SETUP = _setup_sys_path()
+_print_verbose("DONE")

--- a/python/private/site_init_template.py
+++ b/python/private/site_init_template.py
@@ -185,7 +185,7 @@ def _setup_sys_path():
             coverage_setup = True
         else:
             _print_verbose_coverage(
-                "Coverage was enabled, but python coverage tool was not configured."
+                "Coverage was enabled, but python coverage tool was not configured. "
                 + "To enable coverage, consult the docs at "
                 + "https://rules-python.readthedocs.io/en/latest/coverage.html"
             )

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -106,8 +106,8 @@ def print_verbose(*args, mapping=None, values=None):
 
 def print_verbose_coverage(*args):
     """Print output if VERBOSE_COVERAGE is non-empty in the environment."""
-    if os.environ.get("VERBOSE_COVERAGE"):
-        print(*args, file=sys.stderr, flush=True)
+    if is_verbose_coverage():
+        print("bootstrap: coverage:", *args, file=sys.stderr, flush=True)
 
 
 def is_verbose_coverage():
@@ -397,6 +397,8 @@ def main():
         coverage_enabled = _bazel_site_init.COVERAGE_SETUP
     else:
         coverage_enabled = False
+
+    print_verbose_coverage("coverage_enabled:", coverage_enabled)
 
     with _maybe_collect_coverage(enable=coverage_enabled):
         # The first arg is this bootstrap, so drop that for the re-invocation.


### PR DESCRIPTION
The script based bootstrap wasn't expanding the coverage template variable, which prevented
coverage from activating. This was introduced when it was switched to the venv layout.

To fix, expand the `%coverage_tool%` template variable as done elsewhere.

Tested manually, per repro instructions in #2572. While I did devise a way to mostly
test this without an integration test, it was thwarted by some other bugs.

Along the way, improve some of the bootstrap debug output and fix a comment.

Fixes https://github.com/bazelbuild/rules_python/issues/2572