### PR TITLE
refactor(pypi): print a better error message for duplicate repos

### DIFF
--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -173,6 +173,7 @@ bzl_library(
         ":whl_repo_name_bzl",
         "//python/private:full_version_bzl",
         "//python/private:normalize_name_bzl",
+        "//python/private:text_util_bzl",
         "//python/private:version_bzl",
         "//python/private:version_label_bzl",
     ],

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -31,7 +31,7 @@ def _is_repo_debug_enabled(mrctx):
     """
     return _getenv(mrctx, REPO_DEBUG_ENV_VAR) == "1"
 
-def _logger(mrctx = None, name = None, verbosity_level = None):
+def _logger(mrctx = None, name = None, verbosity_level = None, printer = None):
     """Creates a logger instance for printing messages.
 
     Args:
@@ -39,7 +39,9 @@ def _logger(mrctx = None, name = None, verbosity_level = None):
             `_rule_name` is present, it will be included in log messages.
         name: name for the logger. Optional for repository_ctx usage.
         verbosity_level: {type}`int | None` verbosity level. If not set,
-            taken from `mrctx`
+            taken from `mrctx`.
+        printer: a function to use for printing. Defaults to `print` or `fail` depending
+            on the logging method.
 
     Returns:
         A struct with attributes logging: trace, debug, info, warn, fail.
@@ -70,9 +72,14 @@ def _logger(mrctx = None, name = None, verbosity_level = None):
     elif not name:
         fail("The name has to be specified when using the logger with `module_ctx`")
 
+    failures = []
+
     def _log(enabled_on_verbosity, level, message_cb_or_str, printer = print):
         if verbosity < enabled_on_verbosity:
             return
+
+        if level == "FAIL":
+            failures.append(None)
 
         if type(message_cb_or_str) == "string":
             message = message_cb_or_str
@@ -86,11 +93,12 @@ def _logger(mrctx = None, name = None, verbosity_level = None):
         ), message)  # buildifier: disable=print
 
     return struct(
-        trace = lambda message_cb: _log(3, "TRACE", message_cb),
-        debug = lambda message_cb: _log(2, "DEBUG", message_cb),
-        info = lambda message_cb: _log(1, "INFO", message_cb),
-        warn = lambda message_cb: _log(0, "WARNING", message_cb),
-        fail = lambda message_cb: _log(-1, "FAIL", message_cb, fail),
+        trace = lambda message_cb: _log(3, "TRACE", message_cb, printer or print),
+        debug = lambda message_cb: _log(2, "DEBUG", message_cb, printer or print),
+        info = lambda message_cb: _log(1, "INFO", message_cb, printer or print),
+        warn = lambda message_cb: _log(0, "WARNING", message_cb, printer or print),
+        fail = lambda message_cb: _log(-1, "FAIL", message_cb, printer or fail),
+        failed = lambda: len(failures) != 0,
     )
 
 def _execute_internal(


### PR DESCRIPTION
Before this PR the error message would not be super helpful and may
potentially make it hard to debug and report errors. This PR does the
following:
* Add a better error message which also adds comparison of the args with
  which we create the whl library.
* Add a test that ensures that the error message is legible and works.
* Add the necessary plumbing to logger to allow for testing error
  messages.

A proper fix requires more work, so just adding better logging and error
messages may be useful here.

Work towards #3479
