### PR TITLE
chore: silence annoying compile warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,3 +41,7 @@ common --incompatible_python_disallow_native_rules
 common --incompatible_no_implicit_file_export
 
 build --lockfile_mode=update
+
+# Suppress sign-compare warnings from external dependencies like protobuf
+build --copt=-Wno-sign-compare
+build --host_copt=-Wno-sign-compare


### PR DESCRIPTION
Protobuf was causing spammy C++ compile warnings. To fix them, silence them in copts.