### PR TITLE
refactor: Migrate usages of `py_internal.cc_helper` to `@rules_cc`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_cc", version = "0.2.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
 # Those are loaded only when using py_proto_library

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,10 @@ load("//:internal_dev_setup.bzl", "rules_python_internal_setup")
 
 rules_python_internal_setup()
 
+load("@rules_cc//cc:extensions.bzl", _cc_compatibility_proxy_repo = "compatibility_proxy_repo")
+
+_cc_compatibility_proxy_repo()
+
 load("@pythons_hub//:versions.bzl", "PYTHON_VERSIONS")
 load("//python:repositories.bzl", "py_repositories", "python_register_multi_toolchains")
 

--- a/internal_dev_deps.bzl
+++ b/internal_dev_deps.bzl
@@ -238,9 +238,9 @@ def rules_python_internal_deps():
 
     http_archive(
         name = "rules_cc",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
-        sha256 = "b8b918a85f9144c01f6cfe0f45e4f2838c7413961a8ff23bc0c6cdf8bb07a3b6",
-        strip_prefix = "rules_cc-0.1.5",
+        sha256 = "ae244f400218f4a12ee81658ff246c0be5cb02c5ca2de5519ed505a6795431e9",
+        strip_prefix = "rules_cc-0.2.0",
+        url = "https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz",
     )
 
     http_archive(

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -119,22 +119,16 @@ bzl_library(
 )
 
 bzl_library(
-    name = "cc_helper_bzl",
-    srcs = ["cc_helper.bzl"],
-    deps = [":py_internal_bzl"],
-)
-
-bzl_library(
     name = "common_bzl",
     srcs = ["common.bzl"],
     deps = [
-        ":cc_helper_bzl",
         ":py_cc_link_params_info_bzl",
         ":py_info_bzl",
         ":py_internal_bzl",
         ":reexports_bzl",
         ":rules_cc_srcs_bzl",
         "@bazel_skylib//lib:paths",
+        "@rules_cc//cc/common:cc_helper_bzl",
     ],
 )
 
@@ -404,7 +398,6 @@ bzl_library(
     srcs = ["py_executable.bzl"],
     deps = [
         ":attributes_bzl",
-        ":cc_helper_bzl",
         ":common_bzl",
         ":common_labels_bzl",
         ":flags_bzl",
@@ -422,6 +415,9 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:structs",
         "@bazel_skylib//rules:common_settings",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc/common",
+        "@rules_cc//cc/common:cc_helper_bzl",
     ],
 )
 

--- a/python/private/common.bzl
+++ b/python/private/common.bzl
@@ -15,8 +15,8 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_helper.bzl", "cc_helper")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load(":cc_helper.bzl", "cc_helper")
 load(":py_cc_link_params_info.bzl", "PyCcLinkParamsInfo")
 load(":py_info.bzl", "PyInfo", "PyInfoBuilder")
 load(":py_internal.bzl", "py_internal")

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -17,7 +17,9 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_helper.bzl", "cc_helper")
 load("@rules_python_internal//:rules_python_config.bzl", rp_config = "config")
 load(":attr_builders.bzl", "attrb")
 load(
@@ -33,7 +35,6 @@ load(
     "apply_config_settings_attr",
 )
 load(":builders.bzl", "builders")
-load(":cc_helper.bzl", "cc_helper")
 load(
     ":common.bzl",
     "collect_cc_info",
@@ -1435,7 +1436,7 @@ def _write_build_data(ctx, central_uncachable_version_file, extra_write_build_da
             # https://github.com/bazelbuild/bazel/issues/9363
             "INFO_FILE": ctx.info_file.path,
             "OUTPUT": build_data.path,
-            "PLATFORM": cc_helper.find_cpp_toolchain(ctx).toolchain_id,
+            "PLATFORM": find_cc_toolchain(ctx).toolchain_id,
             "TARGET": str(ctx.label),
             "VERSION_FILE": version_file.path,
         }, extra_write_build_data_env),

--- a/python/private/py_repositories.bzl
+++ b/python/private/py_repositories.bzl
@@ -68,9 +68,9 @@ def py_repositories(transition_settings = []):
     )
     http_archive(
         name = "rules_cc",
-        sha256 = "b8b918a85f9144c01f6cfe0f45e4f2838c7413961a8ff23bc0c6cdf8bb07a3b6",
-        strip_prefix = "rules_cc-0.1.5",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
+        sha256 = "ae244f400218f4a12ee81658ff246c0be5cb02c5ca2de5519ed505a6795431e9",
+        strip_prefix = "rules_cc-0.2.0",
+        url = "https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz",
     )
 
     # Needed by rules_cc, triggered by @rules_java_prebuilt in Bazel by using @rules_cc//cc:defs.bzl


### PR DESCRIPTION
The builtins symbols are deleted in Bazel 9
