### PR TITLE
fix(pipstar): actually pass the extras down the call stack

### DIFF
--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -433,6 +433,7 @@ bzl_library(
         ":generate_whl_library_build_bazel_bzl",
         ":parse_whl_name_bzl",
         ":patch_whl_bzl",
+        ":pep508_requirement_bzl",
         ":pypi_repo_utils_bzl",
         ":whl_metadata_bzl",
         ":whl_target_platforms_bzl",

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -24,6 +24,7 @@ load(":deps.bzl", "all_repo_names", "record_files")
 load(":generate_whl_library_build_bazel.bzl", "generate_whl_library_build_bazel")
 load(":parse_whl_name.bzl", "parse_whl_name")
 load(":patch_whl.bzl", "patch_whl")
+load(":pep508_requirement.bzl", "requirement")
 load(":pypi_repo_utils.bzl", "pypi_repo_utils")
 load(":whl_metadata.bzl", "whl_metadata")
 load(":whl_target_platforms.bzl", "whl_target_platforms")
@@ -435,6 +436,7 @@ def _whl_library_impl(rctx):
             group_deps = rctx.attr.group_deps,
             group_name = rctx.attr.group_name,
             namespace_package_files = namespace_package_files,
+            extras = requirement(rctx.attr.requirement).extras,
         )
     else:
         target_platforms = rctx.attr.experimental_target_platforms or []


### PR DESCRIPTION
It seems that the extras were not correctly passed down the call stack.
The upstream code was handling everything correctly and we had unit
tests for the downstream code.

Fixes #3352
