### PR TITLE
build: Export runtime_env_toolchain_interpreter.sh file

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -27,6 +27,8 @@ package(
 
 licenses(["notice"])
 
+exports_files(["runtime_env_toolchain_interpreter.sh"])
+
 filegroup(
     name = "distribution",
     srcs = glob(["**"]) + [


### PR DESCRIPTION
I am working on https://github.com/bazelbuild/bazel/pull/27674 towards https://github.com/bazelbuild/bazel/issues/10225 to flip `incompatible_no_implicit_file_export`. I found that https://github.com/bazelbuild/bazel/blob/master/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py and https://github.com/bazelbuild/bazel/blob/master/src/test/py/bazel/bzlmod/bazel_module_test.py require `runtime_env_toolchain_interpreter.sh`. Since it is no longer implicitly exported after flipping the flag, we have to export it explicitly.