### PR TITLE
docs: enable pipstar for doc building

### DIFF
--- a/docs/readthedocs_build.sh
+++ b/docs/readthedocs_build.sh
@@ -15,6 +15,7 @@ extra_env+=("--//sphinxdocs:extra_env=HOSTNAME=$HOSTNAME")
 export RULES_PYTHON_ENABLE_PIPSTAR=1
 
 set -x
+export RULES_PYTHON_ENABLE_PIPSTAR=1
 bazel run \
   --config=rtd \
   "--//sphinxdocs:extra_defines=version=$READTHEDOCS_VERSION" \


### PR DESCRIPTION
Since we want to enable pipstar by default, enable it for our docs builds as a way to
try it out consistently.