### PR TITLE
ci: soft fail for upcoming bazel job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -194,6 +194,10 @@ tasks:
     name: "Default: Ubuntu, upcoming Bazel"
     platform: ubuntu2204
     bazel: last_rc
+    # RCs may have regressions, so don't fail our CI on them
+    soft_fail:
+      - exit_status: 1
+      - exit_status: 3
   ubuntu_rolling:
     name: "Default: Ubuntu, rolling Bazel"
     platform: ubuntu2204


### PR DESCRIPTION
Upcoming RC builds may have regressions, so instead of blocking our CI on their failures,
mark them as soft-fail. This way we can be aware of upcoming problems, but not block
regular development.