### PR TITLE
fix: make CI pass with the next version of Bazel (9.0.0rc1)

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "rules_java", version = "8.3.1")
 # MODULE.bazel.lock is cross-platform friendly, and there are transitive
 # dependencies on rules_rust, so we need rules_rust 0.54.1+ where such issues
 # were fixed.
-bazel_dep(name = "rules_rust", version = "0.54.1")
+bazel_dep(name = "rules_rust", version = "0.67.0")
 
 # We next initialize the python toolchain using the extension.
 # You can set different Python versions in this block.

--- a/tests/support/cc_toolchains/fake_cc_toolchain_config.bzl
+++ b/tests/support/cc_toolchains/fake_cc_toolchain_config.bzl
@@ -15,6 +15,7 @@
 """Fake for providing CcToolchainConfigInfo."""
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 
 def _impl(ctx):
     return cc_common.create_cc_toolchain_config_info(


### PR DESCRIPTION
Explicitly load CcToolchainConfigInfo in the fake cc toolchain config.

For examples/bzlmod, bump rules_rust to a newer version so that it pulls
in dependencies that work correctly with Bazel 9.0.0rc1.

Work towards #3392