### PR TITLE
chore: have no-matching-distribution error message hint about target_platforms vs requirements_by_platform

### DIFF
--- a/python/private/pypi/pkg_aliases.bzl
+++ b/python/private/pypi/pkg_aliases.bzl
@@ -53,6 +53,9 @@ wheels available for this distribution. This distribution supports the following
 configuration settings:
     {config_settings}
 
+As configured by the `pip.parse.target_platforms` settings (note that
+`requirements_by_platform` only affects the Bazel host platform).
+
 To determine the current configuration's Python version, run:
     `bazel config <config id>` (shown further below)
 

--- a/python/private/pypi/pkg_aliases.bzl
+++ b/python/private/pypi/pkg_aliases.bzl
@@ -53,8 +53,9 @@ wheels available for this distribution. This distribution supports the following
 configuration settings:
     {config_settings}
 
-As configured by the `pip.parse.target_platforms` settings (note that
-`requirements_by_platform` only affects the Bazel host platform).
+As configured by the `pip.parse.target_platforms` attribute. Note that
+`requirements_by_platform` only affects the Bazel host platform unless
+`target_platforms` is also set.
 
 To determine the current configuration's Python version, run:
     `bazel config <config id>` (shown further below)

--- a/python/private/pypi/pkg_aliases.bzl
+++ b/python/private/pypi/pkg_aliases.bzl
@@ -46,7 +46,7 @@ load(
 )
 
 _NO_MATCH_ERROR_TEMPLATE = """\
-No matching wheel for current configuration's Python version.
+No matching wheel for current configuration's Python version and platform.
 
 The current build configuration's Python version doesn't match any of the Python
 wheels available for this distribution. This distribution supports the following Python


### PR DESCRIPTION
Based on the slack discussion where a cross-build was failing because
`requirements_by_platform` was set, but `target_platforms` wasn't
set, have the error message hint at the distinction to better point
users for how to fix it.