### PR TITLE
refactor(pypi): use py_console_script_binary in whl_library_targets

### DIFF
--- a/python/private/pypi/generate_whl_library_build_bazel.bzl
+++ b/python/private/pypi/generate_whl_library_build_bazel.bzl
@@ -23,7 +23,7 @@ _RENDER = {
     "data_exclude": render.list,
     "dependencies": render.list,
     "dependencies_by_platform": lambda x: render.dict(x, value_repr = render.list),
-    "entry_points": render.dict,
+    "entry_points": render.list,
     "extras": render.list,
     "group_deps": render.list,
     "include": str,

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -30,7 +30,6 @@ load(":whl_target_platforms.bzl", "whl_target_platforms")
 
 _CPPFLAGS = "CPPFLAGS"
 _COMMAND_LINE_TOOLS_PATH_SLUG = "commandlinetools"
-_WHEEL_ENTRY_POINT_PREFIX = "rules_python_wheel_entry_point"
 
 def _get_xcode_location_cflags(rctx, logger = None):
     """Query the xcode sdk location to update cflags
@@ -399,30 +398,6 @@ def _whl_library_impl(rctx):
             logger = logger,
         )
 
-        # NOTE @aignas 2024-06-22: this has to live on until we stop supporting
-        # passing `twine` as a `:pkg` library via the `WORKSPACE` builds.
-        #
-        # See ../../packaging.bzl line 190
-        entry_points = {}
-        for item in metadata.entry_points:
-            name = item.name
-            module = item.module
-            attribute = item.attribute
-
-            # There is an extreme edge-case with entry_points that end with `.py`
-            # See: https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/test/java/com/google/devtools/build/lib/rules/python/PyBinaryConfiguredTargetTest.java#L174
-            entry_point_without_py = name[:-3] + "_py" if name.endswith(".py") else name
-            entry_point_target_name = (
-                _WHEEL_ENTRY_POINT_PREFIX + "_" + entry_point_without_py
-            )
-            entry_point_script_name = entry_point_target_name + ".py"
-
-            rctx.file(
-                entry_point_script_name,
-                _generate_entry_point_contents(module, attribute),
-            )
-            entry_points[entry_point_without_py] = entry_point_script_name
-
         build_file_contents = generate_whl_library_build_bazel(
             name = whl_path.basename,
             sdist_filename = sdist_filename,
@@ -430,7 +405,7 @@ def _whl_library_impl(rctx):
                 rctx.attr.repo_prefix,
             ),
             config_load = rctx.attr.config_load,
-            entry_points = entry_points,
+            entry_points = [e.name for e in metadata.entry_points],
             metadata_name = metadata.name,
             metadata_version = metadata.version,
             requires_dist = metadata.requires_dist,
@@ -476,35 +451,11 @@ def _whl_library_impl(rctx):
         metadata = json.decode(rctx.read("metadata.json"))
         rctx.delete("metadata.json")
 
-        # NOTE @aignas 2024-06-22: this has to live on until we stop supporting
-        # passing `twine` as a `:pkg` library via the `WORKSPACE` builds.
-        #
-        # See ../../packaging.bzl line 190
-        entry_points = {}
-        for item in metadata["entry_points"]:
-            name = item["name"]
-            module = item["module"]
-            attribute = item["attribute"]
-
-            # There is an extreme edge-case with entry_points that end with `.py`
-            # See: https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/test/java/com/google/devtools/build/lib/rules/python/PyBinaryConfiguredTargetTest.java#L174
-            entry_point_without_py = name[:-3] + "_py" if name.endswith(".py") else name
-            entry_point_target_name = (
-                _WHEEL_ENTRY_POINT_PREFIX + "_" + entry_point_without_py
-            )
-            entry_point_script_name = entry_point_target_name + ".py"
-
-            rctx.file(
-                entry_point_script_name,
-                _generate_entry_point_contents(module, attribute),
-            )
-            entry_points[entry_point_without_py] = entry_point_script_name
-
         build_file_contents = generate_whl_library_build_bazel(
             name = whl_path.basename,
             sdist_filename = sdist_filename,
             dep_template = rctx.attr.dep_template or "@{}{{name}}//:{{target}}".format(rctx.attr.repo_prefix),
-            entry_points = entry_points,
+            entry_points = [e["name"] for e in metadata["entry_points"]],
             # TODO @aignas 2025-05-17: maybe have a build flag for this instead
             enable_implicit_namespace_pkgs = rctx.attr.enable_implicit_namespace_pkgs,
             # TODO @aignas 2025-04-14: load through the hub:
@@ -541,34 +492,6 @@ def _whl_library_impl(rctx):
 
     rctx.file("BUILD.bazel", build_file_contents)
     return
-
-def _generate_entry_point_contents(
-        module,
-        attribute,
-        shebang = "#!/usr/bin/env python3"):
-    """Generate the contents of an entry point script.
-
-    Args:
-        module (str): The name of the module to use.
-        attribute (str): The name of the attribute to call.
-        shebang (str, optional): The shebang to use for the entry point python
-            file.
-
-    Returns:
-        str: A string of python code.
-    """
-    contents = """\
-{shebang}
-import sys
-from {module} import {attribute}
-if __name__ == "__main__":
-    sys.exit({attribute}())
-""".format(
-        shebang = shebang,
-        module = module,
-        attribute = attribute,
-    )
-    return contents
 
 # NOTE @aignas 2024-03-21: The usage of dict({}, **common) ensures that all args to `dict` are unique
 whl_library_attrs = dict({


### PR DESCRIPTION
With this the `whl_library` with pipstar enabled is doing very little logic for
whls in the repo phase. This makes it more sustainable and we can start
trimming the fat away.

TODO:
- [ ] Fix tests

Work towards #2948
