### PR TITLE
fix(gazelle): Include YAML 'docstart' in gazelle manifest file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,13 @@ Unreleased changes template.
 * (deps) platforms 0.0.4 -> 0.0.11
 * (py_wheel) Package `py_library.pyi_srcs` (`.pyi` files) in the wheel.
 * (py_package) Package `py_library.pyi_srcs` (`.pyi` files) in `py_package`.
+* (gazelle) The generated manifest file (default: `gazelle_python.yaml`) will now include the
+  YAML document start `---` line. Implemented in [#x[().
 
 {#v0-0-0-fixed}
 ### Fixed
 * (pypi) The `ppc64le` is now pointing to the right target in the `platforms` package.
-* (gazelle) No longer incorrectly merge `py_binary` targets during partial updates in 
+* (gazelle) No longer incorrectly merge `py_binary` targets during partial updates in
   `file` generation mode. Fixed in [#2619](https://github.com/bazelbuild/rules_python/pull/2619).
 * (bzlmod) Running as root is no longer an error. `ignore_root_user_error=True`
   is now the default. Note that running as root may still cause spurious

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ Unreleased changes template.
 * (py_wheel) Package `py_library.pyi_srcs` (`.pyi` files) in the wheel.
 * (py_package) Package `py_library.pyi_srcs` (`.pyi` files) in `py_package`.
 * (gazelle) The generated manifest file (default: `gazelle_python.yaml`) will now include the
-  YAML document start `---` line. Implemented in [#x[().
+  YAML document start `---` line. Implemented in
+  [#2656](https://github.com/bazelbuild/rules_python/pull/2656).
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/examples/build_file_generation/gazelle_python.yaml
+++ b/examples/build_file_generation/gazelle_python.yaml
@@ -3,6 +3,7 @@
 # To update this file, run:
 #   bazel run //:gazelle_python_manifest.update
 
+---
 manifest:
   modules_mapping:
     alabaster: alabaster

--- a/examples/bzlmod_build_file_generation/gazelle_python.yaml
+++ b/examples/bzlmod_build_file_generation/gazelle_python.yaml
@@ -3,6 +3,7 @@
 # To update this file, run:
 #   bazel run //:gazelle_python_manifest.update
 
+---
 manifest:
   modules_mapping:
     S3: s3cmd

--- a/examples/bzlmod_build_file_generation/gazelle_python_with_types.yaml
+++ b/examples/bzlmod_build_file_generation/gazelle_python_with_types.yaml
@@ -3,6 +3,7 @@
 # To update this file, run:
 #   bazel run //:gazelle_python_manifest_with_types.update
 
+---
 manifest:
   modules_mapping:
     S3: s3cmd

--- a/gazelle/manifest/generate/generate.go
+++ b/gazelle/manifest/generate/generate.go
@@ -151,7 +151,7 @@ func writeOutput(
 	}
 	defer outputFile.Close()
 
-	if _, err := fmt.Fprintf(outputFile, "%s\n", header); err != nil {
+	if _, err := fmt.Fprintf(outputFile, "%s\n---\n", header); err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
 	}
 


### PR DESCRIPTION
Update `gazelle_python.yaml` to include the YAML docstart string:

```diff
-- a/gazelle_python.yaml
+++ b/gazelle_python.yaml
@@ -3,6 +3,7 @@
 # To update this file, run:
 #   bazel run //:gazelle_python_manifest.update
 
+---
 manifest:
   modules_mapping:
     30fcd23745efe32ce681__mypyc: black
```

While _technically_ not required, it is good practice to include. And then users don't have to exclude `gazelle_python.yaml` from their linters :upside_down_face:.

/cc @joshgc