### PR TITLE
fix(pip): add read permissions when extracting wheels

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -243,7 +243,6 @@ use_repo(
     "rules_python_runtime_env_tc_info",
     "somepkg_with_build_files",
     "whl_library_extras_direct_dep",
-    "whl_perms_bad_perms_pkg",
     "whl_with_build_files",
 )
 


### PR DESCRIPTION
Fix for wheels like https://files.pythonhosted.org/packages/ad/39/da8b5c0f875ccb1770349caaecd87a253949ccbcdc2c869929919d744551/ag_ui_adk-0.4.2-py3-none-any.whl where the contents do not have the read bit set.

Fixes #3554