### PR TITLE
docs: fix changelog header for 1.2.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Unreleased changes template.
 * Nothing removed.
 
 {#v1-2-0}
-## Unreleased
+## [1.2.0] - 2025-02-21
 
 [1.2.0]: https://github.com/bazelbuild/rules_python/releases/tag/1.2.0
 


### PR DESCRIPTION
When adding the 1.2 section, everything was updated exception the section title.