### PR TITLE
fix(sphinxdocs): do not crash when tag_class does not have doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Unreleased changes template.
   as UTF-8 on all platforms.
 * (coverage) Coverage with `--bootstrap_impl=script` is fixed
   ([#2572](https://github.com/bazelbuild/rules_python/issues/2572)).
+* (sphinxdocs) Do not crash when `tag_class` does not have a populated `doc` value.
+  Fixes ([#2579](https://github.com/bazelbuild/rules_python/issues/2579)).
 
 {#v0-0-0-added}
 ### Added

--- a/sphinxdocs/private/proto_to_markdown.py
+++ b/sphinxdocs/private/proto_to_markdown.py
@@ -197,7 +197,7 @@ class _MySTRenderer:
             # Ensure a newline between the directive and the doc fields,
             # otherwise they get parsed as directive options instead.
             if not doc_string and tag.attribute:
-                self.write("\n")
+                self._write("\n")
             self._render_attributes(tag.attribute)
             self._write(":::::\n")
         self._write("::::::\n")

--- a/sphinxdocs/tests/proto_to_markdown/proto_to_markdown_test.py
+++ b/sphinxdocs/tests/proto_to_markdown/proto_to_markdown_test.py
@@ -82,6 +82,14 @@ module_extension_info: {
       default_value: "[BZLMOD_EXT_TAG_A_ATTRIBUTE_1_DEFAULT_VALUE]"
     }
   }
+  tag_class: {
+    tag_name: "bzlmod_ext_tag_no_doc"
+    attribute: {
+      name: "bzlmod_ext_tag_a_attribute_2",
+      type: STRING_LIST
+      default_value: "[BZLMOD_EXT_TAG_A_ATTRIBUTE_2_DEFAULT_VALUE]"
+    }
+  }
 }
 repository_rule_info: {
   rule_name: "repository_rule",
@@ -151,6 +159,9 @@ class ProtoToMarkdownTest(absltest.TestCase):
         self.assertRegex(actual, "bzlmod_ext_tag_a_attribute_1")
         self.assertRegex(actual, "BZLMOD_EXT_TAG_A_ATTRIBUTE_1_DOC_STRING")
         self.assertRegex(actual, "BZLMOD_EXT_TAG_A_ATTRIBUTE_1_DEFAULT_VALUE")
+        self.assertRegex(actual, "{bzl:tag-class} bzlmod_ext_tag_no_doc")
+        self.assertRegex(actual, "bzlmod_ext_tag_a_attribute_2")
+        self.assertRegex(actual, "BZLMOD_EXT_TAG_A_ATTRIBUTE_2_DEFAULT_VALUE")
 
         self.assertRegex(actual, "{bzl:repo-rule} repository_rule")
         self.assertRegex(actual, "REPOSITORY_RULE_DOC_STRING")


### PR DESCRIPTION
It seems that there was a typo in the code and instead of calling
`self._write` we were calling `self.write`. It went unnoticed because of
lack of coverage. This adds test code exercising the edge case and fixes
the typo.

Fixes #2579
