### PR TITLE
gazelle: set min rules_python version as 1.4

### DIFF
--- a/gazelle/examples/bzlmod_build_file_generation/MODULE.bazel
+++ b/gazelle/examples/bzlmod_build_file_generation/MODULE.bazel
@@ -13,7 +13,7 @@ module(
 # For typical setups you set the version.
 # See the releases page for available versions.
 # https://github.com/bazel-contrib/rules_python/releases
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.4.0")
 
 # The following stanza defines the dependency rules_python_gazelle_plugin.
 # For typical setups you set the version.


### PR DESCRIPTION
rules_python 1.4 is when the python.defaults tag class was introduced, which is used in the example's module file.

Fixes BCR presubmit failures in https://github.com/bazelbuild/bazel-central-registry/pull/6330 and https://github.com/bazelbuild/bazel-central-registry/pull/6241
