### PR TITLE
docs: mention PyRuntimeInfo in PyExecutableInfo

### DIFF
--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -19,8 +19,9 @@ e.g. the Python runtime itself. It's roughly akin to the files a traditional
 venv would have installed into it.
 
 :::{seealso}
-{obj}`PyRuntimeInfo` for the Python runtime files, which is available from
-{obj}`py_binary` et al rules.
+{obj}`PyRuntimeInfo` for the Python runtime files. The {obj}`py_binary` et al
+rules provide it directly so that the runtime the binary original chose
+can be accessed.
 :::
 
 :::{versionadded} VERSION_NEXT_FEATURE


### PR DESCRIPTION
This is to make it more apparent how the interpreter's information can be mixed
together with the executable info.

Related to https://github.com/bazel-contrib/rules_python/issues/3181