### PR TITLE
chore: add missing py_internal dep to venv_runfiles

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -724,6 +724,7 @@ bzl_library(
     deps = [
         ":common_bzl",
         ":py_info.bzl",
+        ":py_internal.bzl",
         "@bazel_skylib//lib:paths",
     ],
 )


### PR DESCRIPTION
Add the missing py_internal.bzl dep to venv_runfiles.bzl