### PR TITLE
docs: add changelog update for //python/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ Unreleased changes template.
 
 {#v0-0-0-added}
 ### Added
-* Nothing added.
+* {obj}`//python/bin:python`: convenience target for directly running an
+  interpreter. {obj}`--//python/bin:python_src` can be used to specify a
+  binary whose interpreter to use.
 
 {#v0-0-0-removed}
 ### Removed


### PR DESCRIPTION
This was a forgotten part of the original PR (#2507) implementing it.