### PR TITLE
docs: doc the imports attribute as a target-relative path

### DIFF
--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -196,6 +196,7 @@ The values are target-directory-relative runfiles-root paths. e.g. given target
 * `a/b` adds `$runfilesRoot/$repo/foo/bar/a/b`
 * `../sibling` adds `$runfilesRoot/$repo/foo/sibling`
 * `../../` adds `$runfilesRoot/$repo`
+(where `$repo` is the name of the repository containing the target).
 
 Absolute paths (paths that start with `/`) and paths that references a path
 above the execution root are not allowed and will result in an error.


### PR DESCRIPTION
The docs incorrectly refer to the path as a repo-root relative path, but this is
plainly not the case, as the underlying code does, essentially,
`join(repoRoot, ctx.label, importsAttr)`

Work towards https://github.com/bazel-contrib/rules_python/issues/3565