### PR TITLE
perf: improve analysis performance by 95% for `py_binary` and `py_test` rules

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//python:py_binary.bzl", "py_binary")
 load("//python:py_library.bzl", "py_library")
 load(":print_toolchain_checksums.bzl", "print_toolchains_checksums")
@@ -827,6 +828,19 @@ py_binary(
     visibility = [
         "//visibility:public",
     ],
+)
+
+# Used for py_executable rule
+# C++ wrapper for zipper to process Python zip manifests
+cc_binary(
+    name = "py_executable_zip_gen",
+    srcs = ["py_executable_zip_gen.cc"],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["/std:c++17"],
+        "//conditions:default": ["-std=c++17"],
+    }),
+    data = ["@bazel_tools//tools/zip:zipper"],
+    deps = ["@bazel_tools//tools/cpp/runfiles"],
 )
 
 py_binary(

--- a/python/private/py_executable_zip_gen.cc
+++ b/python/private/py_executable_zip_gen.cc
@@ -1,0 +1,291 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Wrapper for zipper that processes Python zip manifest generation.
+//
+// This C++ script wraps `@bazel_tools//tools/zip/zipper` to produce the
+// input manifest for the zipper tool during build time, rather than at
+// analysis time.
+//
+// Usage: py_executable_zip_gen [flags...] <input_files_manifest>
+//   Flags are passed as regular command-line arguments
+//   Input files manifest contains the list of files to include (short_path=disk_path)
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+namespace fs = std::filesystem;
+
+// Path manipulation utilities
+namespace path {
+
+// Normalize a path (remove "../" and "." components)
+std::string normalize(const std::string &p) {
+  return fs::path(p).lexically_normal().generic_string();
+}
+
+// Remove prefix from path
+std::string relativize(const std::string &path, const std::string &prefix) {
+  if (path.size() >= prefix.size() && path.compare(0, prefix.size(), prefix) == 0) {
+    size_t start = prefix.size();
+    if (start < path.size() && path[start] == '/') {
+      start++;
+    }
+    return path.substr(start);
+  }
+  return path;
+}
+
+bool starts_with(const std::string &str, const std::string &prefix) {
+  return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
+}  // namespace path
+
+struct FileEntry {
+  std::string short_path;
+  std::string disk_path;
+
+  // Parse a file entry in "short_path=disk_path" format
+  static FileEntry parse(const std::string &line) {
+    FileEntry entry;
+    size_t eq = line.find('=');
+    if (eq == std::string::npos) {
+      std::cerr << "ERROR: Invalid file entry (no '='): " << line << std::endl;
+      std::exit(1);
+    }
+
+    entry.short_path = line.substr(0, eq);
+    entry.disk_path = line.substr(eq + 1);
+
+    return entry;
+  }
+};
+
+// Get path inside the zip where a file should go
+std::string get_zip_runfiles_path(const std::string &path, const std::string &workspace_name,
+                                  bool legacy_external_runfiles) {
+  std::string zip_runfiles_path;
+
+  if (legacy_external_runfiles && path::starts_with(path, "external/")) {
+    zip_runfiles_path = path::relativize(path, "external");
+  } else {
+    // Normalize workspace_name/../external/path to external/path
+    std::string combined = workspace_name + "/" + path;
+    zip_runfiles_path = path::normalize(combined);
+  }
+
+  return "runfiles/" + zip_runfiles_path;
+}
+
+// Check if an executable exists in runfiles, accounting for Windows file extensions.
+// Returns the path if found, otherwise an empty string.
+std::string find_executable_in_runfiles(Runfiles *runfiles, const std::string &runfile_path) {
+  std::string path = runfiles->Rlocation(runfile_path);
+  if (path.empty()) {
+    return "";
+  }
+
+#ifndef _WIN32
+  if (std::filesystem::exists(path)) {
+    return path;
+  }
+#else
+  // On Windows, try common executable extensions
+  std::string path_with_ext;
+  const std::vector<std::string> extensions = {".exe", ".bat", ".cmd"};
+  for (const auto &ext : extensions) {
+    path_with_ext = path + ext;
+    if (std::filesystem::exists(path_with_ext)) {
+      return path_with_ext;
+    }
+  }
+#endif
+
+  return "";  // Not found
+}
+
+struct Config {
+  std::string output;
+  std::string workspace_name;
+  std::string main_file;
+  std::string repo_mapping_manifest;
+  bool legacy_external_runfiles = false;
+  std::string input_files_manifest;
+};
+
+Config parse_args(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " [flags...] <input_files_manifest>" << std::endl;
+    std::exit(1);
+  }
+
+  Config config;
+
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+
+    if (arg == "--output") {
+      if (i + 1 >= argc) {
+        std::cerr << "ERROR: --output requires a value" << std::endl;
+        std::exit(1);
+      }
+      config.output = argv[++i];
+    } else if (arg == "--workspace-name") {
+      if (i + 1 >= argc) {
+        std::cerr << "ERROR: --workspace-name requires a value" << std::endl;
+        std::exit(1);
+      }
+      config.workspace_name = argv[++i];
+    } else if (arg == "--main-file") {
+      if (i + 1 >= argc) {
+        std::cerr << "ERROR: --main-file requires a value" << std::endl;
+        std::exit(1);
+      }
+      config.main_file = argv[++i];
+    } else if (arg == "--repo-mapping-manifest") {
+      if (i + 1 >= argc) {
+        std::cerr << "ERROR: --repo-mapping-manifest requires a value" << std::endl;
+        std::exit(1);
+      }
+      config.repo_mapping_manifest = argv[++i];
+    } else if (arg == "--legacy-external-runfiles") {
+      config.legacy_external_runfiles = true;
+    } else {
+      config.input_files_manifest = arg;
+    }
+  }
+
+  return config;
+}
+
+std::vector<FileEntry> read_input_manifest(const std::string &manifest_path) {
+  std::vector<FileEntry> files;
+  std::ifstream in(manifest_path);
+
+  if (!in) {
+    std::cerr << "ERROR: Cannot open input files manifest: " << manifest_path << std::endl;
+    std::exit(1);
+  }
+
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      files.push_back(FileEntry::parse(line));
+    }
+  }
+
+  return files;
+}
+
+void validate_config(const Config &config) {
+  if (config.input_files_manifest.empty()) {
+    std::cerr << "ERROR: No input files manifest specified" << std::endl;
+    std::exit(1);
+  }
+  if (config.output.empty()) {
+    std::cerr << "ERROR: --output is required" << std::endl;
+    std::exit(1);
+  }
+  if (config.workspace_name.empty()) {
+    std::cerr << "ERROR: --workspace-name is required" << std::endl;
+    std::exit(1);
+  }
+  if (config.main_file.empty()) {
+    std::cerr << "ERROR: --main-file is required" << std::endl;
+    std::exit(1);
+  }
+}
+
+void write_zip_manifest(const Config &config, const std::vector<FileEntry> &files,
+                        const std::string &manifest_path) {
+  // Open in binary mode to avoid LF -> CRLF conversion on Windows.
+  std::ofstream manifest(manifest_path, std::ios::binary);
+  if (!manifest) {
+    std::cerr << "ERROR: Cannot create manifest file: " << manifest_path << std::endl;
+    std::exit(1);
+  }
+
+  manifest << "__main__.py=" << config.main_file << "\n";
+
+  manifest << "__init__.py=\n";
+  manifest << get_zip_runfiles_path("__init__.py", config.workspace_name,
+                                    config.legacy_external_runfiles)
+           << "=\n";
+
+  for (const auto &file : files) {
+    std::string zip_path = get_zip_runfiles_path(file.short_path, config.workspace_name,
+                                                 config.legacy_external_runfiles);
+    manifest << zip_path << "=" << file.disk_path << "\n";
+  }
+
+  if (!config.repo_mapping_manifest.empty()) {
+    manifest << "runfiles/_repo_mapping=" << config.repo_mapping_manifest << "\n";
+  }
+}
+
+void run_zipper(const std::string &executable, const std::string &output,
+                const std::string &manifest_path) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(executable, &error));
+
+  if (runfiles == nullptr) {
+    std::cerr << "ERROR: Failed to initialize runfiles: " << error << std::endl;
+    std::exit(1);
+  }
+
+  std::string zipper_path =
+      find_executable_in_runfiles(runfiles.get(), "bazel_tools/tools/zip/zipper/zipper");
+  if (zipper_path.empty()) {
+    // @bazel_tools/tools/zip:zipper is an alias for @bazel_tools/third_party/ijar:zipper.
+    // On some systems, this means the binary is located in bazel_tools/third_party/ijar/zipper
+    // instead.
+    zipper_path =
+        find_executable_in_runfiles(runfiles.get(), "bazel_tools/third_party/ijar/zipper");
+    if (zipper_path.empty()) {
+      std::cerr << "ERROR: Could not locate zipper in runfiles" << std::endl;
+      std::exit(1);
+    }
+  }
+
+  std::string cmd = zipper_path + " cC " + output + " @" + manifest_path;
+  int result = std::system(cmd.c_str());
+
+  if (result != 0) {
+    std::cerr << "ERROR: zipper failed with exit code " << result << std::endl;
+    std::exit(1);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  Config config = parse_args(argc, argv);
+  validate_config(config);
+
+  std::vector<FileEntry> files = read_input_manifest(config.input_files_manifest);
+
+  std::string zip_manifest_path = config.output + ".manifest.txt";
+  write_zip_manifest(config, files, zip_manifest_path);
+  run_zipper(argv[0], config.output, zip_manifest_path);
+
+  return 0;
+}


