### PR TITLE
chore: remove bcr app settings

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-fixedReleaser:
-  login: f0rmiga
-  email: 3149049+f0rmiga@users.noreply.github.com
 moduleRoots: [".", "gazelle"]


### PR DESCRIPTION
The fixedRelease setting is only relevant to the BCR App, which we don't use anymore.