### PR TITLE
chore: replace version marker in features.bzl

### DIFF
--- a/python/features.bzl
+++ b/python/features.bzl
@@ -26,7 +26,7 @@ def _features_typedef():
     A map of public API targets available in rules_python for feature detection
     purposes.
 
-    :::{versionadded} VERSION_NEXT_FEATURE
+    :::{versionadded} 1.9.0
     :::
     ::::
 


### PR DESCRIPTION
A version marker in features.bzl was missed. Replace it with 1.9.