### PR TITLE
refactor: remove gazelle plugin as dev dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -45,7 +45,6 @@ filegroup(
         "version.bzl",
         "//python:distribution",
         "//tools:distribution",
-        ##"@rules_python_gazelle_plugin//:distribution",
     ],
     visibility = [
         "//:__subpackages__",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -227,8 +227,6 @@ bazel_dep(name = "another_module", version = "0", dev_dependency = True)
 # Extra gazelle plugin deps so that WORKSPACE.bzlmod can continue including it for e2e tests.
 # We use `WORKSPACE.bzlmod` because it is impossible to have dev-only local overrides.
 bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
-##bazel_dep(name = "rules_python_gazelle_plugin", version = "0", dev_dependency = True)
-##bazel_dep(name = "gazelle", version = "0.40.0", dev_dependency = True, repo_name = "bazel_gazelle")
 
 internal_dev_deps = use_extension(
     "//python/private:internal_dev_deps.bzl",
@@ -257,13 +255,6 @@ dev_rules_python_config.add_transition_setting(
 dev_rules_python_config.add_transition_setting(
     setting = "//tests/multi_pypi:external_deps_name",
 )
-
-# Add gazelle plugin so that we can run the gazelle example as an e2e integration
-# test and include the distribution files.
-##local_path_override(
-##    module_name = "rules_python_gazelle_plugin",
-##    path = "gazelle",
-##)
 
 local_path_override(
     module_name = "other",

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -23,14 +23,6 @@ _WORKSPACE_FLAGS = [
     "--enable_workspace",
 ]
 
-##_WORKSPACE_GAZELLE_PLUGIN_FLAGS = [
-##    "--override_repository=rules_python_gazelle_plugin=../../../rules_python_gazelle_plugin",
-##]
-
-##_GAZELLE_PLUGIN_FLAGS = [
-##    "--override_module=rules_python_gazelle_plugin=../../../rules_python_gazelle_plugin",
-##]
-
 default_test_runner(
     name = "workspace_test_runner",
     bazel_cmds = [
@@ -40,30 +32,10 @@ default_test_runner(
     visibility = ["//visibility:public"],
 )
 
-##default_test_runner(
-##    name = "workspace_test_runner_gazelle_plugin",
-##    bazel_cmds = [
-##        "info {}".format(" ".join(_WORKSPACE_FLAGS + _WORKSPACE_GAZELLE_PLUGIN_FLAGS)),
-##        "test {} //...".format(" ".join(_WORKSPACE_FLAGS + _WORKSPACE_GAZELLE_PLUGIN_FLAGS)),
-##    ],
-##    visibility = ["//visibility:public"],
-##)
-
 default_test_runner(
     name = "test_runner",
     visibility = ["//visibility:public"],
 )
-
-##default_test_runner(
-##    name = "test_runner_gazelle_plugin",
-##    bazel_cmds = [
-##        "info {}".format(" ".join(_GAZELLE_PLUGIN_FLAGS)),
-##        "test {} //...".format(" ".join(_GAZELLE_PLUGIN_FLAGS)),
-##    ],
-##    visibility = ["//visibility:public"],
-##)
-
-# TODO: add compile_pip_requirements_test_from_external_repo
 
 rules_python_integration_test(
     name = "compile_pip_requirements_test",

--- a/tests/integration/integration_test.bzl
+++ b/tests/integration/integration_test.bzl
@@ -21,7 +21,7 @@ load(
 )
 load("//python:py_test.bzl", "py_test")
 
-def _test_runner(*, name, bazel_version, py_main, bzlmod, gazelle_plugin):
+def _test_runner(*, name, bazel_version, py_main, bzlmod):
     if py_main:
         test_runner = "{}_bazel_{}_py_runner".format(name, bazel_version)
         py_test(
@@ -35,12 +35,8 @@ def _test_runner(*, name, bazel_version, py_main, bzlmod, gazelle_plugin):
         )
         return test_runner
 
-    if bzlmod and gazelle_plugin:
-        return "//tests/integration:test_runner_gazelle_plugin"
-    elif bzlmod:
+    if bzlmod:
         return "//tests/integration:test_runner"
-    elif gazelle_plugin:
-        return "//tests/integration:workspace_test_runner_gazelle_plugin"
     else:
         return "//tests/integration:workspace_test_runner"
 
@@ -48,7 +44,6 @@ def rules_python_integration_test(
         name,
         workspace_path = None,
         bzlmod = True,
-        gazelle_plugin = False,
         tags = None,
         py_main = None,
         bazel_versions = None,
@@ -61,7 +56,6 @@ def rules_python_integration_test(
             `_test` suffix.
         bzlmod: bool, default True. If true, run with bzlmod enabled, otherwise
             disable bzlmod.
-        gazelle_plugin: Whether the test uses the gazelle plugin.
         tags: Test tags.
         py_main: Optional `.py` file to run tests using. When specified, a
             python based test runner is used, and this source file is the main
@@ -98,7 +92,6 @@ def rules_python_integration_test(
             bazel_version = bazel_version,
             py_main = py_main,
             bzlmod = bzlmod,
-            gazelle_plugin = gazelle_plugin,
         )
         bazel_integration_test(
             name = "{}_bazel_{}".format(name, bazel_version),


### PR DESCRIPTION
Remove the gazelle pluging as a dev-time dependency of rules_python itself.

This is to avoid gazelle-related build issues that affect the main build.

The gazelle code paths in tests/integration are removed because they were just
test runners being defined, but weren't actually used with any tests.