### PR TITLE
fix(coverage): prevent issues when packages execute files in tmp dir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Unreleased changes template.
   The related issue is [#908](https://github.com/bazelbuild/rules_python/issue/908).
 * (sphinxdocs) Do not crash when `tag_class` does not have a populated `doc` value.
   Fixes ([#2579](https://github.com/bazelbuild/rules_python/issues/2579)).
+* (coverage) Prevent coveragepy report issues when packages execute files in tmp dir.
+  Fixes ([#2575](https://github.com/bazelbuild/rules_python/issues/2575)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -461,6 +461,9 @@ relative_files = True
     kparams['stdout'] = sys.stderr
     kparams['stderr'] = sys.stderr
 
+  # Prevent coveragepy report issues when packages execute files in tmp dir.
+  params.append('--omit="$TMPDIR/*"')
+
   ret_code = subprocess.call(
     params,
     **kparams

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -462,7 +462,9 @@ relative_files = True
     kparams['stderr'] = sys.stderr
 
   # Prevent coveragepy report issues when packages execute files in tmp dir.
-  params.append('--omit="$TMPDIR/*"')
+  import tempfile
+  omit_pattern = os.path.join(tempfile.gettempdir(), "*")
+  params.append(f'--omit={omit_pattern}')
 
   ret_code = subprocess.call(
     params,

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -462,6 +462,7 @@ relative_files = True
     kparams['stderr'] = sys.stderr
 
   # Prevent coveragepy report issues when packages execute files in tmp dir.
+  # See https://github.com/nedbat/coveragepy/issues/1921#issuecomment-2629154773.
   import tempfile
   omit_pattern = os.path.join(tempfile.gettempdir(), "*")
   params.append(f'--omit={omit_pattern}')


### PR DESCRIPTION
## Background

(A good addition to https://github.com/bazelbuild/rules_python/pull/2597)

This is a proposal to have a workaround for https://github.com/bazelbuild/rules_python/issues/2575 where an inherent issue from [coverage.py](https://coverage.readthedocs.io/en/7.6.10/) when creating the lcov output file.

## Proposed Changes

Add an `--omit='...'` flag pointing to tempdir.

## Reproducible steps

We can see how this proposal addresses the issue described from https://github.com/BurnzZ/rules_python.

1. Clone the repo: https://github.com/BurnzZ/rules_python

```
git clone https://github.com/BurnzZ/rules_python.git rules_python_tmp
cd rules_python_tmp/examples
git checkout fix-omit-tmpdir-coveragepy
```

2. Clone the reproducible example

```
git clone https://github.com/BurnzZ/bazel-python-coverage-issue.git
cd bazel-python-coverage-issue
git checkout enable-torchvision
```

3. Add these lines in line 2 of `MODULE.bazel`:

```
local_path_override(
    module_name = "rules_python",
    path = "../..",
)
```

4. Generate the coverage report:

```
bazel coverage --combined_report=lcov :test --nocache_test_results --test_output=all
lcov --list "$(bazel info output_path)/_coverage/_coverage_report.dat"
genhtml --branch-coverage --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
```