### PR TITLE
feat(python): add arm64e-apple-darwin platform support

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -1127,6 +1127,14 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "aarch64",
         ),
+        "arm64e-apple-darwin": platform_info(
+            compatible_with = [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64e",
+            ],
+            os_name = MACOS_NAME,
+            arch = "aarch64",
+        ),
         "armv7-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",


### PR DESCRIPTION
MacOS supported architectures include x86_64, arm64 and arm64e. While unusual, there are certain edge cases that require setting the host platform to arm64e, in which case we probably want the python toolchain resolution to happen properly. So we're adding a new platform in this commit that will match the same arm64 toolchain on arm64e platform.