### PR TITLE
chore: ignore rmtree errors in wheel_installer_test

### DIFF
--- a/tests/pypi/whl_installer/wheel_installer_test.py
+++ b/tests/pypi/whl_installer/wheel_installer_test.py
@@ -63,7 +63,9 @@ class TestWhlFilegroup(unittest.TestCase):
         shutil.copy(os.path.join("examples", "wheel", self.wheel_name), self.wheel_dir)
 
     def tearDown(self):
-        shutil.rmtree(self.wheel_dir)
+        # On windows, the wheel file remains open, so gives an error upon
+        # deletion for some reason.
+        shutil.rmtree(self.wheel_dir, ignore_errors=True)
 
     def test_wheel_exists(self) -> None:
         wheel_installer._extract_wheel(


### PR DESCRIPTION
When run on Windows with zip mode disabled, the cleanup can fail if the files are
still open on Windows. This is an innocuous failure, so just ignore it.