### PR TITLE
chore: switch bcr to 8.x instead of last_rc

### DIFF
--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -16,8 +16,7 @@ bcr_test_module:
   module_path: "examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    # last_rc is to get latest 8.x release. Replace with 8.x when available.
-    bazel: [7.x, last_rc]
+    bazel: [7.x, 8.x]
   tasks:
     run_tests:
       name: "Run test module"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -16,8 +16,7 @@ bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    # last_rc is to get latest 8.x release. Replace with 8.x when available.
-    bazel: [7.x, last_rc]
+    bazel: [7.x, 8.x]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
It seems that we forgot to complete this TODO item.

Work towards #3392
