### PR TITLE
fix: remove CONFIG_ID write from build_data_writer.ps1

### DIFF
--- a/python/private/build_data_writer.ps1
+++ b/python/private/build_data_writer.ps1
@@ -1,7 +1,6 @@
 $OutputPath = $env:OUTPUT
 
 Add-Content -Path $OutputPath -Value "TARGET $env:TARGET"
-Add-Content -Path $OutputPath -Value "CONFIG_ID $env:CONFIG_ID"
 Add-Content -Path $OutputPath -Value "CONFIG_MODE $env:CONFIG_MODE"
 Add-Content -Path $OutputPath -Value "STAMPED $env:STAMPED"
 


### PR DESCRIPTION
Follow up from #3553 [comment](https://github.com/bazel-contrib/rules_python/pull/3553#issuecomment-3828794485) - removes extraneous CONFIG_ID write from build_data_writer.ps1 script.
