### PR TITLE
fix: use powershell.exe instead of pwsh.exe for build_data_writer

### DIFF
--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -1369,8 +1369,12 @@ def _write_build_data(ctx):
     action_args = ctx.actions.args()
     writer_file = ctx.files._build_data_writer[0]
     if writer_file.path.endswith(".ps1"):
+        # powershell.exe is used for broader compatibility
+        # It is installed by default on most Windows versions
         action_exe = "powershell.exe"
         action_args.add_all([
+            # Bypass execution policy is needed because,
+            # by default, Windows blocks ps1 scripts.
             "-ExecutionPolicy",
             "Bypass",
             "-File",


### PR DESCRIPTION
Stock Windows ships with Windows PowerShell 5.1 (powershell.exe) but not PowerShell 7+ (pwsh.exe). Using pwsh.exe causes builds to fail on machines without PowerShell 7 installed. Also adds -ExecutionPolicy Bypass since Windows PowerShell defaults to Restricted policy which blocks .ps1 script execution.

Fixes #3552