### PR TITLE
chore: make builtin build_python_zip flag optional for tests (bazel 10 compatibility)

### DIFF
--- a/python/private/internal_config_repo.bzl
+++ b/python/private/internal_config_repo.bzl
@@ -35,6 +35,7 @@ config = struct(
   enable_deprecation_warnings = {enable_deprecation_warnings},
   bazel_8_or_later = {bazel_8_or_later},
   bazel_9_or_later = {bazel_9_or_later},
+  bazel_10_or_later = {bazel_10_or_later},
   BuiltinPyInfo = getattr(getattr(native, "legacy_globals", None), "PyInfo", {builtin_py_info_symbol}),
   BuiltinPyRuntimeInfo = getattr(getattr(native, "legacy_globals", None), "PyRuntimeInfo", {builtin_py_runtime_info_symbol}),
   BuiltinPyCcLinkParamsProvider = getattr(getattr(native, "legacy_globals", None), "PyCcLinkParamsProvider", {builtin_py_cc_link_params_provider}),
@@ -124,6 +125,7 @@ def _internal_config_repo_impl(rctx):
         builtin_py_cc_link_params_provider = builtin_py_cc_link_params_provider,
         bazel_8_or_later = str(bazel_major_version >= 8),
         bazel_9_or_later = str(bazel_major_version >= 9),
+        bazel_10_or_later = str(bazel_major_version > 9),
     ))
 
     shim_content = _PY_INTERNAL_SHIM

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -26,7 +26,7 @@ load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")  # buildifier: di
 load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", "WINDOWS_ATTR", pt_util = "util")
 load("//tests/support:py_executable_info_subject.bzl", "PyExecutableInfoSubject")
-load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP")
+load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP", "maybe_builtin_build_python_zip")
 load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _tests = []
@@ -49,14 +49,13 @@ def _test_basic_windows(name, config):
             # platforms.
             # Pass value to both native and starlark versions of the flag until
             # the native one is removed.
-            "//command_line_option:build_python_zip": "true",
             labels.BUILD_PYTHON_ZIP: True,
             "//command_line_option:cpu": "windows_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_execution_platforms": [platform_targets.WINDOWS_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [platform_targets.WINDOWS_X86_64],
-        },
+        } | maybe_builtin_build_python_zip("true"),
         attr_values = {},
     )
 
@@ -95,14 +94,13 @@ def _test_basic_zip(name, config):
             # platforms.
             # Pass value to both native and starlark versions of the flag until
             # the native one is removed.
-            "//command_line_option:build_python_zip": "true",
             labels.BUILD_PYTHON_ZIP: True,
             "//command_line_option:cpu": "linux_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_execution_platforms": [platform_targets.LINUX_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [platform_targets.LINUX_X86_64],
-        },
+        } | maybe_builtin_build_python_zip("true"),
         attr_values = {"target_compatible_with": target_compatible_with},
     )
 

--- a/tests/config_settings/transition/multi_version_tests.bzl
+++ b/tests/config_settings/transition/multi_version_tests.bzl
@@ -22,7 +22,7 @@ load("//python:py_info.bzl", "PyInfo")
 load("//python:py_test.bzl", "py_test")
 load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-visibility
 load("//python/private:reexports.bzl", "BuiltinPyInfo")  # buildifier: disable=bzl-visibility
-load("//tests/support:support.bzl", "CC_TOOLCHAIN")
+load("//tests/support:support.bzl", "CC_TOOLCHAIN", "maybe_builtin_build_python_zip")
 load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 # NOTE @aignas 2024-06-04: we are using here something that is registered in the MODULE.Bazel
@@ -92,11 +92,10 @@ def _setup_py_binary_windows(name, *, impl, build_python_zip):
         target = name + "_subject",
         impl = impl,
         config_settings = {
-            "//command_line_option:build_python_zip": str(build_python_zip),
             labels.BUILD_PYTHON_ZIP: build_python_zip,
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
             "//command_line_option:platforms": str(platform_targets.WINDOWS_X86_64),
-        },
+        } | maybe_builtin_build_python_zip(str(build_python_zip)),
     )
 
 def _test_py_binary_windows_build_python_zip_false(name):

--- a/tests/support/py_reconfig.bzl
+++ b/tests/support/py_reconfig.bzl
@@ -31,7 +31,9 @@ def _perform_transition_impl(input_settings, attr, base_impl):
     settings.update(base_impl(input_settings, attr))
 
     settings[labels.VISIBLE_FOR_TESTING] = True
-    settings["//command_line_option:build_python_zip"] = str(attr.build_python_zip)
+
+    if _BUILTIN_BUILD_PYTHON_ZIP:
+        settings["//command_line_option:build_python_zip"] = str(attr.build_python_zip)
     settings[labels.BUILD_PYTHON_ZIP] = attr.build_python_zip
     if attr.bootstrap_impl:
         settings[labels.BOOTSTRAP_IMPL] = attr.bootstrap_impl
@@ -49,6 +51,10 @@ def _perform_transition_impl(input_settings, attr, base_impl):
         settings[str(key)] = value
     return settings
 
+_BUILTIN_BUILD_PYTHON_ZIP = [] if config.bazel_10_or_later else [
+    "//command_line_option:build_python_zip",
+]
+
 _RECONFIG_INPUTS = [
     "//command_line_option:extra_toolchains",
     CUSTOM_RUNTIME,
@@ -59,10 +65,9 @@ _RECONFIG_INPUTS = [
     labels.VENVS_USE_DECLARE_SYMLINK,
 ]
 _RECONFIG_OUTPUTS = _RECONFIG_INPUTS + [
-    "//command_line_option:build_python_zip",
     labels.BUILD_PYTHON_ZIP,
     labels.VISIBLE_FOR_TESTING,
-]
+] + _BUILTIN_BUILD_PYTHON_ZIP
 _RECONFIG_INHERITED_OUTPUTS = [v for v in _RECONFIG_OUTPUTS if v in _RECONFIG_INPUTS]
 
 _RECONFIG_ATTRS = {

--- a/tests/support/support.bzl
+++ b/tests/support/support.bzl
@@ -19,6 +19,7 @@
 # rules_testing or as config_setting values, which don't support Label in some
 # places.
 
+load("@rules_python_internal//:rules_python_config.bzl", "config")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 
 PY_TOOLCHAINS = str(Label("//tests/support/py_toolchains:all"))
@@ -43,3 +44,10 @@ NOT_WINDOWS = select({
     "@platforms//os:windows": ["@platforms//:incompatible"],
     "//conditions:default": [],
 })
+
+def maybe_builtin_build_python_zip(value):
+    settings = {}
+    if not config.bazel_10_or_later:
+        settings["//command_line_option:build_python_zip"] = value
+
+    return settings


### PR DESCRIPTION
Starting in bazel 10, the build_python_zip flag is removed. This means using
the flag in e.g. transitions no longer works, which breaks some of the tests
that set the flag for testing.

To fix, don't set the flags or add them to transitions when running under
bazel 10.

Fixes https://github.com/bazel-contrib/rules_python/issues/3496