### PR TITLE
chore: update changelog with 1.8.5 notes, fix 1.8 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ END_UNRELEASED_TEMPLATE
 
 [1.8.4]: https://github.com/bazel-contrib/rules_python/releases/tag/1.8.4
 
+{#v1-8-4-fixed}
 ### Fixed
 * (pipstar): A corner case of evaluation of version specifiers (`"1.2" ~= "1.2.0"`)
   has been fixed improving compatibility with the PEP440 standard.


### PR DESCRIPTION
Copies the changelog updates in 1.8.5 to main.

Also fixes some links for the other 1.8 releases