### PR TITLE
Link a quickstart screen recording for rules_python beginners into docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,8 @@ For more detailed information about configuring `rules_python`, see:
 * [Configuring third-party dependencies (pip/PyPI)](./pypi/index)
 * [API docs](api/index)
 
+A [screen recording](https://www.youtube.com/watch?v=Xtuh-WipOnk) on configuring rules_python for beginners is also available.
+
 ## Including dependencies
 
 The first step to using `rules_python` is to add the dependency to


### PR DESCRIPTION
aignas suggested I add a link to this YouTube video somewhere in the docs:
https://bazelbuild.slack.com/archives/CA306CEV6/p1773133824891709?thread_ts=1773089164.263869&cid=CA306CEV6
