### PR TITLE
chore: add a script to easily checkout prs

### DIFF
--- a/tools/git-pr
+++ b/tools/git-pr
@@ -269,7 +269,7 @@ function cmd_push() {
   local local_branch=$(git rev-parse --abbrev-ref HEAD)
   local pr_branch=$(git config get branch.$local_branch.prPushRemoteBranch)
   local pr_remote=$(git config get branch.$local_branch.pushRemote)
-  (set -x; git push $pr_remote $local_branch:$pr_branch)
+  (set -x; git push "$pr_remote" "$local_branch:$pr_branch")
 }
 
 function cmd_pull() {
@@ -280,7 +280,7 @@ function cmd_pull() {
   local local_branch=$(git rev-parse --abbrev-ref HEAD)
   local pr_branch=$(git config get branch.$local_branch.prPushRemoteBranch)
   local pr_remote=$(git config get branch.$local_branch.pushRemote)
-  (set -x; git pull $pr_remote $pr_branch "$@")
+  (set -x; git pull "$pr_remote" "$pr_branch" "$@")
 }
 
 function usage() {


### PR DESCRIPTION
This adds a script I've had for awhile to make it easier to grab PRs and work on them.

It makes grabbing and editing a user's PR much easier, especially with some aliases
setup:

```
git pr-checkout <PR url>
...edit files...
git pr-push
```

While things like `gh pr checkout` exist, it doesn't well handle the "triangle"
workflow and some other edge cases.