### PR TITLE
feat(pypi): make whl_library reproducible under pipstar (#3589)

### DIFF
--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -548,7 +548,12 @@ def _whl_library_impl(rctx):
             paths.extend(path.readdir())
 
     rctx.file("BUILD.bazel", build_file_contents)
-    return
+
+    if enable_pipstar and enable_pipstar_extract:
+        if hasattr(rctx, "repo_metadata"):
+            return rctx.repo_metadata(reproducible = True)
+
+    return None
 
 def _generate_entry_point_contents(
         module,
@@ -690,7 +695,13 @@ whl_library = repository_rule(
     attrs = whl_library_attrs,
     doc = """
 Download and extracts a single wheel based into a bazel repo based on the requirement string passed in.
-Instantiated from pip_repository and inherits config options from there.""",
+Instantiated from pip_repository and inherits config options from there.
+
+:::{versionchanged} 1.9.0
+The `whl_library` is marked as reproducible if using starlark to extract and parse the
+wheel contents without building an `sdist` first.
+:::
+""",
     implementation = _whl_library_impl,
     environ = [
         "RULES_PYTHON_PIP_ISOLATED",


### PR DESCRIPTION
This is testing the new API to make use of remote caching mechanisms.

Needs: https://github.com/bazelbuild/bazel/pull/27634

---------

(cherry picked from commit 06aa36daba6377bdeaf90309c73da22ca1afa153)