### PR TITLE
fix(pypi) Correct likely _BAZEL_REPO_FILE_GLOBS typo

### DIFF
--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -39,7 +39,7 @@ _BAZEL_REPO_FILE_GLOBS = [
     "BUILD.bazel",
     "REPO.bazel",
     "WORKSPACE",
-    "WORKSPACE",
+    "WORKSPACE.bzlmod",
     "WORKSPACE.bazel",
 ]
 


### PR DESCRIPTION
Based on https://github.com/bazel-contrib/rules_python/blob/f5f35d6e9a2f01c754e59c6ff97bfdcdf81abc35/python/private/toolchains_repo.bzl#L340-L345 I suspect the duplicate `"WORKSPACE"` was meant to be `"WORKSPACE.bzlmod"`. Potentially this could be factored out and shared, or `toolchains_repo.bzl` be updated to also include `"BUILD"`.