### PR TITLE
chore: cleanup the usage of rctx.getenv

### DIFF
--- a/python/private/auth.bzl
+++ b/python/private/auth.bzl
@@ -95,11 +95,7 @@ def get_auth(ctx, urls, ctx_attr = None):
     if ctx_attr.netrc:
         netrc = read_netrc(ctx, ctx_attr.netrc)
     elif "NETRC" in ctx.os.environ:
-        # This can be used on newer bazel versions
-        if hasattr(ctx, "getenv"):
-            netrc = read_netrc(ctx, ctx.getenv("NETRC"))
-        else:
-            netrc = read_netrc(ctx, ctx.os.environ["NETRC"])
+        netrc = read_netrc(ctx, ctx.getenv("NETRC"))
     else:
         netrc = read_user_netrc(ctx)
 

--- a/python/private/envsubst.bzl
+++ b/python/private/envsubst.bzl
@@ -20,9 +20,7 @@ def envsubst(template_string, varnames, getenv):
     Supports `$VARNAME`, `${VARNAME}` and `${VARNAME:-default}`
     syntaxes in the `template_string`, looking up each `VARNAME`
     listed in the `varnames` list in the environment defined by the
-    `getenv` function. Typically called with `getenv = rctx.getenv`
-    (if it is available) or `getenv = rctx.os.environ.get` (on e.g.
-    Bazel 6 or Bazel 7, which don't have `rctx.getenv` yet).
+    `getenv` function. Typically called with `getenv = rctx.getenv`.
 
     Limitations: Unlike the shell, we don't support `${VARNAME}` and
     `${VARNAME:-default}` in the default expression for a different

--- a/python/private/internal_config_repo.bzl
+++ b/python/private/internal_config_repo.bzl
@@ -147,4 +147,4 @@ internal_config_repo = repository_rule(
 )
 
 def _bool_from_environ(rctx, key, default):
-    return bool(int(repo_utils.getenv(rctx, key, default)))
+    return bool(int(rctx.getenv(key, default)))

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -359,7 +359,7 @@ def _resolve_interpreter_path(rctx):
         if "/" not in interpreter_path and "\\" not in interpreter_path:
             # Provide a bit nicer integration with pyenv: recalculate the runtime if the
             # user changes the python version using e.g. `pyenv shell`
-            repo_utils.getenv(rctx, "PYENV_VERSION")
+            rctx.getenv("PYENV_VERSION")
             result = repo_utils.which_unchecked(rctx, interpreter_path)
             resolved_path = result.binary
             describe_failure = result.describe_failure

--- a/python/private/pypi/attrs.bzl
+++ b/python/private/pypi/attrs.bzl
@@ -240,7 +240,7 @@ def use_isolated(ctx, attr):
     use_isolated = attr.isolated
 
     # The environment variable will take precedence over the attribute
-    isolated_env = ctx.os.environ.get("RULES_PYTHON_PIP_ISOLATED", None)
+    isolated_env = ctx.getenv("RULES_PYTHON_PIP_ISOLATED", None)
     if isolated_env != None:
         if isolated_env.lower() in ("0", "false"):
             use_isolated = False

--- a/python/private/pypi/pip_repository.bzl
+++ b/python/private/pypi/pip_repository.bzl
@@ -65,7 +65,7 @@ def use_isolated(ctx, attr):
     use_isolated = attr.isolated
 
     # The environment variable will take precedence over the attribute
-    isolated_env = ctx.os.environ.get("RULES_PYTHON_PIP_ISOLATED", None)
+    isolated_env = ctx.getenv("RULES_PYTHON_PIP_ISOLATED", None)
     if isolated_env != None:
         if isolated_env.lower() in ("0", "false"):
             use_isolated = False

--- a/python/private/pypi/simpleapi_download.bzl
+++ b/python/private/pypi/simpleapi_download.bzl
@@ -189,11 +189,7 @@ def _read_simpleapi(ctx, url, attr, cache, get_auth = None, **download_kwargs):
     # them to ctx.download if we want to correctly handle the relative URLs.
     # TODO: Add a test that env subbed index urls do not leak into the lock file.
 
-    real_url = strip_empty_path_segments(envsubst(
-        url,
-        attr.envsubst,
-        ctx.getenv if hasattr(ctx, "getenv") else ctx.os.environ.get,
-    ))
+    real_url = strip_empty_path_segments(envsubst(url, attr.envsubst, ctx.getenv))
 
     cache_key = real_url
     cached_result = cache.get(cache_key)

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -151,21 +151,13 @@ def _parse_optional_attrs(rctx, args, extra_pip_args = None):
     if use_isolated(rctx, rctx.attr):
         args.append("--isolated")
 
-    # Bazel version 7.1.0 and later (and rolling releases from version 8.0.0-pre.20240128.3)
-    # support rctx.getenv(name, default): When building incrementally, any change to the value of
-    # the variable named by name will cause this repository to be re-fetched.
-    if "getenv" in dir(rctx):
-        getenv = rctx.getenv
-    else:
-        getenv = rctx.os.environ.get
-
     # Check for None so we use empty default types from our attrs.
     # Some args want to be list, and some want to be dict.
     if extra_pip_args != None:
         args += [
             "--extra_pip_args",
             json.encode(struct(arg = [
-                envsubst(pip_arg, rctx.attr.envsubst, getenv)
+                envsubst(pip_arg, rctx.attr.envsubst, rctx.getenv)
                 for pip_arg in extra_pip_args
             ])),
         ]

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -56,7 +56,7 @@ def parse_modules(*, module_ctx, logger, _fail = fail):
               platform suffix.
             * register_coverage_tool: bool
     """
-    if module_ctx.os.environ.get("RULES_PYTHON_BZLMOD_DEBUG", "0") == "1":
+    if module_ctx.getenv("RULES_PYTHON_BZLMOD_DEBUG", "0") == "1":
         debug_info = {
             "toolchains_registered": [],
         }

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -29,7 +29,7 @@ def _is_repo_debug_enabled(mrctx):
     Returns:
         True if enabled, False if not.
     """
-    return _getenv(mrctx, REPO_DEBUG_ENV_VAR) == "1"
+    return mrctx.getenv(REPO_DEBUG_ENV_VAR) == "1"
 
 def _logger(mrctx = None, name = None, verbosity_level = None, printer = None):
     """Creates a logger instance for printing messages.
@@ -56,7 +56,7 @@ def _logger(mrctx = None, name = None, verbosity_level = None, printer = None):
         else:
             verbosity_level = "WARN"
 
-        env_var_verbosity = _getenv(mrctx, REPO_VERBOSITY_ENV_VAR)
+        env_var_verbosity = mrctx.getenv(REPO_VERBOSITY_ENV_VAR)
         verbosity_level = env_var_verbosity or verbosity_level
 
     verbosity = {
@@ -302,7 +302,7 @@ def _which_unchecked(mrctx, binary_name):
         mrctx.watch(binary)
         describe_failure = None
     else:
-        path = _getenv(mrctx, "PATH", "")
+        path = mrctx.getenv("PATH", "")
         describe_failure = lambda: _which_describe_failure(binary_name, path)
 
     return struct(
@@ -318,10 +318,6 @@ def _which_describe_failure(binary_name, path):
         binary_name = binary_name,
         path = path,
     )
-
-def _getenv(mrctx, name, default = None):
-    # Bazel 7+ API has (repository|module)_ctx.getenv
-    return getattr(mrctx, "getenv", mrctx.os.environ.get)(name, default)
 
 def _args_to_str(arguments):
     return " ".join([_arg_repr(a) for a in arguments])
@@ -467,7 +463,6 @@ repo_utils = struct(
     extract = _extract,
     get_platforms_cpu_name = _get_platforms_cpu_name,
     get_platforms_os_name = _get_platforms_os_name,
-    getenv = _getenv,
     is_repo_debug_enabled = _is_repo_debug_enabled,
     logger = _logger,
     which_checked = _which_checked,

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -592,7 +592,7 @@ def _get_host_impl_repo_name(*, rctx, logger, python_version, os_name, cpu_name,
             os_name.upper(),
             cpu_name.upper(),
         )
-        preference = repo_utils.getenv(rctx, env_var)
+        preference = rctx.getenv(env_var)
         if preference == None:
             logger.info("Consider using '{}' to select from one of the platforms: {}".format(
                 env_var,

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -24,8 +24,8 @@ _tests = []
 
 def _mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
     return struct(
+        getenv = environ.get,
         os = struct(
-            environ = environ,
             name = os_name,
             arch = arch_name,
         ),

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -27,8 +27,8 @@ _tests = []
 
 def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
     return struct(
+        getenv = environ.get,
         os = struct(
-            environ = environ,
             name = os_name,
             arch = arch_name,
         ),
@@ -89,12 +89,10 @@ def hub_builder(
         evaluate_markers_fn = evaluate_markers_fn,
         logger = repo_utils.logger(
             struct(
-                os = struct(
-                    environ = {
-                        REPO_DEBUG_ENV_VAR: "1",
-                        REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "FAIL",
-                    },
-                ),
+                getenv = {
+                    REPO_DEBUG_ENV_VAR: "1",
+                    REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "FAIL",
+                }.get,
             ),
             "unit-test",
             printer = log_printer,

--- a/tests/pypi/parse_requirements/parse_requirements_tests.bzl
+++ b/tests/pypi/parse_requirements/parse_requirements_tests.bzl
@@ -111,12 +111,10 @@ def parse_requirements(debug = False, **kwargs):
     return _parse_requirements(
         ctx = _mock_ctx(),
         logger = repo_utils.logger(struct(
-            os = struct(
-                environ = {
-                    REPO_DEBUG_ENV_VAR: "1",
-                    REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "INFO",
-                },
-            ),
+            getenv = {
+                REPO_DEBUG_ENV_VAR: "1",
+                REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "INFO",
+            }.get,
         ), "unit-test"),
         **kwargs
     )

--- a/tests/pypi/select_whl/select_whl_tests.bzl
+++ b/tests/pypi/select_whl/select_whl_tests.bzl
@@ -84,12 +84,10 @@ def _select_whl(whls, debug = False, **kwargs):
             for f in whls
         ],
         logger = repo_utils.logger(struct(
-            os = struct(
-                environ = {
-                    REPO_DEBUG_ENV_VAR: "1",
-                    REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "INFO",
-                },
-            ),
+            getenv = {
+                REPO_DEBUG_ENV_VAR: "1",
+                REPO_VERBOSITY_ENV_VAR: "TRACE" if debug else "INFO",
+            }.get,
         ), "unit-test"),
         **kwargs
     )

--- a/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
+++ b/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
@@ -43,7 +43,7 @@ def _test_simple(env):
 
     contents = simpleapi_download(
         ctx = struct(
-            os = struct(environ = {}),
+            getenv = {}.get,
             report_progress = lambda _: None,
         ),
         attr = struct(
@@ -101,7 +101,7 @@ def _test_fail(env):
 
     simpleapi_download(
         ctx = struct(
-            os = struct(environ = {}),
+            getenv = {}.get,
             report_progress = lambda _: None,
         ),
         attr = struct(
@@ -153,7 +153,7 @@ def _test_download_url(env):
 
     simpleapi_download(
         ctx = struct(
-            os = struct(environ = {}),
+            getenv = {}.get,
             download = download,
             report_progress = lambda _: None,
             read = lambda i: "contents of " + i,
@@ -189,7 +189,7 @@ def _test_download_url_parallel(env):
 
     simpleapi_download(
         ctx = struct(
-            os = struct(environ = {}),
+            getenv = {}.get,
             download = download,
             report_progress = lambda _: None,
             read = lambda i: "contents of " + i,
@@ -225,7 +225,7 @@ def _test_download_envsubst_url(env):
 
     simpleapi_download(
         ctx = struct(
-            os = struct(environ = {"INDEX_URL": "https://example.com/main/simple/"}),
+            getenv = {"INDEX_URL": "https://example.com/main/simple/"}.get,
             download = download,
             report_progress = lambda _: None,
             read = lambda i: "contents of " + i,

--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -26,7 +26,6 @@ def _mock_mctx(*modules, environ = {}, mocked_files = {}):
         path = lambda x: struct(exists = x in mocked_files, _file = x),
         read = lambda x, watch = None: mocked_files[x._file if "_file" in dir(x) else x],
         getenv = environ.get,
-        os = struct(environ = environ),
         modules = [
             struct(
                 name = modules[0].name,


### PR DESCRIPTION
Remove most of the usage of os.environ.get and use getenv instead.
The question is if we should just replace all usages blindly?
