### PR TITLE
fix: fallback to /usr/bin/env if env is not in PATH

### DIFF
--- a/python/private/stage1_bootstrap_template.sh
+++ b/python/private/stage1_bootstrap_template.sh
@@ -285,8 +285,14 @@ fi
 
 export RUNFILES_DIR
 
+if command -v env >/dev/null 2>&1; then
+  ENV_CMD="env"
+else
+  ENV_CMD="/usr/bin/env"
+fi
+
 command=(
-  env
+  "$ENV_CMD"
   "${interpreter_env[@]}"
   "$python_exe"
   "${interpreter_args[@]}"


### PR DESCRIPTION
This fixes an issue where the bootstrap script would fail if env was not in the PATH, which is the case on NixOS, or when Bazel's strict action env is enabled.

To fix, the bootstrap checks if env exists, and if not, falls back to /usr/bin/env.

Fixes https://github.com/bazel-contrib/rules_python/issues/3575