### PR TITLE
docs: fix link to releases page

### DIFF
--- a/BZLMOD_SUPPORT.md
+++ b/BZLMOD_SUPPORT.md
@@ -11,7 +11,7 @@ In general `bzlmod` has more features than `WORKSPACE` and users are encouraged 
 
 ## Configuration
 
-The releases page will give you the latest version number, and a basic example.  The release page is located [here](/bazel-contrib/rules_python/releases).
+The releases page will give you the latest version number, and a basic example.  The release page is located [here](https://github.com/bazel-contrib/rules_python/releases).
 
 ## What is bzlmod?
 


### PR DESCRIPTION
Previously, the link was an internal absolute link, which is relative to the repository's root directory, but the releases page isn't part of the source tree.