### PR TITLE
fix(sphinxdocs): update MODULE.bazel to depend on a released version

### DIFF
--- a/sphinxdocs/MODULE.bazel
+++ b/sphinxdocs/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "stardoc", version = "0.7.2", repo_name = "io_bazel_stardoc")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_python", version = "0.0.0")
+bazel_dep(name = "rules_python", version = "1.8.5")
 local_path_override(
     module_name = "rules_python",
     path = "..",


### PR DESCRIPTION
Related to the failure in rc0.

See #3688.