### PR TITLE
tests: set --windows_enable_symlinks in bzlmod example

### DIFF
--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -1,3 +1,8 @@
+# Starting with Bazel 8, Windows requires this flag in order
+# for symlinks to work properly (namely, so that sh_test with
+# py_binary as a data dependency gets symlinks that are executable)
+startup --windows_enable_symlinks
+
 common --enable_bzlmod
 common --lockfile_mode=update
 


### PR DESCRIPTION
The `//tests:version_test_binary_*` targets fail when run on Bazel 8 with Windows with a "permission denied" error with the Python executable. The notable thing about these tests is they're shell tests with a data dependency on the Python program, so a symlink is created to refer to the Python program. As best I can tell, Bazel 8 isn't creating the symlink quite right, so Windows considers the file non-executable.

Setting `--windows_enable_symlinks` fixes this, but it isn't clear why. Presumably it's telling Bazel to create symlinks more properly.

