### PR TITLE
ci: use Python 3.9 for mypy workflow to fix ci

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -22,11 +22,10 @@ jobs:
       - uses: jpetrucciani/mypy-check@master
         with:
           requirements: 1.6.0
-          python_version: 3.8
+          python_version: 3.11
           path: 'python/runfiles'
       - uses: jpetrucciani/mypy-check@master
         with:
           requirements: 1.6.0
-          python_version: 3.8
+          python_version: 3.11
           path: 'tests/runfiles'
-      

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -22,10 +22,10 @@ jobs:
       - uses: jpetrucciani/mypy-check@master
         with:
           requirements: 1.6.0
-          python_version: 3.11
+          python_version: 3.9
           path: 'python/runfiles'
       - uses: jpetrucciani/mypy-check@master
         with:
           requirements: 1.6.0
-          python_version: 3.11
+          python_version: 3.9
           path: 'tests/runfiles'


### PR DESCRIPTION
The mypy check on CI has been failing. The problem was the combination of:
* We were using Python 3.8
* jpetrucciani/mypy-check@master updated to use mypy 1.15
* mypy 1.15 dropped support for Python 3.8

To fix, use Python 3.9.