### PR TITLE
ci: start testing BCR tests with bazel 9

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -117,7 +117,7 @@ matrix:
     - debian11
     - macos_arm64
     - windows
-  bazel: [7.*, 8.*]
+  bazel: [7.*, 8.*, 9.*]
 
 tasks:
   # Keep in sync with .bcr/presubmit.yml
@@ -135,6 +135,7 @@ tasks:
     test_targets:
       - "//..."
 
+  # Keep in sync with .bcr/gazelle/presubmit.yml
   gazelle_bcr_ubuntu:
     <<: *gazelle_common_bcr
     name: "Gazelle: BCR, Bazel {bazel}"

--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -20,10 +20,7 @@ bcr_test_module:
       "macos",
       "ubuntu2204",
     ]
-    bazel: [
-      7.*,
-      8.*,
-    ]
+    bazel: [7.*, 8.*, 9.*]
   tasks:
     run_tests:
       name: "Run test module"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
     platform: ["debian11", "macos", "ubuntu2204", "windows"]
-    bazel: [7.*, 8.*]
+    bazel: [7.*, 8.*, 9.*]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
It seems that the CI is passing now with the latest bazel 9 release.
Hence, start testing it in our CI and when submitting new versions to
BCR.

Fix #3392