### PR TITLE
Resolve relative symlinks in bootstrap script

### DIFF
--- a/python/private/stage1_bootstrap_template.sh
+++ b/python/private/stage1_bootstrap_template.sh
@@ -104,6 +104,10 @@ else
         stub_filename="${stub_filename%/*}/$stub_filename_target"
       fi
       unset stub_filename_target
+      if [[ ! -e "$stub_filename" ]]; then
+        echo >&2 "Unable to find runfiles directory for $1: dangling symlink: $stub_filename"
+        exit 1
+      fi
     done
     echo >&2 "Unable to find runfiles directory for $1"
     exit 1


### PR DESCRIPTION
Currently, the bootstrap script only accepts absolute symlinks.

Implements a patch to resolve relative symlinks.

Adds an extra, take it if you want it, patch that adds an explicit error when a symlink is dangling.