### PR TITLE
chore: factor release note checking into separate script

### DIFF
--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -26,8 +26,10 @@ if [ -z "$TAG" ]; then
 fi
 # If the workflow checks out one commit, but is releasing another
 git fetch origin tag "$TAG"
-# Update our local state so the grep command below searches what we expect
+
+# Update our local state so that check_version_markers searches what we expect
 git checkout "$TAG"
+$(dirname $0)/check_version_markers.sh
 
 # A prefix is added to better match the GitHub generated archives.
 PREFIX="rules_python-${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-      - name: Check version markers
-        run: .github/workflows/check_version_markers.sh ${{ inputs.tag_name || github.ref_name }}
       - name: Create release archive and notes
         run: .github/workflows/create_archive_and_notes.sh ${{ inputs.tag_name || github.ref_name }}
       - name: Release


### PR DESCRIPTION
This is to make it easier to check for missing version markers by running the script directly