### PR TITLE
feat: new COVERAGEPY_IGNORE_ERRORS env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ Unreleased changes template.
 
 {#v0-0-0-added}
 ### Added
-* Nothing added.
+* (coverage) New COVERAGEPY_IGNORE_ERRORS environment var that adds the `--ignore-errors`
+  flag to coverage.py when producing the lcov output file.
 
 {#v0-0-0-removed}
 ### Removed

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -461,7 +461,8 @@ relative_files = True
     kparams['stdout'] = sys.stderr
     kparams['stderr'] = sys.stderr
 
-  # Workaround for coveragepy having weird errors.
+  # Ignore errors finding source files during coverage.py reporting
+  # See https://coverage.readthedocs.io/en/7.6.10/cmd.html#reporting
   # See: https://github.com/bazelbuild/rules_python/issues/2575
   if os.getenv("COVERAGEPY_IGNORE_ERRORS"):
     params.append("--ignore-errors")

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -461,6 +461,11 @@ relative_files = True
     kparams['stdout'] = sys.stderr
     kparams['stderr'] = sys.stderr
 
+  # Workaround for coveragepy having weird errors.
+  # See: https://github.com/bazelbuild/rules_python/issues/2575
+  if os.getenv("COVERAGEPY_IGNORE_ERRORS"):
+    params.append("--ignore-errors")
+
   ret_code = subprocess.call(
     params,
     **kparams


### PR DESCRIPTION
## Background

This is a proposal to have a workaround for https://github.com/bazelbuild/rules_python/issues/2575 where an inherent issue from [coverage.py](https://coverage.readthedocs.io/en/7.6.10/) when creating the lcov output file.

## Proposed Changes

An env var flag that a user can turn on via `--test_env=COVERAGEPY_IGNORE_ERRORS=true` when running `bazel coverage`.

## Reproducible steps

We can see how this proposal addresses the issue described from https://github.com/BurnzZ/rules_python.

1. Clone the repo: https://github.com/BurnzZ/rules_python

```
git clone https://github.com/BurnzZ/rules_python.git rules_python_tmp
cd rules_python_tmp/examples
git checkout feat-new-env-var-COVERAGEPY_IGNORE_ERRORS
```

2. Clone the reproducible example

```
git clone https://github.com/BurnzZ/bazel-python-coverage-issue.git
cd bazel-python-coverage-issue
git checkout enable-torchvision
```

3. Add these lines in line 2 of `MODULE.bazel`:

```
local_path_override(
    module_name = "rules_python",
    path = "../..",
)
```

4. Generate the coverage report:

```
bazel coverage --combined_report=lcov :test --nocache_test_results --test_output=all --test_env=COVERAGEPY_IGNORE_ERRORS=true
lcov --list "$(bazel info output_path)/_coverage/_coverage_report.dat"
genhtml --branch-coverage --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
```

Issue from https://github.com/bazelbuild/rules_python/issues/2575 now resolved. 🎉 