### PR TITLE
chore: factor mock mctx/rctx functionality into separate file

### DIFF
--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -18,13 +18,13 @@ load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "subjects")
 load("//python/private/pypi:extension.bzl", "build_config", "parse_modules")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:whl_config_setting.bzl", "whl_config_setting")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 load(":pip_parse.bzl", _parse = "pip_parse")
 
 _tests = []
 
 def _pypi_mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
-    return mock_mctx(
+    return mocks.mctx(
         modules = list(modules),
         os_name = os_name,
         arch_name = arch_name,
@@ -36,34 +36,32 @@ simple==0.0.1 \
     )
 
 def _mod(*, name, default = [], parse = [], override = [], whl_mods = [], is_root = True):
-    return struct(
-        name = name,
-        tags = struct(
-            parse = parse,
-            override = override,
-            whl_mods = whl_mods,
-            default = default or [
-                _default(
-                    platform = "{}_{}{}".format(os, cpu, freethreaded),
-                    os_name = os,
-                    arch_name = cpu,
-                    config_settings = [
-                        "@platforms//os:{}".format(os),
-                        "@platforms//cpu:{}".format(cpu),
-                    ],
-                    whl_abi_tags = ["cp{major}{minor}t"] if freethreaded else ["abi3", "cp{major}{minor}"],
-                    whl_platform_tags = whl_platform_tags,
-                )
-                for (os, cpu, freethreaded), whl_platform_tags in {
-                    ("linux", "x86_64", ""): ["linux_x86_64", "manylinux_*_x86_64"],
-                    ("linux", "x86_64", "_freethreaded"): ["linux_x86_64", "manylinux_*_x86_64"],
-                    ("linux", "aarch64", ""): ["linux_aarch64", "manylinux_*_aarch64"],
-                    ("osx", "aarch64", ""): ["macosx_*_arm64"],
-                    ("windows", "aarch64", ""): ["win_arm64"],
-                }.items()
-            ],
-        ),
+    return mocks.module(
+        name,
         is_root = is_root,
+        parse = parse,
+        override = override,
+        whl_mods = whl_mods,
+        default = default or [
+            _default(
+                platform = "{}_{}{}".format(os, cpu, freethreaded),
+                os_name = os,
+                arch_name = cpu,
+                config_settings = [
+                    "@platforms//os:{}".format(os),
+                    "@platforms//cpu:{}".format(cpu),
+                ],
+                whl_abi_tags = ["cp{major}{minor}t"] if freethreaded else ["abi3", "cp{major}{minor}"],
+                whl_platform_tags = whl_platform_tags,
+            )
+            for (os, cpu, freethreaded), whl_platform_tags in {
+                ("linux", "x86_64", ""): ["linux_x86_64", "manylinux_*_x86_64"],
+                ("linux", "x86_64", "_freethreaded"): ["linux_x86_64", "manylinux_*_x86_64"],
+                ("linux", "aarch64", ""): ["linux_aarch64", "manylinux_*_aarch64"],
+                ("osx", "aarch64", ""): ["macosx_*_arm64"],
+                ("windows", "aarch64", ""): ["win_arm64"],
+            }.items()
+        ],
     )
 
 def _parse_modules(env, enable_pipstar = 0, **kwargs):

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -18,35 +18,21 @@ load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "subjects")
 load("//python/private/pypi:extension.bzl", "build_config", "parse_modules")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:whl_config_setting.bzl", "whl_config_setting")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 load(":pip_parse.bzl", _parse = "pip_parse")
 
 _tests = []
 
-def _mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
-    return struct(
-        getenv = environ.get,
-        os = struct(
-            name = os_name,
-            arch = arch_name,
-        ),
+def _pypi_mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
+    return mock_mctx(
+        modules = list(modules),
+        os_name = os_name,
+        arch_name = arch_name,
+        environ = environ,
         read = read or (lambda _: """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
     --hash=sha256:deadbaaf"""),
-        modules = [
-            struct(
-                name = modules[0].name,
-                tags = modules[0].tags,
-                is_root = modules[0].is_root,
-            ),
-        ] + [
-            struct(
-                name = mod.name,
-                tags = mod.tags,
-                is_root = False,
-            )
-            for mod in modules[1:]
-        ],
     )
 
 def _mod(*, name, default = [], parse = [], override = [], whl_mods = [], is_root = True):
@@ -140,7 +126,7 @@ def _default(
 def _test_simple(env):
     pypi = _parse_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _pypi_mock_mctx(
             _mod(
                 name = "rules_python",
                 parse = [
@@ -187,7 +173,7 @@ _tests.append(_test_simple)
 def _test_build_pipstar_platform(env):
     config = _build_config(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _pypi_mock_mctx(
             _mod(
                 name = "rules_python",
                 default = [

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -29,10 +29,12 @@ def _pypi_mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", enviro
         os_name = os_name,
         arch_name = arch_name,
         environ = environ,
-        read = read or (lambda _: """\
+        mock_files = {
+            "requirements.txt": """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
-    --hash=sha256:deadbaaf"""),
+    --hash=sha256:deadbaaf"""
+        },
     )
 
 def _mod(*, name, default = [], parse = [], override = [], whl_mods = [], is_root = True):

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -24,6 +24,7 @@ load(":pip_parse.bzl", _parse = "pip_parse")
 _tests = []
 
 def _pypi_mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
+    _ = read  # @unused
     return mocks.mctx(
         modules = list(modules),
         os_name = os_name,
@@ -33,7 +34,7 @@ def _pypi_mock_mctx(*modules, os_name = "unittest", arch_name = "exotic", enviro
             "requirements.txt": """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
-    --hash=sha256:deadbaaf"""
+    --hash=sha256:deadbaaf""",
         },
     )
 

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -162,10 +162,10 @@ def _test_simple_multiple_requirements(env):
         builder = hub_builder(env)
         builder.pip_parse(
             mocks.mctx(
-                read = lambda x: {
+                mock_files = {
                     "darwin.txt": "simple==0.0.2 --hash=sha256:deadb00f",
                     "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
-                }[x],
+                },
                 os_name = host_os,
                 arch_name = host_arch,
             ),
@@ -208,10 +208,10 @@ def _test_simple_extras_vs_no_extras(env):
         builder = hub_builder(env)
         builder.pip_parse(
             mocks.mctx(
-                read = lambda x: {
+                mock_files = {
                     "darwin.txt": "simple[foo]==0.0.1 --hash=sha256:deadbeef",
                     "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
-                }[x],
+                },
                 os_name = host_os,
                 arch_name = host_arch,
             ),
@@ -273,10 +273,10 @@ def _test_simple_extras_vs_no_extras_simpleapi(env):
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "darwin.txt": "simple[foo]==0.0.1 --hash=sha256:deadbeef",
                 "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -349,12 +349,12 @@ def _test_simple_multiple_python_versions(env):
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "requirements_3_15.txt": """
 simple==0.0.1 --hash=sha256:deadbeef
 old-package==0.0.1 --hash=sha256:deadbaaf
 """,
-            }[x],
+            },
             os_name = "linux",
             arch_name = "amd64",
         ),
@@ -366,12 +366,12 @@ old-package==0.0.1 --hash=sha256:deadbaaf
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "requirements_3_16.txt": """
 simple==0.0.2 --hash=sha256:deadb00f
 new-package==0.0.1 --hash=sha256:deadb00f2
 """,
-            }[x],
+            },
             os_name = "linux",
             arch_name = "amd64",
         ),
@@ -454,13 +454,13 @@ def _test_simple_with_markers(env):
         )
         builder.pip_parse(
             mocks.mctx(
-                read = lambda x: {
+                mock_files = {
                     "universal.txt": """\
     torch==2.4.1+cpu ; platform_machine == 'x86_64'
     torch==2.4.1 ; platform_machine != 'x86_64' \
         --hash=sha256:deadbeef
     """,
-                }[x],
+                },
                 os_name = host_os,
                 arch_name = host_arch,
             ),
@@ -576,7 +576,7 @@ def _test_torch_experimental_index_url(env):
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "universal.txt": """\
 torch==2.4.1 ; platform_machine != 'x86_64' \
     --hash=sha256:1495132f30f722af1a091950088baea383fe39903db06b20e6936fd99402803e \
@@ -603,7 +603,7 @@ torch==2.4.1+cpu ; platform_machine == 'x86_64' \
     --hash=sha256:c4f2c3c026e876d4dad7629170ec14fff48c076d6c2ae0e354ab3fdc09024f00
     # via -r requirements.in
 """,
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -769,9 +769,9 @@ simple==0.0.1 --hash=sha256:deadb00f
         )
         builder.pip_parse(
             _mock_mctx(
-                read = lambda x: {
+                mock_files = {
                     "requirements.txt": test.requirements_txt,
-                }[x],
+                },
             ),
             _parse(
                 hub_name = "pypi",
@@ -833,7 +833,7 @@ def _test_download_only_multiple(env):
     builder = hub_builder(env)
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "requirements.linux_x86_64.txt": """\
 --platform=manylinux_2_17_x86_64
 --python-version=315
@@ -854,7 +854,7 @@ extra==0.0.1 \
 simple==0.0.3 \
     --hash=sha256:deadbaaf
 """,
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -996,7 +996,7 @@ def _test_simple_get_index(env):
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "requirements.txt": """
 simple==0.0.1 \
     --hash=sha256:deadbeef \
@@ -1010,7 +1010,7 @@ pip_fallback==0.0.1
 direct_sdist_without_sha @ some-archive/any-name.tar.gz
 git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
 """,
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -1244,12 +1244,12 @@ def _test_optimum_sys_platform_extra(env):
         )
         builder.pip_parse(
             mocks.mctx(
-                read = lambda x: {
+                mock_files = {
                     "universal.txt": """\
 optimum[onnxruntime]==1.17.1 ; sys_platform == 'darwin'
 optimum[onnxruntime-gpu]==1.17.1 ; sys_platform == 'linux'
 """,
-                }[x],
+                },
                 os_name = host_os,
                 arch_name = host_arch,
             ),
@@ -1312,12 +1312,12 @@ def _test_pipstar_platforms(env):
     )
     builder.pip_parse(
         mocks.mctx(
-            read = lambda x: {
+            mock_files = {
                 "universal.txt": """\
 optimum[onnxruntime]==1.17.1 ; sys_platform == 'darwin'
 optimum[onnxruntime-gpu]==1.17.1 ; sys_platform == 'linux'
 """,
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -1400,12 +1400,12 @@ def _test_pipstar_platforms_limit(env):
         mocks.mctx(
             os_name = "linux",
             arch_name = "amd64",
-            read = lambda x: {
+            mock_files = {
                 "universal.txt": """\
 optimum[onnxruntime]==1.17.1 ; sys_platform == 'darwin'
 optimum[onnxruntime-gpu]==1.17.1 ; sys_platform == 'linux'
 """,
-            }[x],
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -1452,9 +1452,9 @@ def _test_err_duplicate_repos(env):
         _mock_mctx(
             os_name = "osx",
             arch_name = "aarch64",
-            read = lambda x: {
+            mock_files = {
                 "requirements.txt": "foo==0.0.1",
-            }.get(getattr(x, "_path", str(x)), ""),
+            },
         ),
         _parse(
             hub_name = "pypi",
@@ -1466,9 +1466,9 @@ def _test_err_duplicate_repos(env):
         _mock_mctx(
             os_name = "osx",
             arch_name = "aarch64",
-            read = lambda x: {
+            mock_files = {
                 "requirements.txt": "foo==0.0.1",
-            }.get(getattr(x, "_path", str(x)), ""),
+            },
         ),
         _parse(
             hub_name = "pypi",

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -161,7 +161,7 @@ def _test_simple_multiple_requirements(env):
     for (host_os, host_arch), want_requirement in sub_tests.items():
         builder = hub_builder(env)
         builder.pip_parse(
-            _mock_mctx(
+            mocks.mctx(
                 read = lambda x: {
                     "darwin.txt": "simple==0.0.2 --hash=sha256:deadb00f",
                     "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
@@ -207,7 +207,7 @@ def _test_simple_extras_vs_no_extras(env):
     for (host_os, host_arch), want_requirement in sub_tests.items():
         builder = hub_builder(env)
         builder.pip_parse(
-            _mock_mctx(
+            mocks.mctx(
                 read = lambda x: {
                     "darwin.txt": "simple[foo]==0.0.1 --hash=sha256:deadbeef",
                     "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
@@ -272,7 +272,7 @@ def _test_simple_extras_vs_no_extras_simpleapi(env):
         ),
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "darwin.txt": "simple[foo]==0.0.1 --hash=sha256:deadbeef",
                 "win.txt": "simple==0.0.1 --hash=sha256:deadbeef",
@@ -348,7 +348,7 @@ def _test_simple_multiple_python_versions(env):
         },
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "requirements_3_15.txt": """
 simple==0.0.1 --hash=sha256:deadbeef
@@ -365,7 +365,7 @@ old-package==0.0.1 --hash=sha256:deadbaaf
         ),
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "requirements_3_16.txt": """
 simple==0.0.2 --hash=sha256:deadb00f
@@ -453,7 +453,7 @@ def _test_simple_with_markers(env):
             },
         )
         builder.pip_parse(
-            _mock_mctx(
+            mocks.mctx(
                 read = lambda x: {
                     "universal.txt": """\
     torch==2.4.1+cpu ; platform_machine == 'x86_64'
@@ -575,7 +575,7 @@ def _test_torch_experimental_index_url(env):
         ),
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "universal.txt": """\
 torch==2.4.1 ; platform_machine != 'x86_64' \
@@ -832,7 +832,7 @@ _tests.append(_test_index_url_precedence)
 def _test_download_only_multiple(env):
     builder = hub_builder(env)
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "requirements.linux_x86_64.txt": """\
 --platform=manylinux_2_17_x86_64
@@ -995,7 +995,7 @@ def _test_simple_get_index(env):
         },
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "requirements.txt": """
 simple==0.0.1 \
@@ -1243,7 +1243,7 @@ def _test_optimum_sys_platform_extra(env):
             env,
         )
         builder.pip_parse(
-            _mock_mctx(
+            mocks.mctx(
                 read = lambda x: {
                     "universal.txt": """\
 optimum[onnxruntime]==1.17.1 ; sys_platform == 'darwin'
@@ -1311,7 +1311,7 @@ def _test_pipstar_platforms(env):
         ),
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             read = lambda x: {
                 "universal.txt": """\
 optimum[onnxruntime]==1.17.1 ; sys_platform == 'darwin'
@@ -1397,7 +1397,7 @@ def _test_pipstar_platforms_limit(env):
         ),
     )
     builder.pip_parse(
-        _mock_mctx(
+        mocks.mctx(
             os_name = "linux",
             arch_name = "amd64",
             read = lambda x: {
@@ -1452,6 +1452,9 @@ def _test_err_duplicate_repos(env):
         _mock_mctx(
             os_name = "osx",
             arch_name = "aarch64",
+            read = lambda x: {
+                "requirements.txt": "foo==0.0.1",
+            }.get(getattr(x, "_path", str(x)), ""),
         ),
         _parse(
             hub_name = "pypi",
@@ -1463,6 +1466,9 @@ def _test_err_duplicate_repos(env):
         _mock_mctx(
             os_name = "osx",
             arch_name = "aarch64",
+            read = lambda x: {
+                "requirements.txt": "foo==0.0.1",
+            }.get(getattr(x, "_path", str(x)), ""),
         ),
         _parse(
             hub_name = "pypi",

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -27,15 +27,7 @@ load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
-def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, mock_files = {}):
-    # Because mocks.mctx no longer accepts read lambda directly, we rely on mock_files.
-    # We will populate mock_files if read is not passed.
-    # Wait, earlier I reverted `mocks.mctx` to NOT accept read/download/report_progress args.
-    # Ah, let's just make it use mock_files appropriately.
-    # For tests that pass read=, they're already failing, I should just fix how they call it!
-    # Ah! I see the issue. `test_err_duplicate_repos` is trying to pass `mock_files=` to `_mock_mctx`.
-    # Let's just pass `mock_files=mock_files` down to `mocks.mctx`.
-
+def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, mock_files = None):
     return mocks.mctx(
         os_name = os_name,
         arch_name = arch_name,

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -23,12 +23,12 @@ load("//python/private/pypi:platform.bzl", _plat = "platform")  # buildifier: di
 load("//python/private/pypi:simpleapi_download.bzl", "simpleapi_download")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:whl_config_setting.bzl", "whl_config_setting")  # buildifier: disable=bzl-visibility
 load("//tests/pypi/extension:pip_parse.bzl", _parse = "pip_parse")
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
 def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
-    return mock_mctx(
+    return mocks.mctx(
         os_name = os_name,
         arch_name = arch_name,
         environ = environ,

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -28,6 +28,7 @@ load("//tests/support/mocks:mocks.bzl", "mocks")
 _tests = []
 
 def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None, mock_files = {}):
+    _ = read  # @unused
     # Because mocks.mctx no longer accepts read lambda directly, we rely on mock_files.
     # We will populate mock_files if read is not passed.
     # Wait, earlier I reverted `mocks.mctx` to NOT accept read/download/report_progress args.
@@ -44,7 +45,7 @@ def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = 
             "requirements.txt": """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
-    --hash=sha256:deadbaaf"""
+    --hash=sha256:deadbaaf""",
         },
     )
 
@@ -1496,11 +1497,11 @@ def _test_err_duplicate_repos(env):
     env.expect.that_dict(logs).keys().contains_exactly(["rules_python:unit-test FAIL:"])
     env.expect.that_collection(logs["rules_python:unit-test FAIL:"]).contains_exactly([
         """\
-Attempting to create a duplicate library pypi_315_simple for simple with different arguments. Already existing declaration has:
+Attempting to create a duplicate library pypi_315_foo for foo with different arguments. Already existing declaration has:
     common: {
         "dep_template": "@pypi//{name}:{target}",
         "config_load": "@pypi//:config.bzl",
-        "requirement": "simple==0.0.1 --hash=sha256:deadbeef --hash=sha256:deadbaaf",
+        "requirement": "foo==0.0.1",
     }
     different: {
         "python_interpreter_target": ("unit_test_interpreter_target_1", "unit_test_interpreter_target_2"),

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -27,8 +27,7 @@ load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
-def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None, mock_files = {}):
-    _ = read  # @unused
+def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, mock_files = {}):
     # Because mocks.mctx no longer accepts read lambda directly, we rely on mock_files.
     # We will populate mock_files if read is not passed.
     # Wait, earlier I reverted `mocks.mctx` to NOT accept read/download/report_progress args.

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -27,15 +27,25 @@ load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
-def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
+def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None, mock_files = {}):
+    # Because mocks.mctx no longer accepts read lambda directly, we rely on mock_files.
+    # We will populate mock_files if read is not passed.
+    # Wait, earlier I reverted `mocks.mctx` to NOT accept read/download/report_progress args.
+    # Ah, let's just make it use mock_files appropriately.
+    # For tests that pass read=, they're already failing, I should just fix how they call it!
+    # Ah! I see the issue. `test_err_duplicate_repos` is trying to pass `mock_files=` to `_mock_mctx`.
+    # Let's just pass `mock_files=mock_files` down to `mocks.mctx`.
+
     return mocks.mctx(
         os_name = os_name,
         arch_name = arch_name,
         environ = environ,
-        read = read or (lambda _: """\
+        mock_files = mock_files or {
+            "requirements.txt": """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
-    --hash=sha256:deadbaaf"""),
+    --hash=sha256:deadbaaf"""
+        },
     )
 
 def hub_builder(

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -23,21 +23,19 @@ load("//python/private/pypi:platform.bzl", _plat = "platform")  # buildifier: di
 load("//python/private/pypi:simpleapi_download.bzl", "simpleapi_download")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:whl_config_setting.bzl", "whl_config_setting")  # buildifier: disable=bzl-visibility
 load("//tests/pypi/extension:pip_parse.bzl", _parse = "pip_parse")
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 
 _tests = []
 
 def _mock_mctx(os_name = "unittest", arch_name = "exotic", environ = {}, read = None):
-    return struct(
-        getenv = environ.get,
-        os = struct(
-            name = os_name,
-            arch = arch_name,
-        ),
+    return mock_mctx(
+        os_name = os_name,
+        arch_name = arch_name,
+        environ = environ,
         read = read or (lambda _: """\
 simple==0.0.1 \
     --hash=sha256:deadbeef \
     --hash=sha256:deadbaaf"""),
-        report_progress = lambda _: None,
     )
 
 def hub_builder(

--- a/tests/pypi/parse_requirements/parse_requirements_tests.bzl
+++ b/tests/pypi/parse_requirements/parse_requirements_tests.bzl
@@ -19,7 +19,7 @@ load("//python/private:repo_utils.bzl", "REPO_DEBUG_ENV_VAR", "REPO_VERBOSITY_EN
 load("//python/private/pypi:evaluate_markers.bzl", "evaluate_markers")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:parse_requirements.bzl", "select_requirement", _parse_requirements = "parse_requirements")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:pep508_env.bzl", pep508_env = "env")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 def _mock_ctx():
     testdata = {
@@ -98,7 +98,7 @@ bar==0.0.1 --hash=sha256:deadb00f
 """,
     }
 
-    return mock_mctx(
+    return mocks.mctx(
         os_name = "linux",
         arch_name = "x86_64",
         read = lambda x: testdata[x],

--- a/tests/pypi/parse_requirements/parse_requirements_tests.bzl
+++ b/tests/pypi/parse_requirements/parse_requirements_tests.bzl
@@ -101,7 +101,6 @@ bar==0.0.1 --hash=sha256:deadb00f
     return mocks.mctx(
         os_name = "linux",
         arch_name = "x86_64",
-        read = lambda x: testdata[x],
         mock_files = testdata,
     )
 

--- a/tests/pypi/parse_requirements/parse_requirements_tests.bzl
+++ b/tests/pypi/parse_requirements/parse_requirements_tests.bzl
@@ -102,6 +102,7 @@ bar==0.0.1 --hash=sha256:deadb00f
         os_name = "linux",
         arch_name = "x86_64",
         read = lambda x: testdata[x],
+        mock_files = testdata,
     )
 
 _tests = []

--- a/tests/pypi/parse_requirements/parse_requirements_tests.bzl
+++ b/tests/pypi/parse_requirements/parse_requirements_tests.bzl
@@ -19,6 +19,7 @@ load("//python/private:repo_utils.bzl", "REPO_DEBUG_ENV_VAR", "REPO_VERBOSITY_EN
 load("//python/private/pypi:evaluate_markers.bzl", "evaluate_markers")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:parse_requirements.bzl", "select_requirement", _parse_requirements = "parse_requirements")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:pep508_env.bzl", pep508_env = "env")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 
 def _mock_ctx():
     testdata = {
@@ -97,11 +98,9 @@ bar==0.0.1 --hash=sha256:deadb00f
 """,
     }
 
-    return struct(
-        os = struct(
-            name = "linux",
-            arch = "x86_64",
-        ),
+    return mock_mctx(
+        os_name = "linux",
+        arch_name = "x86_64",
         read = lambda x: testdata[x],
     )
 

--- a/tests/pypi/pypi_cache/pypi_cache_tests.bzl
+++ b/tests/pypi/pypi_cache/pypi_cache_tests.bzl
@@ -3,7 +3,7 @@
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "subjects")
 load("//python/private/pypi:pypi_cache.bzl", "pypi_cache")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
@@ -86,7 +86,7 @@ _tests.append(_test_memory_cache_hit)
 
 def _test_pypi_cache_writes_to_facts(env):
     """Verifies that setting a value in the cache also populates the facts store."""
-    mock_ctx = mock_mctx(facts = {})
+    mock_ctx = mocks.mctx(facts = {})
     cache = _cache(env, mctx = mock_ctx)
 
     fake_result = struct(
@@ -193,7 +193,7 @@ _tests.append(_test_pypi_cache_writes_to_facts)
 
 def _test_pypi_cache_reads_from_facts(env):
     """Verifies that setting a value in the cache also populates the facts store."""
-    mock_ctx = mock_mctx(facts = {
+    mock_ctx = mocks.mctx(facts = {
         "dist_hashes": {
             # We are not using the real index URL, because we may have credentials in here
             "https://{PYPI_INDEX_URL}": {

--- a/tests/pypi/pypi_cache/pypi_cache_tests.bzl
+++ b/tests/pypi/pypi_cache/pypi_cache_tests.bzl
@@ -3,6 +3,7 @@
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "subjects")
 load("//python/private/pypi:pypi_cache.bzl", "pypi_cache")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 
 _tests = []
 
@@ -85,7 +86,7 @@ _tests.append(_test_memory_cache_hit)
 
 def _test_pypi_cache_writes_to_facts(env):
     """Verifies that setting a value in the cache also populates the facts store."""
-    mock_ctx = struct(facts = {})
+    mock_ctx = mock_mctx(facts = {})
     cache = _cache(env, mctx = mock_ctx)
 
     fake_result = struct(
@@ -192,7 +193,7 @@ _tests.append(_test_pypi_cache_writes_to_facts)
 
 def _test_pypi_cache_reads_from_facts(env):
     """Verifies that setting a value in the cache also populates the facts store."""
-    mock_ctx = struct(facts = {
+    mock_ctx = mock_mctx(facts = {
         "dist_hashes": {
             # We are not using the real index URL, because we may have credentials in here
             "https://{PYPI_INDEX_URL}": {

--- a/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
+++ b/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
@@ -17,6 +17,7 @@
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python/private/pypi:pypi_cache.bzl", "pypi_cache")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:simpleapi_download.bzl", "simpleapi_download")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 
 _tests = []
 
@@ -48,10 +49,7 @@ def _test_simple(env):
         )
 
     contents = simpleapi_download(
-        ctx = struct(
-            getenv = {}.get,
-            report_progress = lambda _: None,
-        ),
+        ctx = mock_mctx(),
         attr = struct(
             index_url_overrides = {},
             index_url = "https://main.com",
@@ -123,10 +121,7 @@ def _test_index_overrides(env):
         )
 
     contents = simpleapi_download(
-        ctx = struct(
-            getenv = {}.get,
-            report_progress = lambda _: None,
-        ),
+        ctx = mock_mctx(),
         attr = struct(
             index_url_overrides = {
                 "foo": "https://extra.com",

--- a/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
+++ b/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
@@ -17,7 +17,7 @@
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python/private/pypi:pypi_cache.bzl", "pypi_cache")  # buildifier: disable=bzl-visibility
 load("//python/private/pypi:simpleapi_download.bzl", "simpleapi_download")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
@@ -49,7 +49,7 @@ def _test_simple(env):
         )
 
     contents = simpleapi_download(
-        ctx = mock_mctx(),
+        ctx = mocks.mctx(),
         attr = struct(
             index_url_overrides = {},
             index_url = "https://main.com",
@@ -121,7 +121,7 @@ def _test_index_overrides(env):
         )
 
     contents = simpleapi_download(
-        ctx = mock_mctx(),
+        ctx = mocks.mctx(),
         attr = struct(
             index_url_overrides = {
                 "foo": "https://extra.com",

--- a/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
+++ b/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
@@ -20,6 +20,7 @@ load(
     "whl_library_targets",
     "whl_library_targets_from_requires",
 )  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_glob", "mock_glob_call")
 
 _tests = []
 
@@ -191,11 +192,11 @@ def _test_whl_and_library_deps_from_requires(env):
     py_library_calls = []
     env_marker_setting_calls = []
 
-    mock_glob = _mock_glob()
+    m_glob = mock_glob()
 
-    mock_glob.results.append(["site-packages/foo/SRCS.py"])
-    mock_glob.results.append(["site-packages/foo/DATA.txt"])
-    mock_glob.results.append(["site-packages/foo/PYI.pyi"])
+    m_glob.results.append(["site-packages/foo/SRCS.py"])
+    m_glob.results.append(["site-packages/foo/DATA.txt"])
+    m_glob.results.append(["site-packages/foo/PYI.pyi"])
 
     whl_library_targets_from_requires(
         name = "foo-0-py3-none-any.whl",
@@ -215,7 +216,7 @@ def _test_whl_and_library_deps_from_requires(env):
         native = struct(
             filegroup = lambda **kwargs: filegroup_calls.append(kwargs),
             config_setting = lambda **_: None,
-            glob = mock_glob.glob,
+            glob = m_glob.glob,
         ),
         rules = struct(
             py_library = lambda **kwargs: py_library_calls.append(kwargs),
@@ -263,15 +264,15 @@ def _test_whl_and_library_deps_from_requires(env):
         }),
     })  # buildifier: @unsorted-dict-items
 
-    env.expect.that_collection(mock_glob.calls).contains_exactly([
+    env.expect.that_collection(m_glob.calls).contains_exactly([
         # srcs call
-        _glob_call(
+        mock_glob_call(
             ["site-packages/**/*.py"],
             exclude = [],
             allow_empty = True,
         ),
         # data call
-        _glob_call(
+        mock_glob_call(
             ["site-packages/**/*"],
             exclude = [
                 "**/*.py",
@@ -282,7 +283,7 @@ def _test_whl_and_library_deps_from_requires(env):
             allow_empty = True,
         ),
         # pyi call
-        _glob_call(["site-packages/**/*.pyi"], allow_empty = True),
+        mock_glob_call(["site-packages/**/*.pyi"], allow_empty = True),
     ])
 
     env.expect.that_collection(env_marker_setting_calls).contains_exactly([
@@ -298,10 +299,10 @@ _tests.append(_test_whl_and_library_deps_from_requires)
 def _test_whl_and_library_deps(env):
     filegroup_calls = []
     py_library_calls = []
-    mock_glob = _mock_glob()
-    mock_glob.results.append(["site-packages/foo/SRCS.py"])
-    mock_glob.results.append(["site-packages/foo/DATA.txt"])
-    mock_glob.results.append(["site-packages/foo/PYI.pyi"])
+    m_glob = mock_glob()
+    m_glob.results.append(["site-packages/foo/SRCS.py"])
+    m_glob.results.append(["site-packages/foo/DATA.txt"])
+    m_glob.results.append(["site-packages/foo/PYI.pyi"])
 
     whl_library_targets(
         name = "foo.whl",
@@ -323,7 +324,7 @@ def _test_whl_and_library_deps(env):
         native = struct(
             filegroup = lambda **kwargs: filegroup_calls.append(kwargs),
             config_setting = lambda **_: None,
-            glob = mock_glob.glob,
+            glob = m_glob.glob,
         ),
         rules = struct(
             py_library = lambda **kwargs: py_library_calls.append(kwargs),
@@ -396,10 +397,10 @@ def _test_group(env):
     alias_calls = []
     py_library_calls = []
 
-    mock_glob = _mock_glob()
-    mock_glob.results.append(["site-packages/foo/srcs.py"])
-    mock_glob.results.append(["site-packages/foo/data.txt"])
-    mock_glob.results.append(["site-packages/foo/pyi.pyi"])
+    m_glob = mock_glob()
+    m_glob.results.append(["site-packages/foo/srcs.py"])
+    m_glob.results.append(["site-packages/foo/data.txt"])
+    m_glob.results.append(["site-packages/foo/pyi.pyi"])
 
     whl_library_targets(
         name = "foo.whl",
@@ -419,7 +420,7 @@ def _test_group(env):
         filegroups = {},
         native = struct(
             config_setting = lambda **_: None,
-            glob = mock_glob.glob,
+            glob = m_glob.glob,
             alias = lambda **kwargs: alias_calls.append(kwargs),
         ),
         rules = struct(
@@ -463,42 +464,18 @@ def _test_group(env):
         }),
     })  # buildifier: @unsorted-dict-items
 
-    env.expect.that_collection(mock_glob.calls, expr = "glob calls").contains_exactly([
-        _glob_call(["site-packages/**/*.py"], exclude = [], allow_empty = True),
-        _glob_call(["site-packages/**/*"], exclude = [
+    env.expect.that_collection(m_glob.calls, expr = "glob calls").contains_exactly([
+        mock_glob_call(["site-packages/**/*.py"], exclude = [], allow_empty = True),
+        mock_glob_call(["site-packages/**/*"], exclude = [
             "**/*.py",
             "**/*.pyc",
             "**/*.pyc.*",
             "**/*.dist-info/RECORD",
         ], allow_empty = True),
-        _glob_call(["site-packages/**/*.pyi"], allow_empty = True),
+        mock_glob_call(["site-packages/**/*.pyi"], allow_empty = True),
     ])
 
 _tests.append(_test_group)
-
-def _glob_call(*args, **kwargs):
-    return struct(
-        glob = args,
-        kwargs = kwargs,
-    )
-
-def _mock_glob():
-    # buildifier: disable=uninitialized
-    def glob(*args, **kwargs):
-        mock.calls.append(_glob_call(*args, **kwargs))
-        if not mock.results:
-            fail("Mock glob missing for invocation: args={} kwargs={}".format(
-                args,
-                kwargs,
-            ))
-        return mock.results.pop(0)
-
-    mock = struct(
-        calls = [],
-        results = [],
-        glob = glob,
-    )
-    return mock
 
 def whl_library_targets_test_suite(name):
     """create the test suite.

--- a/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
+++ b/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
@@ -20,7 +20,7 @@ load(
     "whl_library_targets",
     "whl_library_targets_from_requires",
 )  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_glob", "mock_glob_call")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
@@ -192,7 +192,7 @@ def _test_whl_and_library_deps_from_requires(env):
     py_library_calls = []
     env_marker_setting_calls = []
 
-    m_glob = mock_glob()
+    m_glob = mocks.glob()
 
     m_glob.results.append(["site-packages/foo/SRCS.py"])
     m_glob.results.append(["site-packages/foo/DATA.txt"])
@@ -266,13 +266,13 @@ def _test_whl_and_library_deps_from_requires(env):
 
     env.expect.that_collection(m_glob.calls).contains_exactly([
         # srcs call
-        mock_glob_call(
+        mocks.glob_call(
             ["site-packages/**/*.py"],
             exclude = [],
             allow_empty = True,
         ),
         # data call
-        mock_glob_call(
+        mocks.glob_call(
             ["site-packages/**/*"],
             exclude = [
                 "**/*.py",
@@ -283,7 +283,7 @@ def _test_whl_and_library_deps_from_requires(env):
             allow_empty = True,
         ),
         # pyi call
-        mock_glob_call(["site-packages/**/*.pyi"], allow_empty = True),
+        mocks.glob_call(["site-packages/**/*.pyi"], allow_empty = True),
     ])
 
     env.expect.that_collection(env_marker_setting_calls).contains_exactly([
@@ -299,7 +299,7 @@ _tests.append(_test_whl_and_library_deps_from_requires)
 def _test_whl_and_library_deps(env):
     filegroup_calls = []
     py_library_calls = []
-    m_glob = mock_glob()
+    m_glob = mocks.glob()
     m_glob.results.append(["site-packages/foo/SRCS.py"])
     m_glob.results.append(["site-packages/foo/DATA.txt"])
     m_glob.results.append(["site-packages/foo/PYI.pyi"])
@@ -397,7 +397,7 @@ def _test_group(env):
     alias_calls = []
     py_library_calls = []
 
-    m_glob = mock_glob()
+    m_glob = mocks.glob()
     m_glob.results.append(["site-packages/foo/srcs.py"])
     m_glob.results.append(["site-packages/foo/data.txt"])
     m_glob.results.append(["site-packages/foo/pyi.pyi"])
@@ -465,14 +465,14 @@ def _test_group(env):
     })  # buildifier: @unsorted-dict-items
 
     env.expect.that_collection(m_glob.calls, expr = "glob calls").contains_exactly([
-        mock_glob_call(["site-packages/**/*.py"], exclude = [], allow_empty = True),
-        mock_glob_call(["site-packages/**/*"], exclude = [
+        mocks.glob_call(["site-packages/**/*.py"], exclude = [], allow_empty = True),
+        mocks.glob_call(["site-packages/**/*"], exclude = [
             "**/*.py",
             "**/*.pyc",
             "**/*.pyc.*",
             "**/*.dist-info/RECORD",
         ], allow_empty = True),
-        mock_glob_call(["site-packages/**/*.pyi"], allow_empty = True),
+        mocks.glob_call(["site-packages/**/*.pyi"], allow_empty = True),
     ])
 
 _tests.append(_test_group)

--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -18,29 +18,9 @@ load("@pythons_hub//:versions.bzl", "MINOR_MAPPING")
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python/private:python.bzl", "parse_modules")  # buildifier: disable=bzl-visibility
 load("//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 
 _tests = []
-
-def _mock_mctx(*modules, environ = {}, mocked_files = {}):
-    return struct(
-        path = lambda x: struct(exists = x in mocked_files, _file = x),
-        read = lambda x, watch = None: mocked_files[x._file if "_file" in dir(x) else x],
-        getenv = environ.get,
-        modules = [
-            struct(
-                name = modules[0].name,
-                tags = modules[0].tags,
-                is_root = modules[0].is_root,
-            ),
-        ] + [
-            struct(
-                name = mod.name,
-                tags = mod.tags,
-                is_root = False,
-            )
-            for mod in modules[1:]
-        ],
-    )
 
 # todo: change is_root to false by default. most modules aren't root
 def _mod(*, name, defaults = [], toolchain = [], override = [], single_version_override = [], single_version_platform_override = [], is_root = False):
@@ -148,7 +128,7 @@ def _single_version_platform_override(
 def _test_default_from_rules_python_when_rules_python_is_root(env):
     """Verify that rules_python (as root module) default is applied."""
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _rules_python_module(is_root = True),
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
@@ -178,7 +158,7 @@ _tests.append(_test_default_from_rules_python_when_rules_python_is_root)
 def _test_default_from_rules_python_when_rules_python_is_not_root(env):
     """Verify that rules_python default applies when rules_python is not the root module."""
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _rules_python_module(),
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
@@ -197,9 +177,11 @@ _tests.append(_test_default_from_rules_python_when_rules_python_is_not_root)
 
 def _test_default_with_patch_version(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
-            _mod(name = "alpha", toolchain = [_toolchain("3.11.2")], is_root = True),
-            _rules_python_module(is_root = True),
+        module_ctx = mock_mctx(
+            modules = [
+                _mod(name = "alpha", toolchain = [_toolchain("3.11.2")], is_root = True),
+                _rules_python_module(is_root = True),
+            ],
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
     )
@@ -217,7 +199,7 @@ _tests.append(_test_default_with_patch_version)
 
 def _test_toolchain_ordering(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 toolchain = [
@@ -264,7 +246,7 @@ _tests.append(_test_toolchain_ordering)
 
 def _test_default_from_defaults(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.11")],
@@ -291,7 +273,7 @@ _tests.append(_test_default_from_defaults)
 
 def _test_default_from_defaults_env(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.11", python_version_env = "PYENV_VERSION")],
@@ -319,7 +301,7 @@ _tests.append(_test_default_from_defaults_env)
 
 def _test_default_from_defaults_file(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version_file = "@@//:.python-version")],
@@ -347,7 +329,7 @@ _tests.append(_test_default_from_defaults_file)
 
 def _test_default_from_single_toolchain(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 toolchain = [_toolchain("3.12")],
@@ -363,7 +345,7 @@ _tests.append(_test_default_from_single_toolchain)
 
 def _test_defaults_overrides_single_toolchain(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [
@@ -383,7 +365,7 @@ _tests.append(_test_defaults_overrides_single_toolchain)
 
 def _test_defaults_overrides_toolchains_setting_is_default(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.13")],
@@ -403,10 +385,12 @@ _tests.append(_test_defaults_overrides_toolchains_setting_is_default)
 
 def _test_first_occurance_of_the_toolchain_wins(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
-            _mod(name = "my_module", is_root = True, toolchain = [_toolchain("3.12")]),
-            _mod(name = "some_module", toolchain = [_toolchain("3.12", configure_coverage_tool = True)]),
-            _rules_python_module(),
+        module_ctx = mock_mctx(
+            modules = [
+                _mod(name = "my_module", is_root = True, toolchain = [_toolchain("3.12")]),
+                _mod(name = "some_module", toolchain = [_toolchain("3.12", configure_coverage_tool = True)]),
+                _rules_python_module(),
+            ],
             environ = {
                 "RULES_PYTHON_BZLMOD_DEBUG": "1",
             },
@@ -444,7 +428,7 @@ _tests.append(_test_first_occurance_of_the_toolchain_wins)
 
 def _test_auth_overrides(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 toolchain = [_toolchain("3.12")],
@@ -486,7 +470,7 @@ _tests.append(_test_auth_overrides)
 
 def _test_add_new_version(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -567,7 +551,7 @@ _tests.append(_test_add_new_version)
 
 def _test_register_all_versions(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -633,7 +617,7 @@ _tests.append(_test_register_all_versions)
 
 def _test_ignore_unsupported_versions(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -704,7 +688,7 @@ _tests.append(_test_ignore_unsupported_versions)
 
 def _test_add_patches(env):
     py = parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -783,7 +767,7 @@ _tests.append(_test_add_patches)
 def _test_fail_two_overrides(env):
     errors = []
     parse_modules(
-        module_ctx = _mock_mctx(
+        module_ctx = mock_mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -815,7 +799,7 @@ def _test_single_version_override_errors(env):
     ]:
         errors = []
         parse_modules(
-            module_ctx = _mock_mctx(
+            module_ctx = mock_mctx(
                 _mod(
                     name = "my_module",
                     is_root = True,
@@ -854,7 +838,7 @@ def _test_single_version_platform_override_errors(env):
     ]:
         errors = []
         parse_modules(
-            module_ctx = _mock_mctx(
+            module_ctx = mock_mctx(
                 _mod(
                     name = "my_module",
                     toolchain = [_toolchain("3.13")],

--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -18,7 +18,7 @@ load("@pythons_hub//:versions.bzl", "MINOR_MAPPING")
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python/private:python.bzl", "parse_modules")  # buildifier: disable=bzl-visibility
 load("//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
@@ -128,7 +128,7 @@ def _single_version_platform_override(
 def _test_default_from_rules_python_when_rules_python_is_root(env):
     """Verify that rules_python (as root module) default is applied."""
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _rules_python_module(is_root = True),
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
@@ -158,7 +158,7 @@ _tests.append(_test_default_from_rules_python_when_rules_python_is_root)
 def _test_default_from_rules_python_when_rules_python_is_not_root(env):
     """Verify that rules_python default applies when rules_python is not the root module."""
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _rules_python_module(),
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
@@ -177,7 +177,7 @@ _tests.append(_test_default_from_rules_python_when_rules_python_is_not_root)
 
 def _test_default_with_patch_version(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             modules = [
                 _mod(name = "alpha", toolchain = [_toolchain("3.11.2")], is_root = True),
                 _rules_python_module(is_root = True),
@@ -199,7 +199,7 @@ _tests.append(_test_default_with_patch_version)
 
 def _test_toolchain_ordering(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 toolchain = [
@@ -246,7 +246,7 @@ _tests.append(_test_toolchain_ordering)
 
 def _test_default_from_defaults(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.11")],
@@ -273,7 +273,7 @@ _tests.append(_test_default_from_defaults)
 
 def _test_default_from_defaults_env(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.11", python_version_env = "PYENV_VERSION")],
@@ -301,7 +301,7 @@ _tests.append(_test_default_from_defaults_env)
 
 def _test_default_from_defaults_file(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version_file = "@@//:.python-version")],
@@ -329,7 +329,7 @@ _tests.append(_test_default_from_defaults_file)
 
 def _test_default_from_single_toolchain(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 toolchain = [_toolchain("3.12")],
@@ -345,7 +345,7 @@ _tests.append(_test_default_from_single_toolchain)
 
 def _test_defaults_overrides_single_toolchain(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [
@@ -365,7 +365,7 @@ _tests.append(_test_defaults_overrides_single_toolchain)
 
 def _test_defaults_overrides_toolchains_setting_is_default(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_root_module",
                 defaults = [_defaults(python_version = "3.13")],
@@ -385,7 +385,7 @@ _tests.append(_test_defaults_overrides_toolchains_setting_is_default)
 
 def _test_first_occurance_of_the_toolchain_wins(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             modules = [
                 _mod(name = "my_module", is_root = True, toolchain = [_toolchain("3.12")]),
                 _mod(name = "some_module", toolchain = [_toolchain("3.12", configure_coverage_tool = True)]),
@@ -428,7 +428,7 @@ _tests.append(_test_first_occurance_of_the_toolchain_wins)
 
 def _test_auth_overrides(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 toolchain = [_toolchain("3.12")],
@@ -470,7 +470,7 @@ _tests.append(_test_auth_overrides)
 
 def _test_add_new_version(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -551,7 +551,7 @@ _tests.append(_test_add_new_version)
 
 def _test_register_all_versions(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -617,7 +617,7 @@ _tests.append(_test_register_all_versions)
 
 def _test_ignore_unsupported_versions(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -688,7 +688,7 @@ _tests.append(_test_ignore_unsupported_versions)
 
 def _test_add_patches(env):
     py = parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -767,7 +767,7 @@ _tests.append(_test_add_patches)
 def _test_fail_two_overrides(env):
     errors = []
     parse_modules(
-        module_ctx = mock_mctx(
+        module_ctx = mocks.mctx(
             _mod(
                 name = "my_module",
                 is_root = True,
@@ -799,7 +799,7 @@ def _test_single_version_override_errors(env):
     ]:
         errors = []
         parse_modules(
-            module_ctx = mock_mctx(
+            module_ctx = mocks.mctx(
                 _mod(
                     name = "my_module",
                     is_root = True,
@@ -838,7 +838,7 @@ def _test_single_version_platform_override_errors(env):
     ]:
         errors = []
         parse_modules(
-            module_ctx = mock_mctx(
+            module_ctx = mocks.mctx(
                 _mod(
                     name = "my_module",
                     toolchain = [_toolchain("3.13")],

--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -22,7 +22,6 @@ load("//tests/support/mocks:mocks.bzl", "mocks")
 
 _tests = []
 
-# todo: change is_root to false by default. most modules aren't root
 def _mod(*, name, defaults = [], toolchain = [], override = [], single_version_override = [], single_version_platform_override = [], is_root = False):
     return mocks.module(
         name,

--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -24,16 +24,14 @@ _tests = []
 
 # todo: change is_root to false by default. most modules aren't root
 def _mod(*, name, defaults = [], toolchain = [], override = [], single_version_override = [], single_version_platform_override = [], is_root = False):
-    return struct(
-        name = name,
-        tags = struct(
-            defaults = defaults,
-            toolchain = toolchain,
-            override = override,
-            single_version_override = single_version_override,
-            single_version_platform_override = single_version_platform_override,
-        ),
+    return mocks.module(
+        name,
         is_root = is_root,
+        defaults = defaults,
+        toolchain = toolchain,
+        override = override,
+        single_version_override = single_version_override,
+        single_version_platform_override = single_version_platform_override,
     )
 
 def _defaults(python_version = None, python_version_env = None, python_version_file = None):
@@ -180,7 +178,7 @@ def _test_default_with_patch_version(env):
         module_ctx = mocks.mctx(
             modules = [
                 _mod(name = "alpha", toolchain = [_toolchain("3.11.2")], is_root = True),
-                _rules_python_module(is_root = True),
+                _rules_python_module(is_root = False),
             ],
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
@@ -308,7 +306,7 @@ def _test_default_from_defaults_file(env):
                 toolchain = [_toolchain("3.10"), _toolchain("3.11"), _toolchain("3.12")],
                 is_root = True,
             ),
-            mocked_files = {"@@//:.python-version": "3.12\n"},
+            mock_files = {"@@//:.python-version": "3.12\n"},
         ),
         logger = repo_utils.logger(verbosity_level = 0, name = "python"),
     )

--- a/tests/support/mocks/BUILD.bazel
+++ b/tests/support/mocks/BUILD.bazel
@@ -1,5 +1,13 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":mocks_tests.bzl", "mocks_test_suite")
+
 package(
     default_visibility = ["//:__subpackages__"],
 )
 
-exports_files(["mocks.bzl"])
+bzl_library(
+    name = "mocks_bzl",
+    srcs = ["mocks.bzl"],
+)
+
+mocks_test_suite(name = "mocks_tests")

--- a/tests/support/mocks/BUILD.bazel
+++ b/tests/support/mocks/BUILD.bazel
@@ -1,0 +1,5 @@
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
+exports_files(["mocks.bzl"])

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -112,6 +112,20 @@ def _mctx_read(self, x, watch = None):
 def _mctx_path(self, x):
     return _path_new(str(x), self.mock_files)
 
+def _get_download_file_name(url, output = ""):
+    """Compute the download file name.
+
+    Args:
+        url: {type}`string` The URL being downloaded.
+        output: {type}`string` The explicit output path, if any.
+
+    Returns:
+        {type}`string` The file name.
+    """
+    if output:
+        return str(output)
+    return str(url).split("?")[0].split("/")[-1]
+
 def _mctx_download(
         self,
         url,
@@ -144,7 +158,7 @@ def _mctx_download(
 
         if content != None:
             if type(content) == "string":
-                out = str(output) if output else u.split("/")[-1]
+                out = _get_download_file_name(u, output)
                 self.mock_files[out] = content
                 return struct(
                     success = True,
@@ -239,21 +253,13 @@ def _mctx_new(
             arch = arch_name,
         ),
         modules = list(modules),
-    )
-    return struct(
-        mock_files = self.mock_files,
-        mock_downloads = self.mock_downloads,
-        report_progress_calls = self.report_progress_calls,
-        getenv = self.getenv,
-        facts = self.facts,
-        os = self.os,
-        modules = self.modules,
         path = lambda *a, **k: _mctx_path(self, *a, **k),
         read = lambda *a, **k: _mctx_read(self, *a, **k),
         download = lambda *a, **k: _mctx_download(self, *a, **k),
         report_progress = lambda *a, **k: _mctx_report_progress(self, *a, **k),
         add_module = lambda **k: _mctx_add_module(self, **k),
     )
+    return self
 
 def _rctx_read(self, x):
     path_str = x._path if hasattr(x, "_path") else str(x)
@@ -330,8 +336,8 @@ def _rctx_download(
         if u in self.mock_downloads:
             res = self.mock_downloads[u]
             if type(res) == "string":
-                if output:
-                    self.mock_files[str(output)] = res
+                out = _get_download_file_name(u, output)
+                self.mock_files[out] = res
                 return struct(success = True, sha256 = "mocksha256")
             else:
                 return res(
@@ -351,6 +357,26 @@ def _rctx_download(
         fail("Download not mocked for url: " + str(urls))
     return struct(success = False)
 
+def _rctx_extract(
+        self,
+        archive,
+        output = "",
+        stripPrefix = "",
+        rename_files = {},
+        *,
+        watch_archive = "auto"):
+    _ = (
+        stripPrefix,
+        rename_files,
+        watch_archive,
+    )  # @unused
+
+    archive_str = str(archive)
+    if archive_str in self.mock_extracts:
+        for f, c in self.mock_extracts[archive_str].items():
+            out_path = "{}/{}".format(output, f) if output else str(f)
+            self.mock_files[out_path] = c
+
 def _rctx_download_and_extract(
         self,
         url,
@@ -364,44 +390,34 @@ def _rctx_download_and_extract(
         headers = {},
         integrity = "",
         rename_files = {}):
-    _ = (
-        sha256,
-        type,
-        stripPrefix,
-        allow_fail,
-        canonical_id,
-        auth,
-        headers,
-        integrity,
-        rename_files,
-    )  # @unused
+    _ = type  # @unused
+
+    res = self.download(
+        url = url,
+        output = "",
+        sha256 = sha256,
+        allow_fail = allow_fail,
+        canonical_id = canonical_id,
+        auth = auth,
+        headers = headers,
+        integrity = integrity,
+    )
+    if not res.success:
+        return res
 
     urls = url if type(url) == "list" else [url]
-
     for u in urls:
-        if u in self.mock_downloads:
-            res = self.mock_downloads[u]
-            if type(res) == "string":
-                pass
-            else:
-                return res(
-                    self,
-                    u,
-                    output,
-                    sha256,
-                    type,
-                    stripPrefix,
-                    allow_fail,
-                    canonical_id,
-                    auth,
-                    headers,
-                    integrity,
-                    rename_files,
-                )
+        downloaded_file = _get_download_file_name(u)
+        if downloaded_file in self.mock_extracts:
+            self.extract(
+                archive = downloaded_file,
+                output = output,
+                stripPrefix = stripPrefix,
+                rename_files = rename_files,
+            )
+            break
 
-    if not allow_fail:
-        fail("Download and extract not mocked for url: " + str(urls))
-    return struct(success = False)
+    return res
 
 def _rctx_execute(
         self,
@@ -431,6 +447,7 @@ def _rctx_new(
         mock_files = None,
         mock_which = None,
         mock_downloads = None,
+        mock_extracts = None,
         os_name = "linux",
         arch_name = "x86_64"):
     """Create a mock repository_ctx object.
@@ -444,6 +461,8 @@ def _rctx_new(
             name to path string.
         mock_downloads: {type}`dict[string, string|callable]` Dict mapping
             url to string or callable.
+        mock_extracts: {type}`dict[string, dict[string, string]]` Dict mapping
+            downloaded filename to a dict of extracted filename to content.
         os_name: {type}`string` The OS name.
         arch_name: {type}`string` The architecture name.
 
@@ -455,12 +474,14 @@ def _rctx_new(
     mock_files = mock_files or {}
     mock_which = mock_which or {}
     mock_downloads = mock_downloads or {}
+    mock_extracts = mock_extracts or {}
 
     # buildifier: disable=uninitialized
     self = struct(
         mock_files = mock_files,
         mock_which = mock_which,
         mock_downloads = mock_downloads,
+        mock_extracts = mock_extracts,
         attr = struct(**attr),
         os = struct(
             name = os_name,
@@ -473,6 +494,7 @@ def _rctx_new(
         template = lambda *a, **k: _rctx_template(self, *a, **k),
         which = lambda *a, **k: _rctx_which(self, *a, **k),
         download = lambda *a, **k: _rctx_download(self, *a, **k),
+        extract = lambda *a, **k: _rctx_extract(self, *a, **k),
         download_and_extract = lambda *a, **k: _rctx_download_and_extract(
             self,
             *a,

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -33,6 +33,7 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
     if owner == None:
         owner = Label("//:mock")
 
+    # In modern bazel, stringified labels can look like `@@//:mock` or `@foo//:mock`
     owner_str = str(owner)
     repo_name = owner_str.split("//")[0]
 
@@ -42,7 +43,6 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
         for _ in range(2):  # Strip up to two leading @
             if repo_name.startswith("@"):
                 repo_name = repo_name[1:]
-
     actual_short_path = short_path
     if not is_main_repo:
         if not actual_short_path.startswith("../"):

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -1,0 +1,243 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mocks for repository_ctx, module_ctx, and File objects."""
+
+def mock_path(path, mocked_files = {}):
+    """Create a mock path object.
+
+    Args:
+        path: The path string.
+        mocked_files: A dict of mocked files.
+
+    Returns:
+        A struct mocking a path object.
+    """
+    return struct(
+        exists = path in mocked_files,
+        basename = path.split("/")[-1],
+        dirname = "/".join(path.split("/")[:-1]),
+        _path = path,
+    )
+
+def mock_file(path, content = ""):
+    """Create a mock File object.
+
+    Args:
+        path: The path to the file.
+        content: The content of the file.
+
+    Returns:
+        A struct mocking a File object.
+    """
+    return struct(
+        path = path,
+        basename = path.split("/")[-1],
+        dirname = "/".join(path.split("/")[:-1]),
+        extension = path.split(".")[-1] if "." in path else "",
+        is_source = True,
+        owner = Label("//:mock"),
+        short_path = path,
+    )
+
+def mock_mctx(
+        *args,
+        **kwargs):
+    """Create a mock module_ctx object.
+
+    Args:
+        *args: Mock modules passed positionally.
+        **kwargs: Optional arguments:
+            modules: List of mock modules (alternative to positional args).
+            environ: Dict of environment variables.
+            mocked_files: Dict mapping path strings to content.
+            os_name: The OS name.
+            arch_name: The architecture name.
+            read: Optional read function.
+            download: Optional download function.
+            report_progress: Optional report_progress function.
+
+    Returns:
+        A struct mocking a module_ctx object.
+    """
+    modules = kwargs.get("modules")
+    if modules == None:
+        modules = list(args)
+    elif type(modules) != "list":
+        modules = [modules]
+
+    environ = kwargs.get("environ", {})
+    mocked_files = kwargs.get("mocked_files", {})
+    os_name = kwargs.get("os_name", "linux")
+    arch_name = kwargs.get("arch_name", "x86_64")
+    read = kwargs.get("read")
+    download = kwargs.get("download")
+    report_progress = kwargs.get("report_progress")
+    facts = kwargs.get("facts")
+
+    def _read(x, watch = None):
+        _ = watch
+        path_str = x._path if hasattr(x, "_path") else str(x)
+        if path_str not in mocked_files:
+            fail("File not found in mocked_files: " + path_str)
+        return mocked_files[path_str]
+
+    def _path(x):
+        return mock_path(str(x), mocked_files)
+
+    return struct(
+        path = _path,
+        read = read or _read,
+        getenv = environ.get,
+        facts = facts,
+        os = struct(
+            name = os_name,
+            arch = arch_name,
+        ),
+        modules = [
+            struct(
+                name = modules[0].name,
+                tags = modules[0].tags,
+                is_root = getattr(modules[0], "is_root", False),
+            ),
+        ] + [
+            struct(
+                name = mod.name,
+                tags = mod.tags,
+                is_root = False,
+            )
+            for mod in modules[1:]
+        ] if modules else [],
+        download = download or (lambda *_, **__: struct(
+            success = True,
+            wait = lambda: struct(
+                success = True,
+            ),
+        )),
+        report_progress = report_progress or (lambda _: None),
+    )
+
+def mock_rctx(
+        attr = {},
+        environ = {},
+        mocked_files = {},
+        os_name = "linux",
+        arch_name = "x86_64",
+        read = None,
+        download = None,
+        download_and_extract = None,
+        execute = None,
+        file = None,
+        symlink = None,
+        template = None,
+        which = None):
+    """Create a mock repository_ctx object.
+
+    Args:
+        attr: Dict of attributes.
+        environ: Dict of environment variables.
+        mocked_files: Dict mapping path strings to content.
+        os_name: The OS name.
+        arch_name: The architecture name.
+        read: Optional read function.
+        download: Optional download function.
+        download_and_extract: Optional download_and_extract function.
+        execute: Optional execute function.
+        file: Optional file function.
+        symlink: Optional symlink function.
+        template: Optional template function.
+        which: Optional which function.
+
+    Returns:
+        A struct mocking a repository_ctx object.
+    """
+
+    def _read(x):
+        path_str = x._path if hasattr(x, "_path") else str(x)
+        if path_str not in mocked_files:
+            fail("File not found in mocked_files: " + path_str)
+        return mocked_files[path_str]
+
+    def _path(x):
+        return mock_path(str(x), mocked_files)
+
+    return struct(
+        attr = struct(**attr),
+        path = _path,
+        read = read or _read,
+        os = struct(
+            name = os_name,
+            arch = arch_name,
+        ),
+        os_environ = environ,
+        download = download,
+        download_and_extract = download_and_extract,
+        execute = execute,
+        file = file,
+        symlink = symlink,
+        template = template,
+        which = which,
+    )
+
+def mock_glob_call(*args, **kwargs):
+    """Create a struct representing a glob call.
+
+    Args:
+        *args: Positional arguments to glob.
+        **kwargs: Keyword arguments to glob.
+
+    Returns:
+        A struct with glob and kwargs fields.
+    """
+    return struct(
+        glob = args,
+        kwargs = kwargs,
+    )
+
+def mock_glob():
+    """Create a mock glob object.
+
+    Returns:
+        A struct with calls and results lists, and a glob function.
+    """
+    calls = []
+    results = []
+
+    def _glob(*args, **kwargs):
+        calls.append(mock_glob_call(*args, **kwargs))
+        if not results:
+            fail("Mock glob missing for invocation: args={} kwargs={}".format(
+                args,
+                kwargs,
+            ))
+        return results.pop(0)
+
+    return struct(
+        calls = calls,
+        results = results,
+        glob = _glob,
+    )
+
+def mock_select(value, no_match_error = None):
+    """A mock select function that returns the value.
+
+    Args:
+        value: The value to return.
+        no_match_error: Ignored.
+
+    Returns:
+        The value.
+    """
+    _ = no_match_error
+    return value

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -33,18 +33,14 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
     if owner == None:
         owner = Label("//:mock")
 
-    # In modern bazel, stringified labels can look like `@@//:mock` or `@foo//:mock`
     owner_str = str(owner)
     repo_name = owner_str.split("//")[0]
 
     is_main_repo = repo_name in ("", "@", "@@")
 
-    if not is_main_repo:
-        for _ in range(2):  # Strip up to two leading @
-            if repo_name.startswith("@"):
-                repo_name = repo_name[1:]
     actual_short_path = short_path
     if not is_main_repo:
+        repo_name = repo_name.lstrip("@")
         if not actual_short_path.startswith("../"):
             actual_short_path = "../{}/{}".format(repo_name, short_path)
 

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -215,9 +215,9 @@ def _mctx_new(
         os = self.os,
         modules = self.modules,
         path = lambda *a, **k: _mctx_path(self, *a, **k),
-        read = lambda *a, **k: _mctx_read(self, *a, **k),
-        download = lambda *a, **k: _mctx_download(self, *a, **k),
-        report_progress = lambda *a, **k: _mctx_report_progress(self, *a, **k),
+        read = read or (lambda *a, **k: _mctx_read(self, *a, **k)),
+        download = download or (lambda *a, **k: _mctx_download(self, *a, **k)),
+        report_progress = report_progress or (lambda *a, **k: _mctx_report_progress(self, *a, **k)),
         add_module = lambda *a, **k: _mctx_add_module(self, *a, **k),
     )
 

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -57,11 +57,12 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
                 path = "external/{}/{}".format(repo_name, rel_path)
             else:
                 path = "bazel-out/k9-deadbeef/bin/external/{}/{}".format(repo_name, rel_path)
-    elif path == None:
-        if is_source:
-            path = short_path
-        else:
-            path = "bazel-out/k9-deadbeef/bin/{}".format(short_path)
+    else:
+        if path == None:
+            if is_source:
+                path = short_path
+            else:
+                path = "bazel-out/k9-deadbeef/bin/{}".format(short_path)
 
     return struct(
         path = path,
@@ -95,13 +96,11 @@ def _module_new(name, *, is_root = False, **tags):
     Returns:
         {type}`MockModule` A mock module object.
     """
-    self = struct(
+    return struct(
         name = name,
         tags = struct(**tags),
         is_root = is_root,
     )
-
-    return self
 
 def _mctx_read(self, x, watch = None):
     _ = watch  # @unused
@@ -126,17 +125,18 @@ def _mctx_report_progress(self, message):
     _ = self, message  # @unused
     return None
 
-def _mctx_add_module(self, module):
+def _mctx_add_module(self, **kwargs):
     """Add a module to the mock module_ctx.
 
     Args:
         self: The mock module_ctx.
-        module: {type}`MockModule` The mock module object.
+        **kwargs: Arguments to pass to _module_new.
 
     Returns:
         {type}`MockModuleCtx` The mock module_ctx.
     """
-    if getattr(module, "is_root", False) and len(self.modules) > 0:
+    module = _module_new(**kwargs)
+    if module.is_root and len(self.modules) > 0:
         fail("is_root=True can only be set on the first module in the modules list.")
     self.modules.append(module)
     return self
@@ -178,6 +178,7 @@ def _mctx_new(
     environ = environ or {}
     mock_files = mock_files or {}
 
+    # buildifier: disable=uninitialized
     self = struct(
         mock_files = mock_files,
         getenv = environ.get,
@@ -198,7 +199,7 @@ def _mctx_new(
         read = read or (lambda *a, **k: _mctx_read(self, *a, **k)),
         download = download or (lambda *a, **k: _mctx_download(self, *a, **k)),
         report_progress = report_progress or (lambda *a, **k: _mctx_report_progress(self, *a, **k)),
-        add_module = lambda *a, **k: _mctx_add_module(self, *a, **k),
+        add_module = lambda **k: _mctx_add_module(self, **k),
     )
 
 def _rctx_read(self, x):
@@ -306,6 +307,7 @@ def _rctx_new(
     mock_which = mock_which or {}
     mock_downloads = mock_downloads or {}
 
+    # buildifier: disable=uninitialized
     self = struct(
         mock_files = mock_files,
         mock_which = mock_which,
@@ -316,15 +318,6 @@ def _rctx_new(
             arch = arch_name,
         ),
         os_environ = environ,
-    )
-
-    return struct(
-        mock_files = self.mock_files,
-        mock_which = self.mock_which,
-        mock_downloads = self.mock_downloads,
-        attr = self.attr,
-        os = self.os,
-        os_environ = self.os_environ,
         path = lambda *a, **k: _rctx_path(self, *a, **k),
         read = lambda *a, **k: _rctx_read(self, *a, **k),
         file = lambda *a, **k: _rctx_file(self, *a, **k),
@@ -335,6 +328,8 @@ def _rctx_new(
         execute = lambda *a, **k: _rctx_execute(self, *a, **k),
         symlink = lambda *a, **k: _rctx_symlink(self, *a, **k),
     )
+
+    return self
 
 def _glob_call_new(*args, **kwargs):
     """Create a struct representing a glob call.

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -220,7 +220,21 @@ def _rctx_read(self, x):
     path_str = x._path if hasattr(x, "_path") else str(x)
     if path_str not in self.mock_files:
         fail("File not found in mock_files: " + path_str)
-    return self.mock_files[path_str]
+        
+    val = self.mock_files[path_str]
+    for _ in range(10):
+        if type(val) == "dict" and val.get("type") == "symlink":
+            path_str = val["target"]
+            if path_str not in self.mock_files:
+                fail("Symlink target not found in mock_files: " + path_str)
+            val = self.mock_files[path_str]
+        else:
+            break
+
+    if type(val) == "dict" and val.get("type") == "symlink":
+        fail("Too many symlinks followed")
+
+    return val
 
 def _rctx_path(self, x):
     return _path_new(str(x), self.mock_files)

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -1,222 +1,387 @@
-# Copyright 2024 The Bazel Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Mocks for repository_ctx, module_ctx, and File objects."""
 
-def mock_path(path, mocked_files = {}):
+def _path_new(path, mock_files = None):
     """Create a mock path object.
 
     Args:
-        path: The path string.
-        mocked_files: A dict of mocked files.
+        path: {type}`string` The path string.
+        mock_files: {type}`dict[string, string]` A dict of mocked files.
 
     Returns:
-        A struct mocking a path object.
+        {type}`MockPath` A struct mocking a path object.
     """
+    mock_files = mock_files or {}
     return struct(
-        exists = path in mocked_files,
+        exists = path in mock_files,
         basename = path.split("/")[-1],
         dirname = "/".join(path.split("/")[:-1]),
         _path = path,
     )
 
-def mock_file(path, content = ""):
+def _file_new(short_path, *, path = None, content = "", is_source = True, owner = Label("@mock//:mock"), repo = "@"):
     """Create a mock File object.
 
     Args:
-        path: The path to the file.
-        content: The content of the file.
+        short_path: {type}`string` The short path to the file.
+        path: {type}`string` The full path to the file. Defaults to a made up exec-root path or the short path if is_source.
+        content: {type}`string` The content of the file.
+        is_source: {type}`bool` Whether the file is a source file.
+        owner: {type}`Label` The owner label of the file.
+        repo: {type}`string` The repository the file belongs to. "@" and "@@" refer to the main repo.
 
     Returns:
-        A struct mocking a File object.
+        {type}`MockFile` A struct mocking a File object.
     """
     _ = content  # @unused
+    
+    repo_name = repo
+    for _ in range(2): # Strip up to two leading @
+        if repo_name.startswith("@"):
+            repo_name = repo_name[1:]
+
+    actual_short_path = short_path
+    if repo_name:
+        if not actual_short_path.startswith("../"):
+            actual_short_path = "../{}/{}".format(repo_name, short_path)
+
+        if path == None:
+            rel_path = short_path
+            if rel_path.startswith("../"):
+                parts = rel_path.split("/")
+                rel_path = "/".join(parts[2:])
+
+            if is_source:
+                path = "external/{}/{}".format(repo_name, rel_path)
+            else:
+                path = "bazel-out/k9-deadbeaf/bin/external/{}/{}".format(repo_name, rel_path)
+    else:
+        if path == None:
+            if is_source:
+                path = short_path
+            else:
+                path = "bazel-out/k9-deadbeaf/bin/{}".format(short_path)
+
     return struct(
         path = path,
         basename = path.split("/")[-1],
         dirname = "/".join(path.split("/")[:-1]),
         extension = path.split(".")[-1] if "." in path else "",
-        is_source = True,
-        owner = Label("//:mock"),
-        short_path = path,
+        is_source = is_source,
+        owner = owner,
+        short_path = actual_short_path,
     )
 
-def mock_mctx(
+def _tag_new(**kwargs):
+    """Create a mock tag.
+
+    Args:
+        **kwargs: {type}`dict` The tag attributes.
+
+    Returns:
+        {type}`MockTag` A mock tag object.
+    """
+    return struct(**kwargs)
+
+def _module_add_tag(self, tag_class, tag):
+    """Add a tag to a module.
+
+    Args:
+        self: The mock module object.
+        tag_class: {type}`str` The name of the tag class.
+        tag: {type}`struct` The tag object.
+
+    Returns:
+        {type}`MockModule` A new mock module object with the tag added.
+    """
+    tags_dict = {k: getattr(self.tags, k) for k in dir(self.tags)}
+    tag_list = list(tags_dict.get(tag_class, []))
+    tag_list.append(tag)
+    tags_dict[tag_class] = tag_list
+    return _module_new(self.name, is_root = self.is_root, **tags_dict)
+
+def _module_new(name, *, is_root = False, **tags):
+    """Create a mock module object.
+
+    Args:
+        name: {type}`string` The name of the module.
+        is_root: {type}`bool` Whether this is the root module.
+        **tags: {type}`list[MockTag]` Lists of tag objects.
+
+    Returns:
+        {type}`MockModule` A mock module object.
+    """
+    self = struct(
+        name = name,
+        tags = struct(**tags),
+        is_root = is_root,
+    )
+    # Re-wrap self to bind methods
+    return struct(
+        name = self.name,
+        tags = self.tags,
+        is_root = self.is_root,
+        add_tag = lambda *a, **k: _module_add_tag(self, *a, **k),
+    )
+
+def _mctx_read(self, x, watch = None):
+    _ = watch  # @unused
+    path_str = x._path if hasattr(x, "_path") else str(x)
+    if path_str not in self.mock_files:
+        return ""
+    return self.mock_files[path_str]
+
+def _mctx_path(self, x):
+    return _path_new(str(x), self.mock_files)
+
+def _mctx_download(self, *args, **kwargs):
+    _ = self, args, kwargs  # @unused
+    return struct(
+        success = True,
+        wait = lambda: struct(
+            success = True,
+        ),
+    )
+
+def _mctx_report_progress(self, message):
+    _ = self, message  # @unused
+    return None
+
+def _mctx_add_module(self, module):
+    """Add a module to the mock module_ctx.
+
+    Args:
+        self: The mock module_ctx.
+        module: {type}`MockModule` The mock module object.
+
+    Returns:
+        {type}`MockModuleCtx` The mock module_ctx.
+    """
+    if getattr(module, "is_root", False) and len(self.modules) > 0:
+        fail("is_root=True can only be set on the first module in the modules list.")
+    self.modules.append(module)
+    return self
+
+def _mctx_new(
         *args,
-        **kwargs):
+        modules = None,
+        environ = None,
+        mock_files = None,
+        os_name = "linux",
+        arch_name = "x86_64",
+        read = None,
+        download = None,
+        report_progress = None,
+        facts = None):
     """Create a mock module_ctx object.
 
     Args:
-        *args: Mock modules passed positionally.
-        **kwargs: Optional arguments:
-            modules: List of mock modules (alternative to positional args).
-            environ: Dict of environment variables.
-            mocked_files: Dict mapping path strings to content.
-            os_name: The OS name.
-            arch_name: The architecture name.
-            read: Optional read function.
-            download: Optional download function.
-            report_progress: Optional report_progress function.
+        *args: {type}`list[MockModule]` Mock modules passed positionally.
+        modules: {type}`list[MockModule]` List of mock modules (alternative to positional args).
+        environ: {type}`dict[string, string]` Dict of environment variables.
+        mock_files: {type}`dict[string, string]` Dict mapping path strings to content.
+        os_name: {type}`string` The OS name.
+        arch_name: {type}`string` The architecture name.
+        read: {type}`callable` Optional read function.
+        download: {type}`callable` Optional download function.
+        report_progress: {type}`callable` Optional report_progress function.
+        facts: {type}`dict` Optional facts dict.
 
     Returns:
-        A struct mocking a module_ctx object.
+        {type}`MockModuleCtx` A struct mocking a module_ctx object.
     """
-    modules = kwargs.get("modules")
-    if modules == None:
-        modules = list(args)
-    elif type(modules) != "list":
-        modules = [modules]
+    modules = list(args) + (modules or [])
 
-    environ = kwargs.get("environ", {})
-    mocked_files = kwargs.get("mocked_files", {})
-    os_name = kwargs.get("os_name", "linux")
-    arch_name = kwargs.get("arch_name", "x86_64")
-    read = kwargs.get("read")
-    download = kwargs.get("download")
-    report_progress = kwargs.get("report_progress")
-    facts = kwargs.get("facts")
+    for i, mod in enumerate(modules):
+        if getattr(mod, "is_root", False) and i != 0:
+            fail("is_root=True can only be set on the first module in the modules list.")
 
-    def _read(x, watch = None):
-        _ = watch  # @unused
-        path_str = x._path if hasattr(x, "_path") else str(x)
-        if path_str not in mocked_files:
-            fail("File not found in mocked_files: " + path_str)
-        return mocked_files[path_str]
+    environ = environ or {}
+    mock_files = mock_files or {}
 
-    def _path(x):
-        return mock_path(str(x), mocked_files)
-
-    return struct(
-        path = _path,
-        read = read or _read,
+    self = struct(
+        mock_files = mock_files,
         getenv = environ.get,
         facts = facts,
         os = struct(
             name = os_name,
             arch = arch_name,
         ),
-        modules = [
-            struct(
-                name = modules[0].name,
-                tags = modules[0].tags,
-                is_root = getattr(modules[0], "is_root", False),
-            ),
-        ] + [
-            struct(
-                name = mod.name,
-                tags = mod.tags,
-                is_root = False,
-            )
-            for mod in modules[1:]
-        ] if modules else [],
-        download = download or (lambda *_, **__: struct(
-            success = True,
-            wait = lambda: struct(
-                success = True,
-            ),
-        )),
-        report_progress = report_progress or (lambda _: None),
+        modules = list(modules),
+    )
+    return struct(
+        mock_files = self.mock_files,
+        getenv = self.getenv,
+        facts = self.facts,
+        os = self.os,
+        modules = self.modules,
+        path = lambda *a, **k: _mctx_path(self, *a, **k),
+        read = lambda *a, **k: _mctx_read(self, *a, **k),
+        download = lambda *a, **k: _mctx_download(self, *a, **k),
+        report_progress = lambda *a, **k: _mctx_report_progress(self, *a, **k),
+        add_module = lambda *a, **k: _mctx_add_module(self, *a, **k),
     )
 
-def mock_rctx(
-        attr = {},
-        environ = {},
-        mocked_files = {},
+def _rctx_read(self, x):
+    path_str = x._path if hasattr(x, "_path") else str(x)
+    if path_str not in self.mock_files:
+        fail("File not found in mock_files: " + path_str)
+    return self.mock_files[path_str]
+
+def _rctx_path(self, x):
+    return _path_new(str(x), self.mock_files)
+
+def _rctx_file(self, path, content = "", executable = True, legacy_utf8 = True):
+    _ = executable, legacy_utf8  # @unused
+    self.mock_files[str(path)] = content
+
+def _rctx_template(self, path, template, substitutions = {}, executable = True):
+    _ = executable  # @unused
+    template_str = str(template)
+    if template_str not in self.mock_files:
+        fail("Template file not found: " + template_str)
+    
+    content = self.mock_files[template_str]
+    for key, value in substitutions.items():
+        content = content.replace(key, value)
+        
+    self.mock_files[str(path)] = content
+
+def _rctx_which(self, program):
+    prog_str = str(program)
+    if prog_str in self.mock_which:
+        res = self.mock_which[prog_str]
+        if res == None:
+            return None
+        return _path_new(res, self.mock_files)
+    return None
+
+def _rctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = ""):
+    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity  # @unused
+    
+    urls = url if type(url) == "list" else [url]
+    
+    for u in urls:
+        if u in self.mock_downloads:
+            res = self.mock_downloads[u]
+            if type(res) == "string":
+                if output:
+                    self.mock_files[str(output)] = res
+                return struct(success = True, sha256 = "mocksha256")
+            else:
+                return res(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
+    
+    if not allow_fail:
+        fail("Download not mocked for url: " + str(urls))
+    return struct(success = False)
+
+def _rctx_download_and_extract(self, url, output = "", sha256 = "", type = "", stripPrefix = "", allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = "", rename_files = {}):
+    _ = sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files  # @unused
+    
+    urls = url if type(url) == "list" else [url]
+    
+    for u in urls:
+        if u in self.mock_downloads:
+            res = self.mock_downloads[u]
+            if type(res) == "string":
+                pass
+            else:
+                return res(self, u, output, sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files)
+                
+    if not allow_fail:
+        fail("Download and extract not mocked for url: " + str(urls))
+    return struct(success = False)
+
+def _rctx_execute(self, arguments, timeout = 600, quiet = True, working_directory = "", environment = {}, custom_reporter = ""):
+    _ = arguments, timeout, quiet, working_directory, environment, custom_reporter  # @unused
+    return struct(return_code = 0, stdout = "", stderr = "")
+
+def _rctx_symlink(self, target, link_name):
+    self.mock_files[str(link_name)] = '{"type": "symlink", "target": "' + str(target) + '"}'
+
+def _rctx_new(
+        attr = None,
+        environ = None,
+        mock_files = None,
+        mock_which = None,
+        mock_downloads = None,
         os_name = "linux",
-        arch_name = "x86_64",
-        read = None,
-        download = None,
-        download_and_extract = None,
-        execute = None,
-        file = None,
-        symlink = None,
-        template = None,
-        which = None):
+        arch_name = "x86_64"):
     """Create a mock repository_ctx object.
 
     Args:
-        attr: Dict of attributes.
-        environ: Dict of environment variables.
-        mocked_files: Dict mapping path strings to content.
-        os_name: The OS name.
-        arch_name: The architecture name.
-        read: Optional read function.
-        download: Optional download function.
-        download_and_extract: Optional download_and_extract function.
-        execute: Optional execute function.
-        file: Optional file function.
-        symlink: Optional symlink function.
-        template: Optional template function.
-        which: Optional which function.
+        attr: {type}`dict` Dict of attributes.
+        environ: {type}`dict[string, string]` Dict of environment variables.
+        mock_files: {type}`dict[string, string]` Dict mapping path strings to content.
+        mock_which: {type}`dict[string, string]` Dict mapping program name to path string.
+        mock_downloads: {type}`dict[string, string|callable]` Dict mapping url to string or callable.
+        os_name: {type}`string` The OS name.
+        arch_name: {type}`string` The architecture name.
 
     Returns:
-        A struct mocking a repository_ctx object.
+        {type}`MockRepositoryCtx` A struct mocking a repository_ctx object.
     """
+    attr = attr or {}
+    environ = environ or {}
+    mock_files = mock_files or {}
+    mock_which = mock_which or {}
+    mock_downloads = mock_downloads or {}
 
-    def _read(x):
-        path_str = x._path if hasattr(x, "_path") else str(x)
-        if path_str not in mocked_files:
-            fail("File not found in mocked_files: " + path_str)
-        return mocked_files[path_str]
-
-    def _path(x):
-        return mock_path(str(x), mocked_files)
-
-    return struct(
+    self = struct(
+        mock_files = mock_files,
+        mock_which = mock_which,
+        mock_downloads = mock_downloads,
         attr = struct(**attr),
-        path = _path,
-        read = read or _read,
         os = struct(
             name = os_name,
             arch = arch_name,
         ),
         os_environ = environ,
-        download = download,
-        download_and_extract = download_and_extract,
-        execute = execute,
-        file = file,
-        symlink = symlink,
-        template = template,
-        which = which,
+    )
+    
+    return struct(
+        mock_files = self.mock_files,
+        mock_which = self.mock_which,
+        mock_downloads = self.mock_downloads,
+        attr = self.attr,
+        os = self.os,
+        os_environ = self.os_environ,
+        path = lambda *a, **k: _rctx_path(self, *a, **k),
+        read = lambda *a, **k: _rctx_read(self, *a, **k),
+        file = lambda *a, **k: _rctx_file(self, *a, **k),
+        template = lambda *a, **k: _rctx_template(self, *a, **k),
+        which = lambda *a, **k: _rctx_which(self, *a, **k),
+        download = lambda *a, **k: _rctx_download(self, *a, **k),
+        download_and_extract = lambda *a, **k: _rctx_download_and_extract(self, *a, **k),
+        execute = lambda *a, **k: _rctx_execute(self, *a, **k),
+        symlink = lambda *a, **k: _rctx_symlink(self, *a, **k),
     )
 
-def mock_glob_call(*args, **kwargs):
+def _glob_call_new(*args, **kwargs):
     """Create a struct representing a glob call.
 
     Args:
-        *args: Positional arguments to glob.
-        **kwargs: Keyword arguments to glob.
+        *args: {type}`tuple` Positional arguments to glob.
+        **kwargs: {type}`dict` Keyword arguments to glob.
 
     Returns:
-        A struct with glob and kwargs fields.
+        {type}`MockGlobCall` A struct with glob and kwargs fields.
     """
     return struct(
         glob = args,
         kwargs = kwargs,
     )
 
-def mock_glob():
+def _glob_new():
     """Create a mock glob object.
 
     Returns:
-        A struct with calls and results lists, and a glob function.
+        {type}`MockGlob` A struct with calls and results lists, and a glob function.
     """
     calls = []
     results = []
 
-    def _glob(*args, **kwargs):
-        calls.append(mock_glob_call(*args, **kwargs))
+    def _glob_fn(*args, **kwargs):
+        calls.append(_glob_call_new(*args, **kwargs))
         if not results:
             fail("Mock glob missing for invocation: args={} kwargs={}".format(
                 args,
@@ -227,18 +392,30 @@ def mock_glob():
     return struct(
         calls = calls,
         results = results,
-        glob = _glob,
+        glob = _glob_fn,
     )
 
-def mock_select(value, no_match_error = None):
+def _select_new(value, no_match_error = None):
     """A mock select function that returns the value.
 
     Args:
-        value: The value to return.
-        no_match_error: Ignored.
+        value: {type}`Any` The value to return.
+        no_match_error: {type}`string` Ignored.
 
     Returns:
-        The value.
+        {type}`MockSelect` The value.
     """
     _ = no_match_error  # @unused
     return value
+
+mocks = struct(
+    file = _file_new,
+    glob = _glob_new,
+    glob_call = _glob_call_new,
+    mctx = _mctx_new,
+    module = _module_new,
+    path = _path_new,
+    rctx = _rctx_new,
+    select = _select_new,
+    tag = _tag_new,
+)

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -23,7 +23,8 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
 
     Args:
         short_path: {type}`string` The short path to the file.
-        path: {type}`string` The full path to the file. Defaults to a made up exec-root path or the short path if is_source.
+        path: {type}`string` The full path to the file. Defaults to a made
+            up exec-root path or the short path if is_source.
         is_source: {type}`bool` Whether the file is a source file.
         owner: {type}`Label|string` The owner label of the file.
 
@@ -53,7 +54,10 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
             if is_source:
                 path = "external/{}/{}".format(repo_name, rel_path)
             else:
-                path = "bazel-out/k9-deadbeef/bin/external/{}/{}".format(repo_name, rel_path)
+                path = "bazel-out/k9-deadbeef/bin/external/{}/{}".format(
+                    repo_name,
+                    rel_path,
+                )
     elif path == None:
         if is_source:
             path = short_path
@@ -108,8 +112,28 @@ def _mctx_read(self, x, watch = None):
 def _mctx_path(self, x):
     return _path_new(str(x), self.mock_files)
 
-def _mctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = "", block = True):
-    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity, block  # @unused
+def _mctx_download(
+        self,
+        url,
+        output = "",
+        sha256 = "",
+        executable = False,
+        allow_fail = False,
+        canonical_id = "",
+        auth = {},
+        headers = {},
+        integrity = "",
+        block = True):
+    _ = (
+        sha256,
+        executable,
+        allow_fail,
+        canonical_id,
+        auth,
+        headers,
+        integrity,
+        block,
+    )  # @unused
     urls = url if type(url) == "list" else [url]
     for u in urls:
         content = None
@@ -122,9 +146,23 @@ def _mctx_download(self, url, output = "", sha256 = "", executable = False, allo
             if type(content) == "string":
                 out = str(output) if output else u.split("/")[-1]
                 self.mock_files[out] = content
-                return struct(success = True, wait = lambda: struct(success = True))
+                return struct(
+                    success = True,
+                    wait = lambda: struct(success = True),
+                )
             else:
-                return content(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
+                return content(
+                    self,
+                    u,
+                    output,
+                    sha256,
+                    executable,
+                    allow_fail,
+                    canonical_id,
+                    auth,
+                    headers,
+                    integrity,
+                )
 
     if not self.mock_downloads:
         return struct(success = True, wait = lambda: struct(success = True))
@@ -146,7 +184,8 @@ def _mctx_add_module(self, **kwargs):
     """
     module = _module_new(**kwargs)
     if module.is_root and len(self.modules) > 0:
-        fail("is_root=True can only be set on the first module in the modules list.")
+        fail("is_root=True can only be set on the first module in the " +
+             "modules list.")
     self.modules.append(module)
     return self
 
@@ -163,10 +202,13 @@ def _mctx_new(
 
     Args:
         *args: {type}`list[MockModule]` Mock modules passed positionally.
-        modules: {type}`list[MockModule]` List of mock modules (alternative to positional args).
+        modules: {type}`list[MockModule]` List of mock modules (alternative
+            to positional args).
         environ: {type}`dict[string, string]` Dict of environment variables.
-        mock_files: {type}`dict[string, string]` Dict mapping path strings to content.
-        mock_downloads: {type}`dict[string, string|callable]` Dict mapping url to string or callable.
+        mock_files: {type}`dict[string, string]` Dict mapping path strings
+            to content.
+        mock_downloads: {type}`dict[string, string|callable]` Dict mapping
+            url to string or callable.
         os_name: {type}`string` The OS name.
         arch_name: {type}`string` The architecture name.
         facts: {type}`dict` Optional facts dict.
@@ -178,7 +220,8 @@ def _mctx_new(
 
     for i, mod in enumerate(modules):
         if getattr(mod, "is_root", False) and i != 0:
-            fail("is_root=True can only be set on the first module in the modules list.")
+            fail("is_root=True can only be set on the first module in the " +
+                 "modules list.")
 
     environ = environ or {}
     mock_files = mock_files or {}
@@ -260,8 +303,26 @@ def _rctx_which(self, program):
         return _path_new(res, self.mock_files)
     return None
 
-def _rctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = ""):
-    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity  # @unused
+def _rctx_download(
+        self,
+        url,
+        output = "",
+        sha256 = "",
+        executable = False,
+        allow_fail = False,
+        canonical_id = "",
+        auth = {},
+        headers = {},
+        integrity = ""):
+    _ = (
+        sha256,
+        executable,
+        allow_fail,
+        canonical_id,
+        auth,
+        headers,
+        integrity,
+    )  # @unused
 
     urls = url if type(url) == "list" else [url]
 
@@ -273,14 +334,47 @@ def _rctx_download(self, url, output = "", sha256 = "", executable = False, allo
                     self.mock_files[str(output)] = res
                 return struct(success = True, sha256 = "mocksha256")
             else:
-                return res(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
+                return res(
+                    self,
+                    u,
+                    output,
+                    sha256,
+                    executable,
+                    allow_fail,
+                    canonical_id,
+                    auth,
+                    headers,
+                    integrity,
+                )
 
     if not allow_fail:
         fail("Download not mocked for url: " + str(urls))
     return struct(success = False)
 
-def _rctx_download_and_extract(self, url, output = "", sha256 = "", type = "", stripPrefix = "", allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = "", rename_files = {}):
-    _ = sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files  # @unused
+def _rctx_download_and_extract(
+        self,
+        url,
+        output = "",
+        sha256 = "",
+        type = "",
+        stripPrefix = "",
+        allow_fail = False,
+        canonical_id = "",
+        auth = {},
+        headers = {},
+        integrity = "",
+        rename_files = {}):
+    _ = (
+        sha256,
+        type,
+        stripPrefix,
+        allow_fail,
+        canonical_id,
+        auth,
+        headers,
+        integrity,
+        rename_files,
+    )  # @unused
 
     urls = url if type(url) == "list" else [url]
 
@@ -290,14 +384,42 @@ def _rctx_download_and_extract(self, url, output = "", sha256 = "", type = "", s
             if type(res) == "string":
                 pass
             else:
-                return res(self, u, output, sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files)
+                return res(
+                    self,
+                    u,
+                    output,
+                    sha256,
+                    type,
+                    stripPrefix,
+                    allow_fail,
+                    canonical_id,
+                    auth,
+                    headers,
+                    integrity,
+                    rename_files,
+                )
 
     if not allow_fail:
         fail("Download and extract not mocked for url: " + str(urls))
     return struct(success = False)
 
-def _rctx_execute(self, arguments, timeout = 600, quiet = True, working_directory = "", environment = {}, custom_reporter = ""):
-    _ = self, arguments, timeout, quiet, working_directory, environment, custom_reporter  # @unused
+def _rctx_execute(
+        self,
+        arguments,
+        timeout = 600,
+        quiet = True,
+        working_directory = "",
+        environment = {},
+        custom_reporter = ""):
+    _ = (
+        self,
+        arguments,
+        timeout,
+        quiet,
+        working_directory,
+        environment,
+        custom_reporter,
+    )  # @unused
     return struct(return_code = 0, stdout = "", stderr = "")
 
 def _rctx_symlink(self, target, link_name):
@@ -316,9 +438,12 @@ def _rctx_new(
     Args:
         attr: {type}`dict` Dict of attributes.
         environ: {type}`dict[string, string]` Dict of environment variables.
-        mock_files: {type}`dict[string, string]` Dict mapping path strings to content.
-        mock_which: {type}`dict[string, string]` Dict mapping program name to path string.
-        mock_downloads: {type}`dict[string, string|callable]` Dict mapping url to string or callable.
+        mock_files: {type}`dict[string, string]` Dict mapping path strings
+            to content.
+        mock_which: {type}`dict[string, string]` Dict mapping program
+            name to path string.
+        mock_downloads: {type}`dict[string, string|callable]` Dict mapping
+            url to string or callable.
         os_name: {type}`string` The OS name.
         arch_name: {type}`string` The architecture name.
 
@@ -348,7 +473,11 @@ def _rctx_new(
         template = lambda *a, **k: _rctx_template(self, *a, **k),
         which = lambda *a, **k: _rctx_which(self, *a, **k),
         download = lambda *a, **k: _rctx_download(self, *a, **k),
-        download_and_extract = lambda *a, **k: _rctx_download_and_extract(self, *a, **k),
+        download_and_extract = lambda *a, **k: _rctx_download_and_extract(
+            self,
+            *a,
+            **k
+        ),
         execute = lambda *a, **k: _rctx_execute(self, *a, **k),
         symlink = lambda *a, **k: _rctx_symlink(self, *a, **k),
     )
@@ -374,7 +503,8 @@ def _glob_new():
     """Create a mock glob object.
 
     Returns:
-        {type}`MockGlob` A struct with calls and results lists, and a glob function.
+        {type}`MockGlob` A struct with calls and results lists, and a
+            glob function.
     """
     calls = []
     results = []

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -220,7 +220,7 @@ def _rctx_read(self, x):
     path_str = x._path if hasattr(x, "_path") else str(x)
     if path_str not in self.mock_files:
         fail("File not found in mock_files: " + path_str)
-        
+
     val = self.mock_files[path_str]
     for _ in range(10):
         if type(val) == "dict" and val.get("type") == "symlink":

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -112,17 +112,25 @@ def _mctx_read(self, x, watch = None):
 def _mctx_path(self, x):
     return _path_new(str(x), self.mock_files)
 
-def _mctx_download(self, *args, **kwargs):
-    _ = self, args, kwargs  # @unused
-    return struct(
-        success = True,
-        wait = lambda: struct(
-            success = True,
-        ),
-    )
+def _mctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = ""):
+    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity  # @unused
+    urls = url if type(url) == "list" else [url]
+    for u in urls:
+        if u in self.mock_downloads:
+            content = self.mock_downloads[u]
+            if type(content) == "string":
+                out = str(output) if output else u.split("/")[-1]
+                self.mock_files[out] = content
+                return struct(success = True, wait = lambda: struct(success = True))
+            else:
+                return content(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
+    
+    if not allow_fail:
+        fail("Download not mocked for url: " + str(urls))
+    return struct(success = False, wait = lambda: struct(success = False))
 
 def _mctx_report_progress(self, message):
-    _ = self, message  # @unused
+    self.report_progress_calls.append(message)
     return None
 
 def _mctx_add_module(self, **kwargs):
@@ -146,11 +154,9 @@ def _mctx_new(
         modules = None,
         environ = None,
         mock_files = None,
+        mock_downloads = None,
         os_name = "linux",
         arch_name = "x86_64",
-        read = None,
-        download = None,
-        report_progress = None,
         facts = None):
     """Create a mock module_ctx object.
 
@@ -159,11 +165,9 @@ def _mctx_new(
         modules: {type}`list[MockModule]` List of mock modules (alternative to positional args).
         environ: {type}`dict[string, string]` Dict of environment variables.
         mock_files: {type}`dict[string, string]` Dict mapping path strings to content.
+        mock_downloads: {type}`dict[string, string|callable]` Dict mapping url to string or callable.
         os_name: {type}`string` The OS name.
         arch_name: {type}`string` The architecture name.
-        read: {type}`callable` Optional read function.
-        download: {type}`callable` Optional download function.
-        report_progress: {type}`callable` Optional report_progress function.
         facts: {type}`dict` Optional facts dict.
 
     Returns:
@@ -177,28 +181,33 @@ def _mctx_new(
 
     environ = environ or {}
     mock_files = mock_files or {}
+    mock_downloads = mock_downloads or {}
 
     # buildifier: disable=uninitialized
     self = struct(
         mock_files = mock_files,
+        mock_downloads = mock_downloads,
+        report_progress_calls = [],
         getenv = environ.get,
         facts = facts,
         os = struct(
             name = os_name,
             arch = arch_name,
-        ),
+    ),
         modules = list(modules),
     )
     return struct(
         mock_files = self.mock_files,
+        mock_downloads = self.mock_downloads,
+        report_progress_calls = self.report_progress_calls,
         getenv = self.getenv,
         facts = self.facts,
         os = self.os,
         modules = self.modules,
         path = lambda *a, **k: _mctx_path(self, *a, **k),
-        read = read or (lambda *a, **k: _mctx_read(self, *a, **k)),
-        download = download or (lambda *a, **k: _mctx_download(self, *a, **k)),
-        report_progress = report_progress or (lambda *a, **k: _mctx_report_progress(self, *a, **k)),
+        read = lambda *a, **k: _mctx_read(self, *a, **k),
+        download = lambda *a, **k: _mctx_download(self, *a, **k),
+        report_progress = lambda *a, **k: _mctx_report_progress(self, *a, **k),
         add_module = lambda **k: _mctx_add_module(self, **k),
     )
 
@@ -316,7 +325,7 @@ def _rctx_new(
         os = struct(
             name = os_name,
             arch = arch_name,
-        ),
+    ),
         os_environ = environ,
         path = lambda *a, **k: _rctx_path(self, *a, **k),
         read = lambda *a, **k: _rctx_read(self, *a, **k),
@@ -361,7 +370,7 @@ def _glob_new():
             fail("Mock glob missing for invocation: args={} kwargs={}".format(
                 args,
                 kwargs,
-            ))
+        ))
         return results.pop(0)
 
     return struct(

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -18,29 +18,32 @@ def _path_new(path, mock_files = None):
         _path = path,
     )
 
-def _file_new(short_path, *, path = None, content = "", is_source = True, owner = Label("@mock//:mock"), repo = "@"):
+def _file_new(short_path, *, path = None, is_source = True, owner = None):
     """Create a mock File object.
 
     Args:
         short_path: {type}`string` The short path to the file.
         path: {type}`string` The full path to the file. Defaults to a made up exec-root path or the short path if is_source.
-        content: {type}`string` The content of the file.
         is_source: {type}`bool` Whether the file is a source file.
-        owner: {type}`Label` The owner label of the file.
-        repo: {type}`string` The repository the file belongs to. "@" and "@@" refer to the main repo.
+        owner: {type}`Label|string` The owner label of the file.
 
     Returns:
         {type}`MockFile` A struct mocking a File object.
     """
-    _ = content  # @unused
-    
-    repo_name = repo
-    for _ in range(2): # Strip up to two leading @
+    if owner == None:
+        owner = Label("//:mock")
+
+    owner_str = str(owner)
+    repo_name = owner_str.split("//")[0]
+    for _ in range(2):  # Strip up to two leading @
         if repo_name.startswith("@"):
             repo_name = repo_name[1:]
 
+    if not repo_name:
+        repo_name = "@"
+
     actual_short_path = short_path
-    if repo_name:
+    if repo_name != "@":
         if not actual_short_path.startswith("../"):
             actual_short_path = "../{}/{}".format(repo_name, short_path)
 
@@ -53,13 +56,12 @@ def _file_new(short_path, *, path = None, content = "", is_source = True, owner 
             if is_source:
                 path = "external/{}/{}".format(repo_name, rel_path)
             else:
-                path = "bazel-out/k9-deadbeaf/bin/external/{}/{}".format(repo_name, rel_path)
-    else:
-        if path == None:
-            if is_source:
-                path = short_path
-            else:
-                path = "bazel-out/k9-deadbeaf/bin/{}".format(short_path)
+                path = "bazel-out/k9-deadbeef/bin/external/{}/{}".format(repo_name, rel_path)
+    elif path == None:
+        if is_source:
+            path = short_path
+        else:
+            path = "bazel-out/k9-deadbeef/bin/{}".format(short_path)
 
     return struct(
         path = path,
@@ -82,23 +84,6 @@ def _tag_new(**kwargs):
     """
     return struct(**kwargs)
 
-def _module_add_tag(self, tag_class, tag):
-    """Add a tag to a module.
-
-    Args:
-        self: The mock module object.
-        tag_class: {type}`str` The name of the tag class.
-        tag: {type}`struct` The tag object.
-
-    Returns:
-        {type}`MockModule` A new mock module object with the tag added.
-    """
-    tags_dict = {k: getattr(self.tags, k) for k in dir(self.tags)}
-    tag_list = list(tags_dict.get(tag_class, []))
-    tag_list.append(tag)
-    tags_dict[tag_class] = tag_list
-    return _module_new(self.name, is_root = self.is_root, **tags_dict)
-
 def _module_new(name, *, is_root = False, **tags):
     """Create a mock module object.
 
@@ -115,19 +100,14 @@ def _module_new(name, *, is_root = False, **tags):
         tags = struct(**tags),
         is_root = is_root,
     )
-    # Re-wrap self to bind methods
-    return struct(
-        name = self.name,
-        tags = self.tags,
-        is_root = self.is_root,
-        add_tag = lambda *a, **k: _module_add_tag(self, *a, **k),
-    )
+
+    return self
 
 def _mctx_read(self, x, watch = None):
     _ = watch  # @unused
     path_str = x._path if hasattr(x, "_path") else str(x)
     if path_str not in self.mock_files:
-        return ""
+        fail("File not found in mock_files: " + path_str)
     return self.mock_files[path_str]
 
 def _mctx_path(self, x):
@@ -239,11 +219,11 @@ def _rctx_template(self, path, template, substitutions = {}, executable = True):
     template_str = str(template)
     if template_str not in self.mock_files:
         fail("Template file not found: " + template_str)
-    
+
     content = self.mock_files[template_str]
     for key, value in substitutions.items():
         content = content.replace(key, value)
-        
+
     self.mock_files[str(path)] = content
 
 def _rctx_which(self, program):
@@ -257,9 +237,9 @@ def _rctx_which(self, program):
 
 def _rctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = ""):
     _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity  # @unused
-    
+
     urls = url if type(url) == "list" else [url]
-    
+
     for u in urls:
         if u in self.mock_downloads:
             res = self.mock_downloads[u]
@@ -269,16 +249,16 @@ def _rctx_download(self, url, output = "", sha256 = "", executable = False, allo
                 return struct(success = True, sha256 = "mocksha256")
             else:
                 return res(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
-    
+
     if not allow_fail:
         fail("Download not mocked for url: " + str(urls))
     return struct(success = False)
 
 def _rctx_download_and_extract(self, url, output = "", sha256 = "", type = "", stripPrefix = "", allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = "", rename_files = {}):
     _ = sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files  # @unused
-    
+
     urls = url if type(url) == "list" else [url]
-    
+
     for u in urls:
         if u in self.mock_downloads:
             res = self.mock_downloads[u]
@@ -286,13 +266,13 @@ def _rctx_download_and_extract(self, url, output = "", sha256 = "", type = "", s
                 pass
             else:
                 return res(self, u, output, sha256, type, stripPrefix, allow_fail, canonical_id, auth, headers, integrity, rename_files)
-                
+
     if not allow_fail:
         fail("Download and extract not mocked for url: " + str(urls))
     return struct(success = False)
 
 def _rctx_execute(self, arguments, timeout = 600, quiet = True, working_directory = "", environment = {}, custom_reporter = ""):
-    _ = arguments, timeout, quiet, working_directory, environment, custom_reporter  # @unused
+    _ = self, arguments, timeout, quiet, working_directory, environment, custom_reporter  # @unused
     return struct(return_code = 0, stdout = "", stderr = "")
 
 def _rctx_symlink(self, target, link_name):
@@ -337,7 +317,7 @@ def _rctx_new(
         ),
         os_environ = environ,
     )
-    
+
     return struct(
         mock_files = self.mock_files,
         mock_which = self.mock_which,

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -41,6 +41,7 @@ def mock_file(path, content = ""):
     Returns:
         A struct mocking a File object.
     """
+    _ = content  # @unused
     return struct(
         path = path,
         basename = path.split("/")[-1],
@@ -87,7 +88,7 @@ def mock_mctx(
     facts = kwargs.get("facts")
 
     def _read(x, watch = None):
-        _ = watch
+        _ = watch  # @unused
         path_str = x._path if hasattr(x, "_path") else str(x)
         if path_str not in mocked_files:
             fail("File not found in mocked_files: " + path_str)
@@ -239,5 +240,5 @@ def mock_select(value, no_match_error = None):
     Returns:
         The value.
     """
-    _ = no_match_error
+    _ = no_match_error  # @unused
     return value

--- a/tests/support/mocks/mocks.bzl
+++ b/tests/support/mocks/mocks.bzl
@@ -35,15 +35,16 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
 
     owner_str = str(owner)
     repo_name = owner_str.split("//")[0]
-    for _ in range(2):  # Strip up to two leading @
-        if repo_name.startswith("@"):
-            repo_name = repo_name[1:]
 
-    if not repo_name:
-        repo_name = "@"
+    is_main_repo = repo_name in ("", "@", "@@")
+
+    if not is_main_repo:
+        for _ in range(2):  # Strip up to two leading @
+            if repo_name.startswith("@"):
+                repo_name = repo_name[1:]
 
     actual_short_path = short_path
-    if repo_name != "@":
+    if not is_main_repo:
         if not actual_short_path.startswith("../"):
             actual_short_path = "../{}/{}".format(repo_name, short_path)
 
@@ -57,12 +58,11 @@ def _file_new(short_path, *, path = None, is_source = True, owner = None):
                 path = "external/{}/{}".format(repo_name, rel_path)
             else:
                 path = "bazel-out/k9-deadbeef/bin/external/{}/{}".format(repo_name, rel_path)
-    else:
-        if path == None:
-            if is_source:
-                path = short_path
-            else:
-                path = "bazel-out/k9-deadbeef/bin/{}".format(short_path)
+    elif path == None:
+        if is_source:
+            path = short_path
+        else:
+            path = "bazel-out/k9-deadbeef/bin/{}".format(short_path)
 
     return struct(
         path = path,
@@ -112,21 +112,26 @@ def _mctx_read(self, x, watch = None):
 def _mctx_path(self, x):
     return _path_new(str(x), self.mock_files)
 
-def _mctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = ""):
-    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity  # @unused
+def _mctx_download(self, url, output = "", sha256 = "", executable = False, allow_fail = False, canonical_id = "", auth = {}, headers = {}, integrity = "", block = True):
+    _ = sha256, executable, allow_fail, canonical_id, auth, headers, integrity, block  # @unused
     urls = url if type(url) == "list" else [url]
     for u in urls:
+        content = None
         if u in self.mock_downloads:
             content = self.mock_downloads[u]
+        elif "*" in self.mock_downloads:
+            content = self.mock_downloads["*"]
+
+        if content != None:
             if type(content) == "string":
                 out = str(output) if output else u.split("/")[-1]
                 self.mock_files[out] = content
                 return struct(success = True, wait = lambda: struct(success = True))
             else:
                 return content(self, u, output, sha256, executable, allow_fail, canonical_id, auth, headers, integrity)
-    
-    if not allow_fail:
-        fail("Download not mocked for url: " + str(urls))
+
+    if not self.mock_downloads:
+        return struct(success = True, wait = lambda: struct(success = True))
     return struct(success = False, wait = lambda: struct(success = False))
 
 def _mctx_report_progress(self, message):
@@ -193,7 +198,7 @@ def _mctx_new(
         os = struct(
             name = os_name,
             arch = arch_name,
-    ),
+        ),
         modules = list(modules),
     )
     return struct(
@@ -286,7 +291,7 @@ def _rctx_execute(self, arguments, timeout = 600, quiet = True, working_director
     return struct(return_code = 0, stdout = "", stderr = "")
 
 def _rctx_symlink(self, target, link_name):
-    self.mock_files[str(link_name)] = '{"type": "symlink", "target": "' + str(target) + '"}'
+    self.mock_files[str(link_name)] = {"target": str(target), "type": "symlink"}
 
 def _rctx_new(
         attr = None,
@@ -325,7 +330,7 @@ def _rctx_new(
         os = struct(
             name = os_name,
             arch = arch_name,
-    ),
+        ),
         os_environ = environ,
         path = lambda *a, **k: _rctx_path(self, *a, **k),
         read = lambda *a, **k: _rctx_read(self, *a, **k),
@@ -370,7 +375,7 @@ def _glob_new():
             fail("Mock glob missing for invocation: args={} kwargs={}".format(
                 args,
                 kwargs,
-        ))
+            ))
         return results.pop(0)
 
     return struct(

--- a/tests/support/mocks/mocks_tests.bzl
+++ b/tests/support/mocks/mocks_tests.bzl
@@ -1,0 +1,127 @@
+"""Tests for mocks.bzl"""
+
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//tests/support/mocks:mocks.bzl", "mocks")
+
+_tests = []
+
+def _test_path(env):
+    p1 = mocks.path("a/b/c", mock_files = {"a/b/c": "data"})
+    env.expect.that_bool(p1.exists).equals(True)
+    env.expect.that_str(p1.basename).equals("c")
+    env.expect.that_str(p1.dirname).equals("a/b")
+    env.expect.that_str(p1._path).equals("a/b/c")
+
+    p2 = mocks.path("d/e/f", mock_files = {})
+    env.expect.that_bool(p2.exists).equals(False)
+
+_tests.append(_test_path)
+
+def _test_file(env):
+    # Default main repo
+    f1 = mocks.file("a/b.txt", is_source = True)
+    env.expect.that_str(f1.path).equals("a/b.txt")
+    env.expect.that_str(f1.short_path).equals("a/b.txt")
+    env.expect.that_str(f1.basename).equals("b.txt")
+    env.expect.that_str(f1.dirname).equals("a")
+    env.expect.that_str(f1.extension).equals("txt")
+    env.expect.that_bool(f1.is_source).equals(True)
+    env.expect.that_str(str(f1.owner)).equals(str(Label("//:mock")))
+
+    # External repo
+    f2 = mocks.file("a/b.txt", is_source = True, owner = Label("@foo//:mock"))
+    env.expect.that_str(f2.path).equals("external/foo/a/b.txt")
+    env.expect.that_str(f2.short_path).equals("../foo/a/b.txt")
+
+    # External repo generated file
+    f3 = mocks.file("a/b.txt", is_source = False, owner = Label("@foo//:mock"))
+    env.expect.that_str(f3.path).equals("bazel-out/k9-deadbeef/bin/external/foo/a/b.txt")
+    env.expect.that_str(f3.short_path).equals("../foo/a/b.txt")
+
+_tests.append(_test_file)
+
+def _test_mctx(env):
+    mctx = mocks.mctx(
+        environ = {"FOO": "bar"},
+        mock_files = {"file.txt": "content"},
+        mock_downloads = {"http://example.com": "downloaded"},
+        os_name = "windows",
+        arch_name = "x86_64",
+    )
+    env.expect.that_str(mctx.getenv("FOO")).equals("bar")
+    env.expect.that_str(mctx.read(mocks.path("file.txt"))).equals("content")
+    env.expect.that_str(mctx.os.name).equals("windows")
+    env.expect.that_str(mctx.os.arch).equals("x86_64")
+
+    # Test download
+    res = mctx.download("http://example.com", "out.txt")
+    env.expect.that_bool(res.success).equals(True)
+    env.expect.that_str(mctx.read(mocks.path("out.txt"))).equals("downloaded")
+
+    # Test report progress
+    mctx.report_progress("doing something")
+    env.expect.that_collection(mctx.report_progress_calls).contains_exactly(["doing something"])
+
+_tests.append(_test_mctx)
+
+def _test_rctx(env):
+    rctx = mocks.rctx(
+        environ = {"FOO": "bar"},
+        mock_files = {"file.txt": "content"},
+        mock_which = {"mycmd": "path/to/mycmd"},
+    )
+    env.expect.that_str(rctx.os_environ["FOO"]).equals("bar")
+    env.expect.that_str(rctx.read(mocks.path("file.txt"))).equals("content")
+
+    # Test which
+    w = rctx.which("mycmd")
+    env.expect.that_str(w._path).equals("path/to/mycmd")
+    env.expect.that_bool(rctx.which("not_found") == None).equals(True)
+
+    # Test file writing
+    rctx.file("new.txt", "new content")
+    env.expect.that_str(rctx.read(mocks.path("new.txt"))).equals("new content")
+
+    # Test template
+    rctx.file("template.txt", "Hello {name}")
+    rctx.template("rendered.txt", "template.txt", {"{name}": "World"})
+    env.expect.that_str(rctx.read(mocks.path("rendered.txt"))).equals("Hello World")
+
+    # Test symlink reading
+    rctx.symlink("rendered.txt", "link.txt")
+    env.expect.that_str(rctx.read(mocks.path("link.txt"))).equals("Hello World")
+
+_tests.append(_test_rctx)
+
+def _test_glob(env):
+    g = mocks.glob()
+    g.results.append(["a.txt", "b.txt"])
+    res = g.glob(["*.txt"], exclude = ["c.txt"])
+    env.expect.that_collection(res).contains_exactly(["a.txt", "b.txt"])
+    env.expect.that_collection(g.calls).has_size(1)
+    env.expect.that_collection(g.calls[0].glob[0]).contains_exactly(["*.txt"])
+    env.expect.that_collection(g.calls[0].kwargs["exclude"]).contains_exactly(["c.txt"])
+
+_tests.append(_test_glob)
+
+def _test_module_and_tags(env):
+    mod = mocks.module("my_mod", is_root = True, my_tag = [mocks.tag(attr1 = "val1")])
+    env.expect.that_str(mod.name).equals("my_mod")
+    env.expect.that_bool(mod.is_root).equals(True)
+    env.expect.that_str(mod.tags.my_tag[0].attr1).equals("val1")
+
+_tests.append(_test_module_and_tags)
+
+def _test_select(env):
+    res = mocks.select({"//conditions:default": "val"})
+    env.expect.that_dict(res).contains_exactly({"//conditions:default": "val"})
+
+_tests.append(_test_select)
+
+def mocks_test_suite(name):
+    """Create the test suite.
+
+    Args:
+        name: the name of the test suite
+    """
+    test_suite(name = name, basic_tests = _tests)

--- a/tests/support/mocks/mocks_tests.bzl
+++ b/tests/support/mocks/mocks_tests.bzl
@@ -29,12 +29,12 @@ def _test_file(env):
     env.expect.that_str(str(f1.owner)).equals(str(Label("//:mock")))
 
     # External repo
-    f2 = mocks.file("a/b.txt", is_source = True, owner = Label("@foo//:mock"))
+    f2 = mocks.file("a/b.txt", is_source = True, owner = "@foo//:mock")
     env.expect.that_str(f2.path).equals("external/foo/a/b.txt")
     env.expect.that_str(f2.short_path).equals("../foo/a/b.txt")
 
     # External repo generated file
-    f3 = mocks.file("a/b.txt", is_source = False, owner = Label("@foo//:mock"))
+    f3 = mocks.file("a/b.txt", is_source = False, owner = "@foo//:mock")
     env.expect.that_str(f3.path).equals("bazel-out/k9-deadbeef/bin/external/foo/a/b.txt")
     env.expect.that_str(f3.short_path).equals("../foo/a/b.txt")
 

--- a/tests/support/mocks/mocks_tests.bzl
+++ b/tests/support/mocks/mocks_tests.bzl
@@ -35,7 +35,9 @@ def _test_file(env):
 
     # External repo generated file
     f3 = mocks.file("a/b.txt", is_source = False, owner = "@foo//:mock")
-    env.expect.that_str(f3.path).equals("bazel-out/k9-deadbeef/bin/external/foo/a/b.txt")
+    env.expect.that_str(f3.path).equals(
+        "bazel-out/k9-deadbeef/bin/external/foo/a/b.txt",
+    )
     env.expect.that_str(f3.short_path).equals("../foo/a/b.txt")
 
 _tests.append(_test_file)
@@ -60,7 +62,9 @@ def _test_mctx(env):
 
     # Test report progress
     mctx.report_progress("doing something")
-    env.expect.that_collection(mctx.report_progress_calls).contains_exactly(["doing something"])
+    env.expect.that_collection(mctx.report_progress_calls).contains_exactly([
+        "doing something",
+    ])
 
 _tests.append(_test_mctx)
 
@@ -85,7 +89,9 @@ def _test_rctx(env):
     # Test template
     rctx.file("template.txt", "Hello {name}")
     rctx.template("rendered.txt", "template.txt", {"{name}": "World"})
-    env.expect.that_str(rctx.read(mocks.path("rendered.txt"))).equals("Hello World")
+    env.expect.that_str(rctx.read(mocks.path("rendered.txt"))).equals(
+        "Hello World",
+    )
 
     # Test symlink reading
     rctx.symlink("rendered.txt", "link.txt")
@@ -100,12 +106,18 @@ def _test_glob(env):
     env.expect.that_collection(res).contains_exactly(["a.txt", "b.txt"])
     env.expect.that_collection(g.calls).has_size(1)
     env.expect.that_collection(g.calls[0].glob[0]).contains_exactly(["*.txt"])
-    env.expect.that_collection(g.calls[0].kwargs["exclude"]).contains_exactly(["c.txt"])
+    env.expect.that_collection(g.calls[0].kwargs["exclude"]).contains_exactly([
+        "c.txt",
+    ])
 
 _tests.append(_test_glob)
 
 def _test_module_and_tags(env):
-    mod = mocks.module("my_mod", is_root = True, my_tag = [mocks.tag(attr1 = "val1")])
+    mod = mocks.module(
+        "my_mod",
+        is_root = True,
+        my_tag = [mocks.tag(attr1 = "val1")],
+    )
     env.expect.that_str(mod.name).equals("my_mod")
     env.expect.that_bool(mod.is_root).equals(True)
     env.expect.that_str(mod.tags.my_tag[0].attr1).equals("val1")

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -520,6 +520,7 @@ def _test_rules_python_does_not_take_precedence(env):
                         compatible_with = ["@platforms//os:osx"],
                     ),
                 ],
+                is_root = False,
             ),
         ),
         uv_repository = lambda **kwargs: calls.append(kwargs),

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -21,11 +21,12 @@ load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-
 load("//python/uv:uv_toolchain_info.bzl", "UvToolchainInfo")
 load("//python/uv/private:uv.bzl", "process_modules")  # buildifier: disable=bzl-visibility
 load("//python/uv/private:uv_toolchain.bzl", "uv_toolchain")  # buildifier: disable=bzl-visibility
+load("//tests/support/mocks:mocks.bzl", "mock_mctx")
 load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _tests = []
 
-def _mock_mctx(*modules, download = None, read = None):
+def _uv_mock_mctx(*modules, download = None, read = None):
     # Here we construct a fake minimal manifest file that we use to mock what would
     # be otherwise read from GH files
     manifest_files = {
@@ -66,29 +67,11 @@ def _mock_mctx(*modules, download = None, read = None):
         for fname, contents in manifest_files.items()
     }
 
-    return struct(
-        path = str,
-        download = download or (lambda *_, **__: struct(
-            success = True,
-            wait = lambda: struct(
-                success = True,
-            ),
-        )),
-        read = read or (lambda x: fake_fs[x]),
-        modules = [
-            struct(
-                name = modules[0].name,
-                tags = modules[0].tags,
-                is_root = modules[0].is_root,
-            ),
-        ] + [
-            struct(
-                name = mod.name,
-                tags = mod.tags,
-                is_root = False,
-            )
-            for mod in modules[1:]
-        ],
+    return mock_mctx(
+        modules = list(modules),
+        download = download,
+        read = read,
+        mocked_files = fake_fs,
     )
 
 def _mod(*, name = None, default = [], configure = [], is_root = True):
@@ -148,7 +131,7 @@ def _configure(urls = None, sha256 = None, **kwargs):
 def _test_only_defaults(env):
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -181,7 +164,7 @@ def _test_manual_url_spec(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -238,7 +221,7 @@ def _test_defaults(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -286,7 +269,7 @@ def _test_default_building(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -350,7 +333,7 @@ def _test_complex_configuring(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -462,7 +445,7 @@ def _test_non_rules_python_non_root_is_ignored(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(
@@ -513,7 +496,7 @@ def _test_rules_python_does_not_take_precedence(env):
     calls = []
     uv = _process_modules(
         env,
-        module_ctx = _mock_mctx(
+        module_ctx = _uv_mock_mctx(
             _mod(
                 default = [
                     _default(

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -69,7 +69,7 @@ def _uv_mock_mctx(*modules, download = None, read = None):
     return mocks.mctx(
         modules = list(modules),
         mock_downloads = {
-            "https://example.org/1.0.0/manifest.json": download
+            "*": download,
         } if download else {},
         mock_files = fake_fs,
     )

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -21,9 +21,8 @@ load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-
 load("//python/uv:uv_toolchain_info.bzl", "UvToolchainInfo")
 load("//python/uv/private:uv.bzl", "process_modules")  # buildifier: disable=bzl-visibility
 load("//python/uv/private:uv_toolchain.bzl", "uv_toolchain")  # buildifier: disable=bzl-visibility
-load("//tests/support/mocks:mocks.bzl", "mock_mctx")
+load("//tests/support/mocks:mocks.bzl", "mocks")
 load("//tests/support/platforms:platforms.bzl", "platform_targets")
-
 _tests = []
 
 def _uv_mock_mctx(*modules, download = None, read = None):
@@ -67,21 +66,20 @@ def _uv_mock_mctx(*modules, download = None, read = None):
         for fname, contents in manifest_files.items()
     }
 
-    return mock_mctx(
+    return mocks.mctx(
         modules = list(modules),
         download = download,
         read = read,
-        mocked_files = fake_fs,
+        mock_files = fake_fs,
     )
 
+
 def _mod(*, name = None, default = [], configure = [], is_root = True):
-    return struct(
-        name = name,  # module_name
-        tags = struct(
-            default = default,
-            configure = configure,
-        ),
+    return mocks.module(
+        name,
         is_root = is_root,
+        default = default,
+        configure = configure,
     )
 
 def _process_modules(env, **kwargs):
@@ -465,6 +463,7 @@ def _test_non_rules_python_non_root_is_ignored(env):
                 configure = [
                     _configure(version = "6.6.6"),  # use defaults whatever they are
                 ],
+                is_root = False,
             ),
         ),
         uv_repository = lambda **kwargs: calls.append(kwargs),

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -68,8 +68,9 @@ def _uv_mock_mctx(*modules, download = None, read = None):
 
     return mocks.mctx(
         modules = list(modules),
-        download = download,
-        read = read,
+        mock_downloads = {
+            "https://example.org/1.0.0/manifest.json": download
+        } if download else {},
         mock_files = fake_fs,
     )
 
@@ -183,7 +184,7 @@ def _test_manual_url_spec(env):
                 configure = [
                     _configure(
                         platform = "linux",
-                        urls = ["https://example.org/download.zip"],
+                        urls = ["https://example.org/1.0.0/manifest.json.zip"],
                         sha256 = "deadbeef",
                     ),
                 ],
@@ -208,7 +209,7 @@ def _test_manual_url_spec(env):
             "name": "uv_1_0_0_linux",
             "platform": "linux",
             "sha256": "deadbeef",
-            "urls": ["https://example.org/download.zip"],
+            "urls": ["https://example.org/1.0.0/manifest.json.zip"],
             "version": "1.0.0",
         },
     ])

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -26,9 +26,7 @@ load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _tests = []
 
-def _uv_mock_mctx(*modules, download = None, read = None):
-    _ = read  # @unused
-
+def _uv_mock_mctx(*modules, download = None):
     # Here we construct a fake minimal manifest file that we use to mock what would
     # be otherwise read from GH files
     manifest_files = {
@@ -191,7 +189,6 @@ def _test_manual_url_spec(env):
                     ),
                 ],
             ),
-            read = lambda *args, **kwargs: fail(args, kwargs),
         ),
         uv_repository = lambda **kwargs: calls.append(kwargs),
     )

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -23,9 +23,12 @@ load("//python/uv/private:uv.bzl", "process_modules")  # buildifier: disable=bzl
 load("//python/uv/private:uv_toolchain.bzl", "uv_toolchain")  # buildifier: disable=bzl-visibility
 load("//tests/support/mocks:mocks.bzl", "mocks")
 load("//tests/support/platforms:platforms.bzl", "platform_targets")
+
 _tests = []
 
 def _uv_mock_mctx(*modules, download = None, read = None):
+    _ = read  # @unused
+
     # Here we construct a fake minimal manifest file that we use to mock what would
     # be otherwise read from GH files
     manifest_files = {
@@ -73,7 +76,6 @@ def _uv_mock_mctx(*modules, download = None, read = None):
         } if download else {},
         mock_files = fake_fs,
     )
-
 
 def _mod(*, name = None, default = [], configure = [], is_root = True):
     return mocks.module(


### PR DESCRIPTION
This factors the various mocking logic spread throughout the code
base into a single mocks module. This should make it easier to re-use
and add unit tests of other functionality.