### PR TITLE
docs: Fix broken links to bzlmod build_file_generation example

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -19,7 +19,6 @@ examples/bzlmod/other_module/bazel-other_module
 examples/bzlmod/other_module/bazel-out
 examples/bzlmod/other_module/bazel-testlogs
 examples/bzlmod/py_proto_library/foo_external
-examples/bzlmod_build_file_generation/bazel-bzlmod_build_file_generation
 examples/multi_python_versions/bazel-multi_python_versions
 examples/pip_parse/bazel-pip_parse
 examples/pip_parse_vendored/bazel-pip_parse_vendored

--- a/BZLMOD_SUPPORT.md
+++ b/BZLMOD_SUPPORT.md
@@ -27,7 +27,7 @@ We have two examples that demonstrate how to configure `bzlmod`.
 The first example is in [examples/bzlmod](examples/bzlmod), and it demonstrates basic bzlmod configuration.
 A user does not use `local_path_override` stanza and would define the version in the `bazel_dep` line.
 
-A second example, in [examples/bzlmod_build_file_generation](examples/bzlmod_build_file_generation) demonstrates the use of `bzlmod` to configure `gazelle` support for `rules_python`.
+A second example, in [gazelle/examples/bzlmod_build_file_generation](gazelle/examples/bzlmod_build_file_generation) demonstrates the use of `bzlmod` to configure `gazelle` support for `rules_python`.
 
 ## Differences in behavior from WORKSPACE
 

--- a/examples/build_file_generation/.bazelrc
+++ b/examples/build_file_generation/.bazelrc
@@ -3,7 +3,7 @@ test --test_output=errors --enable_runfiles
 # Windows requires these for multi-python support:
 build --enable_runfiles
 
-# The bzlmod version of this example is in examples/bzlmod_build_file_generation
+# The bzlmod version of this example is in gazelle/examples/bzlmod_build_file_generation
 # Once WORKSPACE support is dropped, this example can be entirely deleted.
 common --noenable_bzlmod
 common --enable_workspace

--- a/gazelle/docs/installation_and_usage.md
+++ b/gazelle/docs/installation_and_usage.md
@@ -5,7 +5,7 @@
 Examples of using Gazelle with Python can be found in the `rules_python`
 repo:
 
-* bzlmod: {gh-path}`examples/bzlmod_build_file_generation`
+* bzlmod: {gh-path}`gazelle/examples/bzlmod_build_file_generation`
 * WORKSPACE: {gh-path}`examples/build_file_generation`
 
 :::{note}


### PR DESCRIPTION
The `examples/bzlmod_build_file_generation` directory was moved under the gazelle directory in f92ad7136ff411755ec8d8361af8263fd8efe6f2

This fixes some outdated links/references to that old directory

