### PR TITLE
tests: don't propagage inner py_binary env to outer sh_test

### DIFF
--- a/tests/support/sh_py_run_test.bzl
+++ b/tests/support/sh_py_run_test.bzl
@@ -86,8 +86,6 @@ def _py_reconfig_impl(ctx):
                 default_info.default_runfiles,
             ),
         ),
-        # Inherit the expanded environment from the inner target.
-        ctx.attr.target[RunEnvironmentInfo],
     ]
 
 def _make_reconfig_rule(**kwargs):


### PR DESCRIPTION
Per conversation in #2507, don't propagate the inner py_binary env to the outer sh_test.
This is because the sh-side expects to call the Python program with a particular environment
state, and it can't do that if the inner Python program is secretly setting things
in the environment.