### PR TITLE
fix(gazelle): Explicitly call sys.exit in the modules_mapping generator

### DIFF
--- a/gazelle/modules_mapping/generator.py
+++ b/gazelle/modules_mapping/generator.py
@@ -164,4 +164,4 @@ if __name__ == "__main__":
     generator = Generator(
         sys.stderr, args.output_file, args.exclude_patterns, args.include_stub_packages
     )
-    exit(generator.run(args.wheels))
+    sys.exit(generator.run(args.wheels))


### PR DESCRIPTION
When running python with `-S` to disable the `site` module, `exit` isn't implicitly imported and you need to explicitly call `sys.exit` instead. Seems to be a remnant of the REPL