### PR DESCRIPTION
PR Status: Addressing windows compatibility issues

## Context
I've recently been looking into Bazel analysis performance in my company's monorepo (predominantly Java and Typescript), and was surprised to find that `rules_python` accounts for almost **60%** of the CPU time during analysis across our repo (433s of 741s).

From a profile, it was clear that `depset.to_list()` being called out of `_create_zip_file()` was accounting for the vast majority of the analysis time. So I focused on eliminating these depset expansions, which are expensive for analysis (anyone who's unaware, see Bazel's [Optimizing Performance](https://bazel.build/rules/performance#avoid-depset-to-list) page). Path normalization in `_get_zip_runfiles_path` was also accounting for a large chunk of the analysis time.

What was slightly less clear, but eventually apparent, was that `runfiles.empty_filenames` being provided as an arg to the `zipper` action was also causing a hit to analysis performance. I traced this back to the fact that the `runfiles.empty_filenames` depset in this context is actually coming from the [`GetInitPyFiles` Java class](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/rules/python/PythonUtils.java#L52) in the Python utils built into Bazel, and this class was also causing an implicit expansion of the `runfiles.files` depset. You can verify this by running a profile using my PR's changes and with `--incompatible_default_to_explicit_init_py=false` (the default).

Note that despite the Bazel-native `--build_python_zip` flag being disabled by default on non-Windows systems, this only affects whether the zipapp is considered a default output, i.e. the analysis cost is still incurred if this flag is disabled.

## Intent
My strategy for optimizing this was basically to get rid of any `depset.to_list()` calls, and shift reproducible but expensive business logic (e.g. path normalization) from the analysis phase to the build phase.

## Changes

1. Introduced a wrapper for `@bazel_tools//tools/zip:zipper`, written in C++, which prepares the input manifest to the `zipper` tool, including all path rewriting
2. Change the inputs to `_create_zip_file` to provide only what it needs (`runfiles_without_exe`) and avoid a depset expansion + filter.

I chose to write the script in C++ because it would keep the actual build action performant whilst avoiding adding new dependencies to `rules_python` (`rules_cc` is already a dependency).

## Testing
I haven't added new tests specific to this wrapper or the affected functionality, instead relying on the existing `//tests`. Please let me know if you'd prefer specific shell tests or C++ tests.

### Snapshot tests
To verify builds were the same, I wrote some [snapshot tests](https://github.com/bazel-contrib/rules_python/compare/main...tobyh-canva:rules_python:zipapp-snapshot), which are not integrated in this branch. Let me know if you'd like these to be brought in (they're platform-specific, and the snapshots may need to be updated somewhat frequently for innocuous changes).

### Manual tests
I manually ran snapshot tests above on macOS, Linux, and Windows, comparing a snapshot from the main branch with this branch.

## Results

Here's the `--starlark_cpu_profile` flame graph before/after these changes (this is profiling analysis of `bazel build --nobuild //...` in our monorepo.

<img width="2048" height="1240" alt="Before" src="https://github.com/user-attachments/assets/77246b83-2b8c-48b7-913b-b8b47899f919" />

Overall the CPU time appears to have been reduced by at least 95% for `py_binary` and `py_test` targets.

The memory profile shows a similar 95% reduction in memory usage for `py_binary` and `py_test`.

- All build outputs are identical after these changes.
- The overall build performance is impacted by the compilation of the new C++ wrapper script. 
- The build performance of the actual `PythonZipper` action is effectively unchanged - the additional work done by the C++ wrapper is barely visible compared to the work which was already being done by the actual `zipper`.

## Notes
I wasn't aware that `--incompatible_default_to_explicit_init_py=true` made such a significant improvement to analysis performance. Is it worth mentioning this somewhere in the docs of `rules_python`? It smells to me like it just disables a legacy Google-specific quirk, though I could be wrong.

I initially moved the `GetInitPyFiles` logic from Java into the C++ wrapper, so at least it would remove the analysis performance hit. But since it's only optimising legacy behaviour, and users can just toggle a flag to disable it, I reverted that change and left the empty `__init__.py` generation alone.
