### PR TITLE
feat!: always generating py_library

### DIFF
--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -55,6 +55,9 @@ func (*Resolver) Name() string { return languageName }
 // If nil is returned, the rule will not be indexed. If any non-nil slice is
 // returned, including an empty slice, the rule will be indexed.
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	if r.Kind() == GetActualKindName(pyBinaryKind, c) {
+		return nil
+	}
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
 	cfg := cfgs[f.Pkg]
 	srcs := r.AttrStrings("srcs")

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.in
@@ -3,6 +3,6 @@
 # gazelle:resolve py pandas @pip//:pandas
 
 filegroup(
-    name = "collided_main",
+    name = "collided_main_bin",
     srcs = ["collided_main.py"],
 )

--- a/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint/BUILD.out
@@ -5,12 +5,12 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 # gazelle:resolve py pandas @pip//:pandas
 
 filegroup(
-    name = "collided_main",
+    name = "collided_main_bin",
     srcs = ["collided_main.py"],
 )
 
 py_binary(
-    name = "main",
+    name = "main_bin",
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],
     deps = [
@@ -20,7 +20,7 @@ py_binary(
 )
 
 py_binary(
-    name = "main2",
+    name = "main2_bin",
     srcs = ["main2.py"],
     visibility = ["//:__subpackages__"],
     deps = [":py_default_library"],

--- a/gazelle/python/testdata/binary_without_entrypoint/test.yaml
+++ b/gazelle/python/testdata/binary_without_entrypoint/test.yaml
@@ -15,4 +15,4 @@
 ---
 expect:
   stderr: |
-    gazelle: failed to generate target "//:collided_main" of kind "py_binary": a target of kind "filegroup" with the same name already exists
+    gazelle: failed to generate target "//:collided_main_bin" of kind "py_binary": a target of kind "filegroup" with the same name already exists

--- a/gazelle/python/testdata/binary_without_entrypoint_per_file_generation/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint_per_file_generation/BUILD.out
@@ -26,12 +26,25 @@ py_library(
 )
 
 py_binary(
+    name = "lib_and_main_bin",
+    srcs = ["lib_and_main.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
     name = "lib_and_main",
     srcs = ["lib_and_main.py"],
     visibility = ["//:__subpackages__"],
 )
 
 py_binary(
+    name = "main_bin",
+    srcs = ["main.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@pip//:pandas"],
+)
+
+py_library(
     name = "main",
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],
@@ -39,6 +52,13 @@ py_binary(
 )
 
 py_binary(
+    name = "main2_bin",
+    srcs = ["main2.py"],
+    visibility = ["//:__subpackages__"],
+    deps = [":lib2"],
+)
+
+py_library(
     name = "main2",
     srcs = ["main2.py"],
     visibility = ["//:__subpackages__"],

--- a/gazelle/python/testdata/binary_without_entrypoint_per_file_generation_partial_update/BUILD.in
+++ b/gazelle/python/testdata/binary_without_entrypoint_per_file_generation_partial_update/BUILD.in
@@ -3,7 +3,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 # gazelle:python_generation_mode file
 
 py_binary(
-    name = "a",
+    name = "a_bin",
     srcs = ["a.py"],
     visibility = ["//:__subpackages__"],
 )

--- a/gazelle/python/testdata/binary_without_entrypoint_per_file_generation_partial_update/BUILD.out
+++ b/gazelle/python/testdata/binary_without_entrypoint_per_file_generation_partial_update/BUILD.out
@@ -1,14 +1,26 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 # gazelle:python_generation_mode file
 
 py_binary(
+    name = "a_bin",
+    srcs = ["a.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
     name = "a",
     srcs = ["a.py"],
     visibility = ["//:__subpackages__"],
 )
 
 py_binary(
+    name = "b_bin",
+    srcs = ["b.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
     name = "b",
     srcs = ["b.py"],
     visibility = ["//:__subpackages__"],

--- a/gazelle/python/testdata/py312_syntax/BUILD.out
+++ b/gazelle/python/testdata/py312_syntax/BUILD.out
@@ -9,6 +9,13 @@ py_library(
 )
 
 py_binary(
+    name = "pep_695_type_parameter_bin",
+    srcs = ["pep_695_type_parameter.py"],
+    visibility = ["//:__subpackages__"],
+    deps = [":_other_module"],
+)
+
+py_library(
     name = "pep_695_type_parameter",
     srcs = ["pep_695_type_parameter.py"],
     visibility = ["//:__subpackages__"],


### PR DESCRIPTION
This PR makes sure that all non-test Python modules are covered by a `py_library` target. When a module is imported by another target, Gazelle no longer resolves it to `py_binary` and only resolves to `py_library`, which is consistent with other languages.

Note that in file mode, this means there would be duplicate `py_binary` and `py_library`, with the same `srcs` and `deps` (see changed test cases). Because these attributes are maintained by Gazelle, there is no additional maintenance cost from the users. To reduce the duplication, we will need to change rules_python to add an `embeds` attribute to `py_binary`, so it can inherit all `srcs` and `deps` from `py_library`, similar to the `embeds` attribute of Go rules. 

In addition, this PR renames the `py_binary` target of `foo.py` to `foo_bin` and use `foo` for the `py_library`, to be consistent with the current naming convention in package mode. However, this requires users to remove or rename their existing `py_binary` rules during the migration.

This is an alternative implementation of #2822. cc @yushan26
