### PR TITLE
ci: disable soft-fail jobs to unbreak ci

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -194,20 +194,23 @@ tasks:
     name: "Default: Ubuntu, upcoming Bazel"
     platform: ubuntu2204
     bazel: last_rc
-  ubuntu_rolling:
-    name: "Default: Ubuntu, rolling Bazel"
-    platform: ubuntu2204
-    bazel: rolling
-    # This is an advisory job; doesn't block merges
-    soft_fail:
-      - exit_status: 1
-      - exit_status: 3
-    test_targets:
-      - "--"
-      - "//tests/..."
-    test_flags:
-      - "--keep_going"
-      - "--test_tag_filters=-integration-test"
+  # Temporarily remove this job to avoid all of CI failing
+  # Can be re-enabled after BazelCI is fixed, see
+  # https://github.com/bazelbuild/continuous-integration/pull/2487
+  # ubuntu_rolling:
+  #   name: "Default: Ubuntu, rolling Bazel"
+  #   platform: ubuntu2204
+  #   bazel: rolling
+  #   # This is an advisory job; doesn't block merges
+  #   soft_fail:
+  #     - exit_status: 1
+  #     - exit_status: 3
+  #   test_targets:
+  #     - "--"
+  #     - "//tests/..."
+  #   test_flags:
+  #     - "--keep_going"
+  #     - "--test_tag_filters=-integration-test"
   ubuntu_workspace:
     <<: *reusable_config
     <<: *common_workspace_flags


### PR DESCRIPTION
BazelCI has a bug where soft_fail jobs will break the entire CI pipeline.

Commenting them out seems to avoid the bug

See also: https://github.com/bazelbuild/continuous-integration/pull/2487