### PR TITLE
fix(pypi): build the environment on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ Other changes:
   )
   ```
   Fixes [#3676](https://github.com/bazel-contrib/rules_python/issues/3676).
+* (pypi) Fixes wheel extraction on hosts without python installed,
+  Fixes [#3712](https://github.com/bazel-contrib/rules_python/issues/3712).
 
 {#v2-0-0-added}
 ### Added

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -359,8 +359,8 @@ def _whl_library_impl(rctx):
     enable_pipstar_extract = enable_pipstar and rp_config.bazel_8_or_later
 
     # When pipstar is enabled, Python isn't used, so there's no need
-    # to setup env vars to run Python.
-    if enable_pipstar_extract:
+    # to setup env vars to run Python, unless we need to build an sdist
+    if enable_pipstar_extract and whl_path:
         environment = {}
     else:
         # Manually construct the PYTHONPATH since we cannot use the toolchain here

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -306,9 +306,6 @@ def _whl_library_impl(rctx):
     extra_pip_args = []
     extra_pip_args.extend(rctx.attr.extra_pip_args)
 
-    # Manually construct the PYTHONPATH since we cannot use the toolchain here
-    environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger)
-
     whl_path = None
     sdist_filename = None
     if rctx.attr.whl_file:
@@ -377,7 +374,8 @@ def _whl_library_impl(rctx):
             python = python_interpreter,
             op = op_tmpl.format(name = rctx.attr.name, requirement = rctx.attr.requirement.split(" ", 1)[0]),
             arguments = args,
-            environment = environment,
+            # Manually construct the PYTHONPATH since we cannot use the toolchain here
+            environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger),
             srcs = rctx.attr._python_srcs,
             quiet = rctx.attr.quiet,
             timeout = rctx.attr.timeout,
@@ -414,7 +412,8 @@ def _whl_library_impl(rctx):
             python_interpreter = python_interpreter,
             args = args,
             whl_path = whl_path,
-            environment = environment,
+            # Manually construct the PYTHONPATH since we cannot use the toolchain here
+            environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger),
             logger = logger,
         )
 

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -358,6 +358,8 @@ def _whl_library_impl(rctx):
     enable_pipstar = (rp_config.enable_pipstar or whl_path) and rctx.attr.config_load
     enable_pipstar_extract = enable_pipstar and rp_config.bazel_8_or_later
 
+    # When pipstar is enabled, Python isn't used, so there's no need
+    # to setup env vars to run Python.
     if enable_pipstar_extract:
         environment = {}
     else:

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -358,6 +358,12 @@ def _whl_library_impl(rctx):
     enable_pipstar = (rp_config.enable_pipstar or whl_path) and rctx.attr.config_load
     enable_pipstar_extract = enable_pipstar and rp_config.bazel_8_or_later
 
+    if enable_pipstar_extract:
+        environment = {}
+    else:
+        # Manually construct the PYTHONPATH since we cannot use the toolchain here
+        environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger)
+
     if not whl_path:
         if rctx.attr.urls:
             op_tmpl = "whl_library.BuildWheelFromSource({name}, {requirement})"
@@ -374,8 +380,7 @@ def _whl_library_impl(rctx):
             python = python_interpreter,
             op = op_tmpl.format(name = rctx.attr.name, requirement = rctx.attr.requirement.split(" ", 1)[0]),
             arguments = args,
-            # Manually construct the PYTHONPATH since we cannot use the toolchain here
-            environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger),
+            environment = environment,
             srcs = rctx.attr._python_srcs,
             quiet = rctx.attr.quiet,
             timeout = rctx.attr.timeout,
@@ -412,8 +417,7 @@ def _whl_library_impl(rctx):
             python_interpreter = python_interpreter,
             args = args,
             whl_path = whl_path,
-            # Manually construct the PYTHONPATH since we cannot use the toolchain here
-            environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger),
+            environment = environment,
             logger = logger,
         )
 


### PR DESCRIPTION
At some point when we started using pipstar, we silently started
building the python environment with system python interpreter. This is
fine because the environment in those code paths would be unused, but
this would break if python was not present on the machine.

This PR fixes this by creating the environment on the fly with a little
bit of code duplication.

Fixes #3712
