### PR TITLE
chore: populate 2.0 for VERSION_NEXT_FEATURE for py_wheel add_path_prefix

### DIFF
--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -181,7 +181,8 @@ For example:
 + `"foo/" will prepend to `"bar/baz/file.py"` as `"foo/bar/baz/file.py"`
 + `"foo_" will prepend to `"bar/baz/file.py"` as `"foo_bar/baz/file.py"`
 + `stripping ["bar/"] and adding "foo/" will change `"bar/baz/file.py"` to `"foo/baz/file.py"`
-:::{versionadded} VERSION_NEXT_FEATURE
+
+:::{versionadded} 2.0.0
 The {attr}`add_path_prefix` attribute was added.
 :::
 """,


### PR DESCRIPTION
The add_path_prefix feature is in the 2.0 branch, but its version
marker wasn't populated. Set it to 2.0.0