### PR TITLE
chore: update rbe ci config to 8.x

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -282,7 +282,7 @@ tasks:
     platform: rbe_ubuntu2204
     # TODO @aignas 2024-12-11: get the RBE working in CI for bazel 8.0
     # See https://github.com/bazelbuild/rules_python/issues/2499
-    bazel: 7.x
+    bazel: 8.x
     test_flags:
       - "--test_tag_filters=-integration-test,-acceptance-test"
       - "--extra_toolchains=@buildkite_config//config:cc-toolchain"


### PR DESCRIPTION
There's two RBE configs: minimum, and current bazel. Both were testing 7.x, so upgrade
the current one to 8.x