### PR TITLE
Add error for pip.parse attrs that require other attrs

### DIFF
--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -481,6 +481,10 @@ You cannot use both the additive_build_content and additive_build_content_file a
                     cache = simpleapi_cache,
                     parallel_download = pip_attr.parallel_download,
                 )
+            elif pip_attr.experimental_extra_index_urls:
+                fail("'experimental_extra_index_urls' is a no-op unless 'experimental_index_url' is set")
+            elif pip_attr.experimental_index_url_overrides:
+                fail("'experimental_index_url_overrides' is a no-op unless 'experimental_index_url' is set")
 
             out = _create_whl_repos(
                 module_ctx,


### PR DESCRIPTION
This makes it more clear when you've misconfigured pip.parse
