### PR TITLE
refactor: clarify %main% is runfiles-root-relative path

### DIFF
--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -27,7 +27,7 @@ from functools import cache
 # ===== Template substitutions start =====
 # We just put them in one place so its easy to tell which are used.
 
-# Runfiles-relative path to the main Python source file.
+# Runfiles-root-relative path to the main Python source file.
 # Empty if MAIN_MODULE is used
 MAIN_PATH = "%main%"
 


### PR DESCRIPTION
I had to go dig through the source to figure out if `%main%` was being treated as
a runfiles-root or main-repo-runfiles relative path. Add this to the variable
description so its unambiguous.