### PR TITLE
chore: update changelog, version markers, for 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,16 +47,16 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
-{#v0-0-0}
-## Unreleased
+{#v2-0-0}
+## [2.0.0] - 2026-04-09
 
-[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+[2.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0
 
-{#v0-0-0-removed}
+{#v2-0-0-removed}
 ### Removed
 * Nothing removed.
 
-{#v0-0-0-changed}
+{#v2-0-0-changed}
 ### Changed
 
 **Breaking**
@@ -91,7 +91,7 @@ Other changes:
 * Windows no longer defaults to creating a zip file and extracting it; a
   symlink-based runfiles tree is created, as on unix-like platforms.
 
-{#v0-0-0-fixed}
+{#v2-0-0-fixed}
 ### Fixed
 * (toolchain) Also set Make variables for local toolchains.
 * (zipapp) Resolve issue passing through compression settings in
@@ -123,7 +123,7 @@ Other changes:
   ```
   Fixes [#3676](https://github.com/bazel-contrib/rules_python/issues/3676).
 
-{#v0-0-0-added}
+{#v2-0-0-added}
 ### Added
 * (pypi) Write SimpleAPI contents to the `MODULE.bazel.lock` file if using
   {obj}`experimental_index_url` which should speed up consecutive

--- a/python/private/py_executable_info.bzl
+++ b/python/private/py_executable_info.bzl
@@ -83,7 +83,7 @@ implementation isn't being used.
 
 Runfiles that are specific to the interpreter within the venv.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 2.0.0
 :::
 """,
         "venv_interpreter_symlinks": """
@@ -95,7 +95,7 @@ Only used with Windows for files that would have used `declare_symlink()`
 to create relative symlinks. These may overlap with paths in runfiles; it's
 up to the consumer to determine how to handle such overlaps.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 2.0.0
 :::
 """,
         "venv_python_exe": """

--- a/python/private/py_runtime_info.bzl
+++ b/python/private/py_runtime_info.bzl
@@ -343,7 +343,7 @@ to meet two criteria:
 Files that should be added to the venv's `bin/` (or platform-specific equivalent)
 directory (using the file's basename).
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 2.0.0
 """,
         "zip_main_template": """
 :type: File

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -206,7 +206,7 @@ filegroup(name = "files", srcs = [":file1.txt", ":file2.txt"])
 
 Allowed paths: {prefixes}
 
-:::{{versionchanged}} VERSION_NEXT_FEATURE
+:::{{versionchanged}} 2.0.0
 Values can end in slash (`/`) to indicate that all files of the target should
 be moved under that directory.
 :::


### PR DESCRIPTION
This updates the changelog and version markers for the next release, 2.0