### PR TITLE
sphinxdocs: remove local rules_python dev overrides

### DIFF
--- a/sphinxdocs/MODULE.bazel
+++ b/sphinxdocs/MODULE.bazel
@@ -9,10 +9,6 @@ bazel_dep(name = "stardoc", version = "0.7.2", repo_name = "io_bazel_stardoc")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_python", version = "1.8.5")
-local_path_override(
-    module_name = "rules_python",
-    path = "..",
-)
 
 dev_pip = use_extension(
     "@rules_python//python/extensions:pip.bzl",

--- a/sphinxdocs/integration_tests/bcr/MODULE.bazel
+++ b/sphinxdocs/integration_tests/bcr/MODULE.bazel
@@ -9,11 +9,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_python", version = "0.0.0")
-local_path_override(
-    module_name = "rules_python",
-    path = "../../..",
-)
+bazel_dep(name = "rules_python", version = "1.8.5")
 
 dev_pip = use_extension(
     "@rules_python//python/extensions:pip.bzl",


### PR DESCRIPTION
In the BCR integration test, the local override breaks on BCR itself
because a local copy of rules_python isn't part of the test
environment.

Remove it from the sphinxdocs module, too, because it shouldn't
be necessary. The two aren't that closely coupled.