### PR TITLE
refactor: cleanup now-unreferenced proto toolchain type

### DIFF
--- a/python/proto/BUILD.bazel
+++ b/python/proto/BUILD.bazel
@@ -14,10 +14,9 @@
 
 package(default_visibility = ["//visibility:public"])
 
-# Toolchain type provided by proto_lang_toolchain rule and used by py_proto_library
-# Deprecated in favour of the implementation in https://github.com/protocolbuffers/protobuf.
-# It will be removed in a future release.
+# Deprecated; use @com_google_protobuf//bazel/private:python_toolchain_type instead.
 # Alias is here to provide backward-compatibility; see #2604
+# It will be removed in a future release.
 alias(
     name = "toolchain_type",
     actual = "@com_google_protobuf//bazel/private:python_toolchain_type",

--- a/python/proto/BUILD.bazel
+++ b/python/proto/BUILD.bazel
@@ -15,4 +15,8 @@
 package(default_visibility = ["//visibility:public"])
 
 # Toolchain type provided by proto_lang_toolchain rule and used by py_proto_library
-toolchain_type(name = "toolchain_type")
+# Alias is here to provide backward-compatibility; see #2604
+alias(
+    name = "toolchain_type",
+    actual = "@com_google_protobuf//bazel/private:python_toolchain_type",
+)

--- a/python/proto/BUILD.bazel
+++ b/python/proto/BUILD.bazel
@@ -15,6 +15,8 @@
 package(default_visibility = ["//visibility:public"])
 
 # Toolchain type provided by proto_lang_toolchain rule and used by py_proto_library
+# Deprecated in favour of the implementation in https://github.com/protocolbuffers/protobuf.
+# It will be removed in a future release.
 # Alias is here to provide backward-compatibility; see #2604
 alias(
     name = "toolchain_type",

--- a/python/proto/BUILD.bazel
+++ b/python/proto/BUILD.bazel
@@ -20,4 +20,5 @@ package(default_visibility = ["//visibility:public"])
 alias(
     name = "toolchain_type",
     actual = "@com_google_protobuf//bazel/private:python_toolchain_type",
+    deprecation = "Use @com_google_protobuf//bazel/private:python_toolchain_type instead",
 )


### PR DESCRIPTION
Follow-up to #2604, fixes a breaking change in v1.2.0-rc0

Note that this toolchain_type became unused in that PR. We leave behind an alias to make this a non-breaking change.

Verified in a downstream repo that requires the toolchain_type to register pre-built `protoc`: https://github.com/aspect-build/toolchains_protoc/pull/50/files
