### PR TITLE
chore: remove extraneous dep from sys_path_order test

### DIFF
--- a/tests/bootstrap_impls/BUILD.bazel
+++ b/tests/bootstrap_impls/BUILD.bazel
@@ -133,9 +133,6 @@ py_reconfig_test(
     env = {"BOOTSTRAP": "system_python"},
     imports = ["./site-packages"],
     main = "sys_path_order_test.py",
-    deps = [
-        "@bazel_tools//tools/python/runfiles",
-    ],
 )
 
 py_reconfig_test(


### PR DESCRIPTION
The bazel_tools runfiles dep was mistakenly also added to another test when the
test for importing bazel_tools was added.