### PR TITLE
fix(venv): Fix all .so files missing when py_binary lives at //:BUILD

### DIFF
--- a/python/private/venv_runfiles.bzl
+++ b/python/private/venv_runfiles.bzl
@@ -64,7 +64,8 @@ def create_venv_app_files(ctx, deps, venv_dir_map):
         for venv_path, link_to in kind_map.items():
             bin_venv_path = paths.join(base, venv_path)
             if is_file(link_to):
-                symlink_from = "{}/{}".format(ctx.label.package, bin_venv_path)
+                # use paths.join to handle ctx.label.package = ""
+                symlink_from = paths.join(ctx.label.package, bin_venv_path)
                 runfiles_symlinks[symlink_from] = link_to
             else:
                 venv_link = ctx.actions.declare_symlink(bin_venv_path)


### PR DESCRIPTION
When `.label.package` was "" (empty string), doing
`"{}/{}".format(ctx.label.package, bin_venv_path)` created an absolute path,
which caused files to be ignored later, as they no longer looked to be part
of the correct prefix. An empty package name occurs when the target is in
`//:BUILD` with venv on.

To fix, use skylib's `paths` instead, which handles it correctly and won't add the
`/` prefix.

Fixes https://github.com/bazel-contrib/rules_python/issues/3470