### PR TITLE
fix: use runfiles_root_path in stage2 bootstrap

### DIFF
--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -768,10 +768,7 @@ def _create_stage1_bootstrap(
     }
 
     if stage2_bootstrap:
-        subs["%stage2_bootstrap%"] = "{}/{}".format(
-            ctx.workspace_name,
-            stage2_bootstrap.short_path,
-        )
+        subs["%stage2_bootstrap%"] = runfiles_root_path(ctx, stage2_bootstrap.short_path)
         template = runtime.bootstrap_template
         subs["%shebang%"] = runtime.stub_shebang
     elif not ctx.files.srcs:


### PR DESCRIPTION
The `%stage2_bootstrap%` template variable was getting a value like
`main/../repo/bla.py`. While most APIs would implicitly process the `../` it's
somewhat confusing and makes textual string matching (such as when looking in
a runfiles manifest) harder.

To fix, use runfiles_root_path helper function, which pre-normalizes the path.