### PR TITLE
fix: use forward slashes for initial Rlocation lookup of build data

### DIFF
--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -66,8 +66,6 @@ class BazelBinaryInfoModule(types.ModuleType):
         except ImportError:
             from python.runfiles import runfiles
         rlocation_path = self.BUILD_DATA_FILE
-        if is_windows():
-            rlocation_path = rlocation_path.replace("/", "\\")
         path = runfiles.Create().Rlocation(rlocation_path)
         if is_windows():
             path = os.path.normpath(path)


### PR DESCRIPTION
Gemini flagged that Rlocation accepts forward-slash delimited paths. This appears to
be correct, since the internal logic uses forward slashes and manifests contain
forward slashes.